### PR TITLE
feat: 예외 처리 기능을 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -15,6 +15,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
+        log.info("[{}]{} : {}", getCorrelationId(), e.getClass().getSimpleName(), e.getMessage());
         return toResponseEntity(e.getMessage(), e.getHttpStatus());
     }
 
@@ -28,7 +29,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
-        log.warn("[{}]", MDC.get("correlationId"), e);
+        log.warn("[{}]", getCorrelationId(), e);
         return toResponseEntity("예상치 못한 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -37,5 +38,9 @@ public class ControllerAdvice {
         return ResponseEntity
                 .status(httpStatus)
                 .body(response);
+    }
+
+    private String getCorrelationId() {
+        return MDC.get("correlationId");
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,25 +13,23 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
-        return ResponseEntity
-                .status(e.getHttpStatus())
-                .body(response);
+        return toResponseEntity(e, e.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleValidationException(final MethodArgumentNotValidException e) {
-        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
-        return ResponseEntity
-                .badRequest()
-                .body(response);
+        return toResponseEntity(e, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
+        return toResponseEntity(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ExceptionResponse> toResponseEntity(final Exception e, final HttpStatus httpStatus) {
         final ExceptionResponse response = new ExceptionResponse(e.getMessage());
         return ResponseEntity
-                .internalServerError()
+                .status(httpStatus)
                 .body(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
 @Slf4j
+@RestControllerAdvice
 public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,7 +20,10 @@ public class ControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleValidationException(final MethodArgumentNotValidException e) {
-        return toResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+        final FieldError fieldError = e.getFieldErrors()
+                .get(0);
+        final String message = fieldError.getField() + " " + fieldError.getDefaultMessage();
+        return toResponseEntity(message, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -1,0 +1,19 @@
+package com.woowacourse.levellog.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ControllerAdvice {
+
+    @ExceptionHandler(LevellogException.class)
+    public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
+        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(response);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -16,4 +16,12 @@ public class ControllerAdvice {
                 .status(e.getHttpStatus())
                 .body(response);
     }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
+        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
+        return ResponseEntity
+                .internalServerError()
+                .body(response);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,6 +15,14 @@ public class ControllerAdvice {
         final ExceptionResponse response = new ExceptionResponse(e.getMessage());
         return ResponseEntity
                 .status(e.getHttpStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleValidationException(final MethodArgumentNotValidException e) {
+        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
+        return ResponseEntity
+                .badRequest()
                 .body(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -13,21 +14,22 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        return toResponseEntity(e, e.getHttpStatus());
+        return toResponseEntity(e.getMessage(), e.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleValidationException(final MethodArgumentNotValidException e) {
-        return toResponseEntity(e, HttpStatus.BAD_REQUEST);
+        return toResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
-        return toResponseEntity(e, HttpStatus.INTERNAL_SERVER_ERROR);
+        log.warn("[{}]", MDC.get("correlationId"), e);
+        return toResponseEntity("예상치 못한 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    private ResponseEntity<ExceptionResponse> toResponseEntity(final Exception e, final HttpStatus httpStatus) {
-        final ExceptionResponse response = new ExceptionResponse(e.getMessage());
+    private ResponseEntity<ExceptionResponse> toResponseEntity(final String message, final HttpStatus httpStatus) {
+        final ExceptionResponse response = new ExceptionResponse(message);
         return ResponseEntity
                 .status(httpStatus)
                 .body(response);

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ExceptionResponse.java
@@ -3,8 +3,8 @@ package com.woowacourse.levellog.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Getter
 @AllArgsConstructor
+@Getter
 public class ExceptionResponse {
 
     private final String message;

--- a/backend/src/main/java/com/woowacourse/levellog/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/ExceptionResponse.java
@@ -1,0 +1,11 @@
+package com.woowacourse.levellog.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExceptionResponse {
+
+    private final String message;
+}

--- a/backend/src/main/java/com/woowacourse/levellog/exception/LevellogException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/LevellogException.java
@@ -1,0 +1,15 @@
+package com.woowacourse.levellog.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class LevellogException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    protected LevellogException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 커스텀 예외
- ExceptionHandler
    - 커스텀 예외 (`LevellogException`)
    - bean validation 예외 (`MethodArgumentNotValidException`)
    - 이외의 모든 예외는 500으로 처리

## 논의하고 싶은 내용
- bean validation 예외도 로그를 남겨야할까요?
    - 500 응답은 **WARN** 레벨의 로그를 남깁니다. (+ stack trace)
    - 커스텀 예외 응답은 **INFO** 레벨의 로그를 남깁니다.

Close #13 
