### PR TITLE
feat: Auditing을 적용한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/FeedbackService.java
@@ -54,7 +54,7 @@ public class FeedbackService {
 
     public FeedbacksResponse findAllByTo(final Long memberId) {
         final Member member = getMember(memberId);
-        final List<Feedback> feedbacks = feedbackRepository.findAllByTo(member);
+        final List<Feedback> feedbacks = feedbackRepository.findAllByToOrderByUpdatedAtDesc(member);
         return new FeedbacksResponse(getFeedbackResponses(feedbacks));
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/FeedbackService.java
@@ -77,7 +77,8 @@ public class FeedbackService {
                 .map(it -> new FeedbackResponse(
                         it.getId(),
                         MemberResponse.from(it.getFrom()),
-                        new FeedbackContentDto(it.getStudy(), it.getSpeak(), it.getEtc())))
+                        new FeedbackContentDto(it.getStudy(), it.getSpeak(), it.getEtc()),
+                        it.getUpdatedAt()))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/common/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/BaseEntity.java
@@ -15,7 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
-public abstract class BaseTimeEntity {
+public abstract class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/woowacourse/levellog/common/BaseTimeEntity.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.woowacourse.levellog.common;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/woowacourse/levellog/common/BaseTimeEntity.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/BaseTimeEntity.java
@@ -3,6 +3,9 @@ package com.woowacourse.levellog.common;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -13,6 +16,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @Getter
 public abstract class BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @CreatedDate
     @Column(updatable = false, nullable = false)

--- a/backend/src/main/java/com/woowacourse/levellog/config/JpaConfig.java
+++ b/backend/src/main/java/com/woowacourse/levellog/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.levellog.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.domain;
 
+import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Feedback {
+public class Feedback extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.domain;
 
-import com.woowacourse.levellog.common.BaseTimeEntity;
+import com.woowacourse.levellog.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class Feedback extends BaseTimeEntity {
+public class Feedback extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_feedback_from_member"))

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Feedback.java
@@ -4,23 +4,18 @@ import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class Feedback extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @ManyToOne
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_feedback_from_member"))
@@ -42,16 +37,6 @@ public class Feedback extends BaseTimeEntity {
 
     @Column(length = 1000)
     private String etc;
-
-    public Feedback(final Member from, final Member to, final Levellog levellog, final String study, final String speak,
-                    final String etc) {
-        this.from = from;
-        this.to = to;
-        this.levellog = levellog;
-        this.study = study;
-        this.speak = speak;
-        this.etc = etc;
-    }
 
     public void updateFeedback(final String study, final String speak, final String etc) {
         this.study = study;

--- a/backend/src/main/java/com/woowacourse/levellog/domain/FeedbackRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/FeedbackRepository.java
@@ -9,5 +9,5 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByLevellog(Levellog levellog);
 
-    List<Feedback> findAllByTo(Member member);
+    List<Feedback> findAllByToOrderByUpdatedAtDesc(Member member);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.domain;
 
+import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Levellog {
+public class Levellog extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.domain;
 
-import com.woowacourse.levellog.common.BaseTimeEntity;
+import com.woowacourse.levellog.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class Levellog extends BaseTimeEntity {
+public class Levellog extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_levellog_author"))

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
@@ -4,24 +4,19 @@ import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class Levellog extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @ManyToOne
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_levellog_author"))
@@ -34,12 +29,6 @@ public class Levellog extends BaseTimeEntity {
     @Column(nullable = false)
     @Lob
     private String content;
-
-    public Levellog(final Member author, final Team team, final String content) {
-        this.author = author;
-        this.team = team;
-        this.content = content;
-    }
 
     public void updateContent(final String content) {
         this.content = content;

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
@@ -3,24 +3,19 @@ package com.woowacourse.levellog.domain;
 import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
 public class Member extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false, length = 50)
     private String nickname;
@@ -30,12 +25,6 @@ public class Member extends BaseTimeEntity {
 
     @Column(nullable = false, length = 2048)
     private String profileUrl;
-
-    public Member(final String nickname, final Integer githubId, final String profileUrl) {
-        this.nickname = nickname;
-        this.githubId = githubId;
-        this.profileUrl = profileUrl;
-    }
 
     public void updateProfileUrl(final String profileUrl) {
         this.profileUrl = profileUrl;

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.domain;
 
+import com.woowacourse.levellog.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.domain;
 
-import com.woowacourse.levellog.common.BaseTimeEntity;
+import com.woowacourse.levellog.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
-public class Member extends BaseTimeEntity {
+public class Member extends BaseEntity {
 
     @Column(nullable = false, length = 50)
     private String nickname;

--- a/backend/src/main/java/com/woowacourse/levellog/dto/FeedbackResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/dto/FeedbackResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.dto;
 
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,4 +14,5 @@ public class FeedbackResponse {
     private Long id;
     private MemberResponse from;
     private FeedbackContentDto feedback;
+    private LocalDateTime updatedAt;
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -13,9 +13,13 @@ import com.woowacourse.levellog.domain.Team;
 import com.woowacourse.levellog.domain.TeamRepository;
 import com.woowacourse.levellog.dto.FeedbackContentDto;
 import com.woowacourse.levellog.dto.FeedbackRequest;
+import com.woowacourse.levellog.dto.FeedbackResponse;
 import com.woowacourse.levellog.dto.FeedbacksResponse;
+import com.woowacourse.levellog.dto.MemberResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -92,15 +96,24 @@ class FeedbackServiceTest {
         final Member alien = memberRepository.save(new Member("알린", 3333, "alien.img"));
         final Team team = teamRepository.save(new Team("잠실 네오조", "트랙룸", LocalDateTime.now(), "progile.img"));
         final Levellog levellog = levellogRepository.save(new Levellog(eve, team, "이브의 레벨로그"));
-        feedbackRepository.save(new Feedback(roma, eve, levellog, "로마 스터디", "로마 말하기", "로마 기타"));
+        final Feedback feedback1 = feedbackRepository.save(new Feedback(roma, eve, levellog, "로마 스터디", "로마 말하기", "로마 기타"));
         feedbackRepository.save(new Feedback(alien, eve, levellog, "알린 스터디", "알린 말하기", "알린 기타"));
         feedbackRepository.save(new Feedback(eve, roma, levellog, "이브 스터디", "이브 말하기", "이브 기타"));
 
+        feedbackRepository.flush();
+
         // when
-        final FeedbacksResponse feedbacksResponse = feedbackService.findAllByTo(roma.getId());
+        feedbackService.update(feedback1.getId(),
+                new FeedbackRequest(new FeedbackContentDto("update", "update", "update")));
+        final List<String> fromNicknames = feedbackService.findAllByTo(eve.getId())
+                .getFeedbacks()
+                .stream()
+                .map(FeedbackResponse::getFrom)
+                .map(MemberResponse::getNickname)
+                .collect(Collectors.toList());
 
         // then
-        assertThat(feedbacksResponse.getFeedbacks()).hasSize(1);
+        assertThat(fromNicknames).containsExactly("로마", "알린");
     }
 
     @Test


### PR DESCRIPTION
## 구현 기능
- Auditing을 적용하기 위한 `BaseEntity` 구현
- 기존 Entity가 `BaseEntity`를 상속받도록 변경
- 기존 Entity에 id 필드를 `BaseEntity`에 할당해서 중복 코드 제거
- 피드백 목록 조회 응답을 수정 시간 기준 내림차순으로 정렬

## 공유하고 싶은 내용
- DB에 row가 최초로 INSERT 될 때, `createdAt`과 `updatedAt`에 동일한 값이 할당됩니다.
- 이제 새로운 Entity를 생성할 때 id 필드를 직접 추가하지 않습니다.

잘 동작합니당 😊
<img width="561" alt="image" src="https://user-images.githubusercontent.com/68512686/179497322-5e355e1a-3259-452b-9337-46cf2b2bf957.png">


Close #65 Close #24