### PR TITLE
refactor: 로그인 성공 응답에 id를 포함하도록 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
@@ -30,7 +30,7 @@ public class OAuthService {
 
         final String token = jwtTokenProvider.createToken(memberId.toString());
 
-        return new LoginResponse(token, githubProfile.getProfileUrl());
+        return new LoginResponse(memberId, token, githubProfile.getProfileUrl());
     }
 
     private Long getMemberIdByGithubProfile(final GithubProfileResponse githubProfile) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LoginResponse {
 
+    private Long id;
     private String accessToken;
     private String profileUrl;
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -7,14 +7,12 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.support.TestAuthenticationConfig;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 // FIXME : 팀 API 구현 후 수정
 @Disabled
 @DisplayName("MyInfo 관련 기능")
-public class MyInfoAcceptanceTest extends AcceptanceTest {
+class MyInfoAcceptanceTest extends AcceptanceTest {
 
     /*
      * Scenario: 내가 받은 피드백 모두 조회하기

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
@@ -39,7 +39,8 @@ class OAuthAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.OK.value())
                 .body("accessToken", notNullValue())
-                .body("profileUrl", is("profile_url"));
+                .body("profileUrl", is("profile_url"))
+                .body("id", is(1));
     }
 
     private ValidatableResponse requestLogin(final GithubCodeRequest request) {

--- a/backend/src/test/java/com/woowacourse/levellog/authentication/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/authentication/application/OAuthServiceTest.java
@@ -42,7 +42,7 @@ class OAuthServiceTest {
     class login {
 
         @Test
-        @DisplayName("첫 로그인 시 회원가입하고 토큰과 이미지 URL를 반환한다.")
+        @DisplayName("첫 로그인 시 회원가입하고 id, 토큰, 이미지 URL를 반환한다.")
         void loginFirst() {
             // given
             given(oAuthClient.getAccessToken("githubCode")).willReturn("accessToken");
@@ -58,6 +58,7 @@ class OAuthServiceTest {
             assertThat(savedMember).isPresent();
             assertThat(Long.parseLong(payload)).isEqualTo(savedMember.get().getId());
             assertThat(tokenResponse.getProfileUrl()).isEqualTo("imageUrl");
+            assertThat(tokenResponse.getId()).isNotNull();
         }
 
         @Test
@@ -77,6 +78,7 @@ class OAuthServiceTest {
             // then
             assertThat(Long.parseLong(payload)).isEqualTo(savedId);
             assertThat(tokenResponse.getProfileUrl()).isEqualTo("imageUrl");
+            assertThat(tokenResponse.getId()).isNotNull();
         }
     }
 }


### PR DESCRIPTION
## 구현 기능
- 로그인 성공 응답에 id를 추가로 포함하도록 변경

## 기타
- 변경된 API 스팩에 대응합니다.

Close #78 
