### PR TITLE
fix: DataJpaTest에서 Auditing이 적용되지 않는 문제 해결

### DIFF
--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
@@ -2,13 +2,16 @@ package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.levellog.config.JpaConfig;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 @DisplayName("MemberRepository의")
 class MemberRepositoryTest {
 


### PR DESCRIPTION
## 구현 기능
- `@DataJpaTest`에서 auditing이 적용되지 않아서 테스트가 실패하는 문제 해결

## 논의하고 싶은 내용
- 추후에 Repository 테스트가 많아지면 상속구조로 변경하면 좋을듯?
