### PR TITLE
feat: 인수테스트를 위한 로그인 픽스쳐를 생성한다.

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/.DS_Store/**
+**/src/test/**/study
 
 ### STS ###
 .apt_generated

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -7,17 +7,19 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.support.TestAuthenticationConfig;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -29,10 +31,14 @@ import org.springframework.test.context.ActiveProfiles;
 abstract class AcceptanceTest {
 
     protected RequestSpecification specification;
+
     @LocalServerPort
     private int port;
 
-    /**
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    /*
      * 기본 생성 snippet은 http-request.adoc, http-response.adoc입니다.
      * Request host는 https://api.levellog.app입니다.
      * 응답 헤더 중 Transfer-Encoding, Date, Keep-Alive, Connection은 제외됩니다.

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -35,9 +35,6 @@ abstract class AcceptanceTest {
     @LocalServerPort
     private int port;
 
-    @Autowired
-    protected ObjectMapper objectMapper;
-
     /*
      * 기본 생성 snippet은 http-request.adoc, http-response.adoc입니다.
      * Request host는 https://api.levellog.app입니다.

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
@@ -3,16 +3,22 @@ package com.woowacourse.levellog.acceptance;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubProfileResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("깃허브 로그인 관련 기능")
 class OAuthAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     /*
      * Scenario: 깃허브 로그인
@@ -22,9 +28,10 @@ class OAuthAcceptanceTest extends AcceptanceTest {
      */
     @Test
     @DisplayName("깃허브 로그인")
-    void login() {
+    void login() throws Exception {
         // given
-        final GithubCodeRequest codeRequest = new GithubCodeRequest("github_auth_code");
+        final String code = objectMapper.writeValueAsString(new GithubProfileResponse("11111", "test", "profile_url"));
+        final GithubCodeRequest codeRequest = new GithubCodeRequest(code);
 
         // when
         final ValidatableResponse response = requestLogin(codeRequest);

--- a/backend/src/test/java/com/woowacourse/levellog/authentication/support/FakeGithubOAuthClient.java
+++ b/backend/src/test/java/com/woowacourse/levellog/authentication/support/FakeGithubOAuthClient.java
@@ -1,25 +1,32 @@
 package com.woowacourse.levellog.authentication.support;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.domain.OAuthClient;
 import com.woowacourse.levellog.authentication.dto.GithubProfileResponse;
 
 public class FakeGithubOAuthClient implements OAuthClient {
 
+    private final ObjectMapper objectMapper;
+
+    public FakeGithubOAuthClient(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Override
     public String getAccessToken(final String code) {
-        if (code.equals("github_auth_code")) {
-            return "access_token";
+        if (!code.isBlank()) {
+            return code;
         }
-
-        throw new IllegalStateException();
+        throw new IllegalStateException("[TEST] code가 비어있습니다.");
     }
 
     @Override
     public GithubProfileResponse getProfile(final String accessToken) {
-        if (accessToken.equals("access_token")) {
-            return new GithubProfileResponse("0000000", "test", "profile_url");
+        try {
+            return objectMapper.readValue(accessToken, GithubProfileResponse.class);
+        } catch (final JsonProcessingException e) {
+            throw new IllegalStateException("[TEST] 로그인 code에는 원하는 GithubProfilerResponse를 json 형식으로 보내야합니다.");
         }
-
-        throw new IllegalStateException();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/authentication/support/TestAuthenticationConfig.java
+++ b/backend/src/test/java/com/woowacourse/levellog/authentication/support/TestAuthenticationConfig.java
@@ -1,6 +1,8 @@
 package com.woowacourse.levellog.authentication.support;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.domain.OAuthClient;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -8,9 +10,12 @@ import org.springframework.context.annotation.Primary;
 @TestConfiguration
 public class TestAuthenticationConfig {
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Bean
     @Primary
     public OAuthClient fakeOAuthClient() {
-        return new FakeGithubOAuthClient();
+        return new FakeGithubOAuthClient(objectMapper);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/RequestFixture.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/RequestFixture.java
@@ -1,0 +1,29 @@
+package com.woowacourse.levellog.fixture;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubProfileResponse;
+import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import io.restassured.RestAssured;
+import org.springframework.http.MediaType;
+
+public class RequestFixture {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static LoginResponse login(final String githubId, final String nickname, final String profileUrl)
+            throws JsonProcessingException {
+        final GithubProfileResponse githubProfileResponse = new GithubProfileResponse(githubId, nickname, profileUrl);
+        final String code = objectMapper.writeValueAsString(githubProfileResponse);
+
+        return RestAssured.given().log().all()
+                .body(new GithubCodeRequest(code))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/api/auth/login")
+                .then().log().all()
+                .extract()
+                .as(LoginResponse.class);
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 인수테스트에서 사용할 로그인 픽스쳐를 생성한다.

## 논의하고 싶은 내용
- 좋게 짜진 코드인지는 모르겠습니다. 하지만 문제를 빠르게 해결하기 위해 사용은 할 수 있을 것 같다.
- 픽스쳐 관련해서 어떻게 더 간결하게 짤 수 있는지 좋은 아이디어 있으면 참고하겠습니다.

## 공유하고 싶은 내용
- 기존의 방식
  - 특정 code 요청에 단 하나의 response만을 반환하기 때문에 우리가 임의의 유저로 로그인하지 못하고 무조건 한 픽스쳐로만 로그인이 되는 현상이 발생가능
- 현재의 방식
  - code 요청을 json으로 받게한 뒤 내부에서 json을 역직렬화하여 원하는 데이터로 로그인하도록 수정
  - 해당 과정이 복잡해서 fixture에 해당 과정을 추상화하고 반환값으로 LoginResponse를 받아 토큰을 받을 수 있도록 설정했다.

Close #84
