### PR TITLE
feat: 내 정보 조회, 내 정보 수정(닉네임 수정) 기능을 구현한다.

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -8,3 +8,4 @@
 
 * link:feedback.html[Feedback]
 * link:levellog.html[Levellog]
+* link:myinfo.html[MyInfo]

--- a/backend/src/docs/asciidoc/myinfo.adoc
+++ b/backend/src/docs/asciidoc/myinfo.adoc
@@ -1,0 +1,25 @@
+= MyInfo
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+* link:index.html[목록으로 가기]
+
+[[read]]
+== 내 정보 조회
+
+[[read-success]]
+=== 성공
+
+operation::myinfo/read[]
+
+[[update-nickname]]
+== 닉네임 변경
+
+[[update-nickname-success]]
+=== 성공
+
+operation::myinfo/update-nickname[]

--- a/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
@@ -27,6 +27,11 @@ public class MemberService {
         return savedMember.getId();
     }
 
+    public MemberResponse findMemberById(final Long memberId) {
+        final Member member = getById(memberId);
+        return MemberResponse.from(member);
+    }
+
     public MembersResponse findAll() {
         final List<MemberResponse> responses = memberRepository.findAll().stream()
                 .map(it -> new MemberResponse(it.getId(), it.getNickname(), it.getProfileUrl()))
@@ -39,7 +44,7 @@ public class MemberService {
         return memberRepository.findByGithubId(githubId);
     }
 
-    public Member getById(final Long id) {
+    private Member getById(final Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
     }

--- a/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
@@ -6,6 +6,7 @@ import com.woowacourse.levellog.domain.MemberRepository;
 import com.woowacourse.levellog.dto.MemberCreateDto;
 import com.woowacourse.levellog.dto.MemberResponse;
 import com.woowacourse.levellog.dto.MembersResponse;
+import com.woowacourse.levellog.dto.NicknameUpdateDto;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -52,5 +53,10 @@ public class MemberService {
     public void updateProfileUrl(final Long id, final String profileUrl) {
         final Member member = getById(id);
         member.updateProfileUrl(profileUrl);
+    }
+
+    public void updateNickname(final Long memberId, final NicknameUpdateDto nicknameUpdateDto) {
+        final Member member = getById(memberId);
+        member.updateNickname(nicknameUpdateDto.getNickname());
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/MemberService.java
@@ -45,11 +45,6 @@ public class MemberService {
         return memberRepository.findByGithubId(githubId);
     }
 
-    private Member getById(final Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(MemberNotFoundException::new);
-    }
-
     public void updateProfileUrl(final Long id, final String profileUrl) {
         final Member member = getById(id);
         member.updateProfileUrl(profileUrl);
@@ -58,5 +53,10 @@ public class MemberService {
     public void updateNickname(final Long memberId, final NicknameUpdateDto nicknameUpdateDto) {
         final Member member = getById(memberId);
         member.updateNickname(nicknameUpdateDto.getNickname());
+    }
+
+    private Member getById(final Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidFieldException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidFieldException.java
@@ -1,0 +1,11 @@
+package com.woowacourse.levellog.authentication.exception;
+
+import com.woowacourse.levellog.exception.LevellogException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFieldException extends LevellogException {
+
+    public InvalidFieldException(final String message, final HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Member.java
@@ -1,5 +1,8 @@
 package com.woowacourse.levellog.domain;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.woowacourse.levellog.authentication.exception.InvalidFieldException;
 import com.woowacourse.levellog.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +20,8 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
 public class Member extends BaseEntity {
 
+    public static final int NICKNAME_MAX_LENGTH = 50;
+
     @Column(nullable = false, length = 50)
     private String nickname;
 
@@ -28,5 +33,27 @@ public class Member extends BaseEntity {
 
     public void updateProfileUrl(final String profileUrl) {
         this.profileUrl = profileUrl;
+    }
+
+    public void updateNickname(final String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+    }
+
+    private void validateNickname(final String nickname) {
+        validateBlank(nickname);
+        validateNicknameLength(nickname);
+    }
+
+    private void validateBlank(final String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new InvalidFieldException("닉네임은 공백이나 null일 수 없습니다.", BAD_REQUEST);
+        }
+    }
+
+    private void validateNicknameLength(final String nickname) {
+        if (nickname.length() > NICKNAME_MAX_LENGTH) {
+            throw new InvalidFieldException("닉네임은 " + NICKNAME_MAX_LENGTH + "자 이하여야합니다.", BAD_REQUEST);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/dto/NicknameUpdateDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/dto/NicknameUpdateDto.java
@@ -8,9 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class MemberCreateDto {
+public class NicknameUpdateDto {
 
     private String nickname;
-    private Integer githubId;
-    private String profileUrl;
 }

--- a/backend/src/main/java/com/woowacourse/levellog/dto/NicknameUpdateDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/dto/NicknameUpdateDto.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class NicknameUpdateDto {
 
+    @NotBlank
     private String nickname;
 }

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
@@ -1,8 +1,10 @@
 package com.woowacourse.levellog.presentation;
 
 import com.woowacourse.levellog.application.FeedbackService;
+import com.woowacourse.levellog.application.MemberService;
 import com.woowacourse.levellog.authentication.support.LoginMember;
 import com.woowacourse.levellog.dto.FeedbacksResponse;
+import com.woowacourse.levellog.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyInfoController {
 
     private final FeedbackService feedbackService;
+    private final MemberService memberService;
 
     @GetMapping("/feedbacks")
     public ResponseEntity<FeedbacksResponse> findAllFeedbackToMe(@LoginMember final Long memberId) {
         final FeedbacksResponse feedbacksResponse = feedbackService.findAllByTo(memberId);
         return ResponseEntity.ok(feedbacksResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<MemberResponse> myInfo(@LoginMember final Long memberId) {
+        final MemberResponse memberResponse = memberService.findMemberById(memberId);
+        return ResponseEntity.ok(memberResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
@@ -5,9 +5,13 @@ import com.woowacourse.levellog.application.MemberService;
 import com.woowacourse.levellog.authentication.support.LoginMember;
 import com.woowacourse.levellog.dto.FeedbacksResponse;
 import com.woowacourse.levellog.dto.MemberResponse;
+import com.woowacourse.levellog.dto.NicknameUpdateDto;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +33,13 @@ public class MyInfoController {
     public ResponseEntity<MemberResponse> myInfo(@LoginMember final Long memberId) {
         final MemberResponse memberResponse = memberService.findMemberById(memberId);
         return ResponseEntity.ok(memberResponse);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateNickname(@LoginMember final Long memberId,
+                                               @RequestBody @Valid final NicknameUpdateDto nicknameUpdateDto) {
+        memberService.updateNickname(memberId, nicknameUpdateDto);
+        System.out.println("happy");
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/MyInfoController.java
@@ -39,7 +39,6 @@ public class MyInfoController {
     public ResponseEntity<Void> updateNickname(@LoginMember final Long memberId,
                                                @RequestBody @Valid final NicknameUpdateDto nicknameUpdateDto) {
         memberService.updateNickname(memberId, nicknameUpdateDto);
-        System.out.println("happy");
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -1,27 +1,76 @@
 package com.woowacourse.levellog.acceptance;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import com.woowacourse.levellog.dto.NicknameUpdateDto;
+import com.woowacourse.levellog.fixture.RequestFixture;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpHeaders;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
-// FIXME : 팀 API 구현 후 수정
 @Disabled
 @DisplayName("MyInfo 관련 기능")
 class MyInfoAcceptanceTest extends AcceptanceTest {
 
     /*
-     * Scenario: 내가 받은 피드백 모두 조회하기
-     *   when:
-     *   then:
+     * Scenario: 내 정보 조회
+     *   given: 로그인이 되어있다.
+     *   when: 내 정보를 조회한다.
+     *   then: 로그인 된 나의 정보와 200 Ok 상태 코드를 응답받는다.
      */
     @Test
-    @DisplayName("내가 받은 피드백 모두 조회하기")
-    void findAllFeedbackToMe() {
+    @DisplayName("내 정보 조회")
+    void readMyInfo() throws Exception {
         // given
+        final LoginResponse loginResponse = RequestFixture.login("123456", "로마", "image.url");
 
         // when
+        final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginResponse.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .filter(document("myinfo/update-nickname"))
+                .when()
+                .get("/api/myinfo")
+                .then().log().all();
 
         // then
+        response.body("id", Matchers.notNullValue(),
+                "nickname", equalTo("로마"),
+                "profileUrl", equalTo("image.url"));
+    }
 
+    /*
+     * Scenario: 내 닉네임 변경하기
+     *   given: 로그인이 되어있다.
+     *   when: 닉네임을 변경한다.
+     *   then: 닉네임이 변경되고 204 No Content 상태 코드를 응답받는다.
+     */
+    @Test
+    @DisplayName("내 닉네임 변경하기")
+    void updateMyNickname() throws Exception {
+        // given
+        final LoginResponse loginResponse = RequestFixture.login("123456", "로마", "image.url");
+        final NicknameUpdateDto nicknameDto = new NicknameUpdateDto("새이름");
+
+        // when
+        final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginResponse.getAccessToken())
+                .body(nicknameDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .filter(document("myinfo/update-nickname"))
+                .when()
+                .put("/api/myinfo")
+                .then().log().all();
+
+        // then
+        response.statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -65,7 +65,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("myinfo/update-nickname"))
                 .when()
-                .put("/api/myinfo")
+                .put("/api/myInfo")
                 .then().log().all();
 
         // then

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -10,7 +10,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.apache.http.HttpHeaders;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -35,7 +34,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginResponse.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("myinfo/update-nickname"))
+                .filter(document("myinfo/read"))
                 .when()
                 .get("/api/myInfo")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-@Disabled
 @DisplayName("MyInfo 관련 기능")
 class MyInfoAcceptanceTest extends AcceptanceTest {
 
@@ -38,7 +37,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("myinfo/update-nickname"))
                 .when()
-                .get("/api/myinfo")
+                .get("/api/myInfo")
                 .then().log().all();
 
         // then

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -1,10 +1,12 @@
 package com.woowacourse.levellog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.levellog.domain.Member;
 import com.woowacourse.levellog.domain.MemberRepository;
 import com.woowacourse.levellog.dto.MemberCreateDto;
+import com.woowacourse.levellog.dto.MemberResponse;
 import com.woowacourse.levellog.dto.MembersResponse;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +51,23 @@ class MemberServiceTest {
 
         // then
         assertThat(membersResponse.getMembers()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("findMemberById 메서드는 Id로 멤버의 정보를 조회한다.")
+    void findMemberById() {
+        // given
+        final Member roma = memberRepository.save(new Member("로마", 1234, "image.png"));
+
+        // when
+        final MemberResponse memberResponse = memberService.findMemberById(roma.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(memberResponse.getId()).isEqualTo(roma.getId()),
+                () -> assertThat(memberResponse.getNickname()).isEqualTo("로마"),
+                () -> assertThat(memberResponse.getProfileUrl()).isEqualTo("image.png")
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -8,6 +8,7 @@ import com.woowacourse.levellog.domain.MemberRepository;
 import com.woowacourse.levellog.dto.MemberCreateDto;
 import com.woowacourse.levellog.dto.MemberResponse;
 import com.woowacourse.levellog.dto.MembersResponse;
+import com.woowacourse.levellog.dto.NicknameUpdateDto;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -99,5 +100,21 @@ class MemberServiceTest {
         // then
         final Member updateMember = memberRepository.findById(id).orElseThrow();
         assertThat(updateMember.getProfileUrl()).isEqualTo(newProfileUrl);
+    }
+
+    @Test
+    @DisplayName("updateNickname 메서드는 닉네임을 업데이트한다.")
+    void updateNickname() {
+        // given
+        final Member savedMember = memberRepository.save(new Member("로마", 1234567, "profileUrl.image"));
+        final Long id = savedMember.getId();
+        final NicknameUpdateDto nicknameUpdateDto = new NicknameUpdateDto("알린");
+
+        // when
+        memberService.updateNickname(id, nicknameUpdateDto);
+
+        // then
+        final Member updateMember = memberRepository.findById(id).orElseThrow();
+        assertThat(updateMember.getNickname()).isEqualTo("알린");
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
@@ -1,0 +1,57 @@
+package com.woowacourse.levellog.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.levellog.authentication.exception.InvalidFieldException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Member 의")
+class MemberTest {
+
+    @Nested
+    @DisplayName("updateNickname 메서드는")
+    class updateNickname {
+
+        @Test
+        @DisplayName("닉네임을 변경한다.")
+        void updateNickname() {
+            // given
+            final Member member = new Member("로마", 123456, "image.png");
+
+            // when
+            member.updateNickname("알린");
+
+            // then
+            assertThat(member.getNickname()).isEqualTo("알린");
+        }
+
+        @Test
+        @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
+        void nicknameInvalidLength_Exception() {
+            // given
+            final Member member = new Member("로마", 123456, "image.png");
+            final String invalidNickname = "a".repeat(51);
+
+            // when & then
+            assertThatThrownBy(() -> member.updateNickname(invalidNickname)).isInstanceOf(InvalidFieldException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        @NullAndEmptySource
+        @DisplayName("닉네임이 공백이나 null일 경우 예외를 던진다.")
+        void nicknameBlank_Exception(final String invalidNickname) {
+            // given
+            final Member member = new Member("로마", 123456, "image.png");
+
+            // when & then
+            assertThatThrownBy(() -> member.updateNickname(invalidNickname)).isInstanceOf(InvalidFieldException.class);
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -1,16 +1,88 @@
 package com.woowacourse.levellog.presentation;
 
-import com.woowacourse.levellog.support.ControllerTest;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(MyInfoController.class)
+import com.woowacourse.levellog.authentication.exception.InvalidFieldException;
+import com.woowacourse.levellog.dto.NicknameUpdateDto;
+import com.woowacourse.levellog.support.ControllerTest;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
 class MyInfoControllerTest extends ControllerTest {
 
     // FIXME : 팀 API 구현 후 수정
     @Disabled
     @Test
     void findAllMyFeedback() {
+    }
+
+    @Nested
+    @DisplayName("updateNickname 메서드는 ")
+    class updateNickname {
+
+        @Test
+        @DisplayName("닉네임에 50자를 초과한 문자열이 들어올 경우 예외를 던진다.")
+        void nicknameInvalidLength_Exception() throws Exception {
+            // given
+            given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+            doThrow(new InvalidFieldException("닉네임은 50자 이하여야합니다.", BAD_REQUEST))
+                    .when(memberService)
+                    .updateNickname(any(), any());
+            final String invalidNickname = "a".repeat(51);
+
+            final NicknameUpdateDto nicknameUpdateDto = new NicknameUpdateDto(invalidNickname);
+            final String requestContent = objectMapper.writeValueAsString(nicknameUpdateDto);
+
+            // when
+            final ResultActions perform = mockMvc.perform(put("/api/myInfo")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestContent)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer: token"))
+                    .andDo(print());
+
+            // then
+            perform.andExpect(
+                    status().isBadRequest()
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        @NullAndEmptySource
+        @DisplayName("닉네임에 null 또는 빈 값이 들어온 경우 예외를 던진다.")
+        void nicknameNullAndEmpty_Exception(final String invalidNickname) throws Exception {
+            // given
+            given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+
+            final NicknameUpdateDto nicknameUpdateDto = new NicknameUpdateDto(invalidNickname);
+            final String requestContent = objectMapper.writeValueAsString(nicknameUpdateDto);
+
+            // when
+            final ResultActions perform = mockMvc.perform(put("/api/myInfo")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestContent)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer: token"))
+                    .andDo(print());
+
+            // then
+            perform.andExpect(
+                    status().isBadRequest()
+            );
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/support/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/support/ControllerTest.java
@@ -11,6 +11,7 @@ import com.woowacourse.levellog.authentication.presentation.OAuthController;
 import com.woowacourse.levellog.presentation.FeedbackController;
 import com.woowacourse.levellog.presentation.LevellogController;
 import com.woowacourse.levellog.presentation.TeamController;
+import com.woowacourse.levellog.presentation.MyInfoController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
         FeedbackController.class,
         LevellogController.class,
         TeamController.class,
-        OAuthController.class
+        OAuthController.class,
+        MyInfoController.class
 })
 public abstract class ControllerTest {
 


### PR DESCRIPTION
## 구현 기능
- 내 정보 조회(`GET /api/myInfo`)
- 내 정보 수정(`PUT /api/myInfo`)
- 내 정보 조회, 수정 문서화 (myinfo.adoc)

## 논의하고 싶은 내용
- 처음으로 도메인 테스트를 작성해봤습니다. 이후 도메인에 대해서 검증로직을 추가해야할 것 같은데 초기 표본으로써 빡리뷰 부탁드립니다.
  - 나중에는 도메인의 AllArgsConstructor 애노테이션을 제거하고 수동으로 생성자를 생성해야할 것 같습니다.

## 공유하고 싶은 내용
- void 타입이 반환되는 메서드를 모킹할 경우에는 `BDDMockitio`의 `given`을 사용하면 안되고 `Mockito의 doThrow` 구문을 써봅시다.
- 컨트롤러 테스트에서 Resolver의 결과로 원하는 값을 받기 위해서는 `jwtTokenProvider.getPayload()` 를 모킹해봅시다.

Close #80 Close #88
