### PR TITLE
fix: TeamServiceTest의 githubId 설정 로직 변경 및 테스트 DisplayName 수정

### DIFF
--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-@DisplayName("LevellogService의")
+@DisplayName("TeamService의")
 class TeamServiceTest {
 
     @Autowired
@@ -104,7 +104,7 @@ class TeamServiceTest {
     }
 
     private Member getMember(final String nickname) {
-        return memberRepository.save(new Member(nickname, (int) System.currentTimeMillis(), "profile.png"));
+        return memberRepository.save(new Member(nickname, (int) System.nanoTime(), "profile.png"));
     }
 
     private Team getTeam(final String title) {


### PR DESCRIPTION
## 구현 기능
- TeamServiceTest의 githubId 설정 로직을 수정한다 (`System.currentTimeMillis()` -> `System.nanoTime()`)
- TeamServiceTest의 DisplayName 수정

## 공유하고 싶은 내용
- System.currentTimeMillis() 로 값을 가져오는 경우 1ms 안에 테스트가 통과할 경우 githubId가 겹쳐 유니크 제약조건이 터져버립니다. 따라서 이를 nanoTime()으로 수정했습니다. < 설마 1ns에 테스트 통과하겠습니까?
- 따라서 이를 수정했고 TeamService 테스트의 DisplayName이 잘못 설정되어있는 것을 수정하였습니다.
