### PR TITLE
feat: 멤버 닉네임 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
@@ -29,10 +29,17 @@ public class MemberService {
 
     public MembersResponse findAll() {
         final List<MemberResponse> responses = memberRepository.findAll().stream()
-                .map(it -> new MemberResponse(it.getId(), it.getNickname(), it.getProfileUrl()))
+                .map(MemberResponse::from)
                 .collect(Collectors.toList());
 
         return new MembersResponse(responses);
+    }
+
+    public MembersResponse findAllByNicknameContains(final String nickname) {
+        final List<MemberResponse> memberResponses = memberRepository.findAllByNicknameContains(nickname).stream()
+                .map(MemberResponse::from)
+                .collect(Collectors.toList());
+        return new MembersResponse(memberResponses);
     }
 
     public Optional<Member> findByGithubId(final int githubId) {

--- a/backend/src/main/java/com/woowacourse/levellog/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.woowacourse.levellog.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByGithubId(int githubId);
+
+    List<Member> findAllByNicknameContains(String nickname);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/MemberController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +19,12 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<MembersResponse> findAll() {
         final MembersResponse response = memberService.findAll();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping(params = {"search"})
+    public ResponseEntity<MembersResponse> searchNickname(@RequestParam final String search) {
+        final MembersResponse response = memberService.findAllByNicknameContains(search);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.levellog.domain.Member;
 import com.woowacourse.levellog.domain.MemberRepository;
@@ -64,6 +65,28 @@ class MemberServiceTest {
         // then
         assertThat(findMember).isPresent();
         assertThat(findMember.get().getGithubId()).isEqualTo(githubId);
+    }
+
+    @Test
+    @DisplayName("findAllByNicknameContains 메서드는 입력한 문자열이 포함된 nickname을 가진 멤버를 모두 조회한다.")
+    void findAllByNicknameContains() {
+        // given
+        final Member roma = memberRepository.save(new Member("roma", 10, "roma.img"));
+        final Member pepper = memberRepository.save(new Member("pepper", 20, "pepper.img"));
+        final Member alien = memberRepository.save(new Member("alien", 30, "alien.img"));
+        final Member rick = memberRepository.save(new Member("rick", 40, "rick.img"));
+        final Member eve = memberRepository.save(new Member("eve", 50, "eve.img"));
+        final Member kyul = memberRepository.save(new Member("kyul", 60, "kyul.img"));
+        final Member harry = memberRepository.save(new Member("harry", 70, "harry.img"));
+
+        // when
+        final MembersResponse members = memberService.findAllByNicknameContains("ali");
+
+        // then
+        assertAll(
+                () -> assertThat(members.getMembers()).hasSize(1),
+                () -> assertThat(members.getMembers().get(0).getId()).isEqualTo(alien.getId())
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.levellog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.levellog.config.JpaConfig;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,5 +30,25 @@ class MemberRepositoryTest {
 
         // then
         assertThat(actual).hasValue(member);
+    }
+
+    @Test
+    @DisplayName("findAllByNicknameContains 메서드는 입력한 문자열이 포함된 nickname을 가진 멤버를 모두 조회한다.")
+    void findAllByNicknameContains() {
+        // given
+        final Member roma = memberRepository.save(new Member("roma", 10, "roma.img"));
+        final Member pepper = memberRepository.save(new Member("pepper", 20, "pepper.img"));
+        final Member alien = memberRepository.save(new Member("alien", 30, "alien.img"));
+        final Member rick = memberRepository.save(new Member("rick", 40, "rick.img"));
+        final Member eve = memberRepository.save(new Member("eve", 50, "eve.img"));
+        final Member kyul = memberRepository.save(new Member("kyul", 60, "kyul.img"));
+        final Member harry = memberRepository.save(new Member("harry", 70, "harry.img"));
+
+        // when
+        final List<Member> actual = memberRepository.findAllByNicknameContains("ali");
+
+        // then
+        assertThat(actual).hasSize(1)
+                .contains(alien);
     }
 }


### PR DESCRIPTION
## 구현 기능
- 멤버 닉네임을 입력하여 검색하는 기능
- 입력한 값이 포함되면 모두 조회하도록 했습니다.
  - 유저 : ["로마", "로마로마", "로마로", "마로마"]
  - 입력 값 : "마로"
  - 찾는 결과 : ["로마로마", "로마로", "마로마"]

## 논의하고 싶은 내용
- API 명세는 다음과 같음
- Method : `GET`
- URI :
    - /api/members?search=alien
- Body
    
    `Request`
    
    ```http
    Get /api/members?search=alien HTTP/1.1
    Content-Type: application/json;charset=UTF-8
    Authorization: Bearer ${ACCESS_TOKEN}
    Accept: */*
    Content-Length: 000
    Host: localhost:8080
    ```
    
    `Response`
    
    ```http
    HTTP/1.1 200 ok
    Vary: Origin
    Vary: Access-Control-Request-Method
    Vary: Access-Control-Request-Headers

    {
        "members" :[
            {
                "id" : 1,
                "nickname" : "alien",
                "profileUrl" : "image1.img"
            },
            {
                "id" : 2,
                "nickname" : "123alien123",
                "profileUrl" : "image2.img"
            }
        ]
    }
    ```


## 공유하고 싶은 내용
- JPA는 Repository에서 메서드 이름을 잘 지으면 기능이 알아서 만들어지는데 그 중 Like로 찾는 여러 기능이 있음
  - Containing , Contains , IsContaining
    - `fiindAllByNicknameContains(String input)`
    - nickname에 input이 어디든 포함이 되면 찾음
  - Like
    - `fiindAllByNicknameContains(String input)`
    - nickname에 input이 어디든 포함이 되면 찾음
    - 대신 메서드를 사용할 때 fiindAllByNicknameContains("%alien%"); 처럼 써줘야함
  - StartsWith
    - `fiindAllByNicknameContains(String input)`
    - input으로 시작하는 nickname을 모두 찾음
  - EndsWith
    - `fiindAllByNicknameContains(String input)`
    - input으로 끝나는 nickname을 모두 찾음

Close #79 
