### PR TITLE
chore: Github Action CI 스크립트 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
           java-version: 11
 
       - name: Move to backend directory
-        run: cd backend/
+        run: cd backend/ && pwd
         shell: bash
-      
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: earth-github-action-test CI
+name: backend CI
 
 # 하기 내용에 해당하는 이벤트 발생 시 github action 동작
 on:
@@ -13,7 +13,7 @@ on:
 # push가 일어난 브랜치에 PR이 존재하면, push에 대한 이벤트와 PR에 대한 이벤트 모두 발생합니다.
 
 jobs:
-  build: 
+  test:
     runs-on: ubuntu-22.04 # 실행 환경 지정
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,12 @@ jobs:
       - name: Set up JDK 11 # JAVA 버전 지정
         uses: actions/setup-java@v1
         with:
-          java-version: 11 
+          java-version: 11
 
+      - name: Move to backend directory
+        run: cd backend/
+        shell: bash
+      
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,18 +24,17 @@ jobs:
         with:
           java-version: 11
 
-      - name: Move to backend directory
-        run: cd backend/ && pwd
-        shell: bash
-
       - name: Grant execute permission for gradlew
+        working-directory: ./backend
         run: chmod +x ./gradlew
 
       - name: Test with Gradle # test application build
+        working-directory: ./backend
         run: ./gradlew test -s
 
       - name: Publish Unit Test Results # test 후 result를 보기 위해 추가
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: ${{ always() }} # test가 실패해도 report를 남기기 위해 설정
         with:
+          working-directory: ./backend
           files: build/test-results/**/*.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: earth-github-action-test CI
+
+# 하기 내용에 해당하는 이벤트 발생 시 github action 동작
+on:
+  push: # 모든 브랜치에서 push가 일어났을 때 github action 동작
+    branches:
+      - '*'
+  pull_request: # 모든 브랜치에서 PR이 일어났을 때 github action 동작
+    branches:
+      - '*'
+
+# 참고사항
+# push가 일어난 브랜치에 PR이 존재하면, push에 대한 이벤트와 PR에 대한 이벤트 모두 발생합니다.
+
+jobs:
+  build: 
+    runs-on: ubuntu-22.04 # 실행 환경 지정
+
+    steps:
+      - uses: actions/checkout@v2 # github action 버전 지정(major version)
+
+      - name: Set up JDK 11 # JAVA 버전 지정
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11 
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test with Gradle # test application build
+        run: ./gradlew test -s
+
+      - name: Publish Unit Test Results # test 후 result를 보기 위해 추가
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: ${{ always() }} # test가 실패해도 report를 남기기 위해 설정
+        with:
+          files: build/test-results/**/*.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x ./gradlew
 
       - name: Test with Gradle # test application build
         run: ./gradlew test -s


### PR DESCRIPTION
## 구현 기능
- 백엔드 CI를 위한 Github Action 스크립트 추가

## 공유하고 싶은 내용
- [참고자료](https://earth-95.tistory.com/107)
- Jenkins에서 CI 부담을 덜기위해
    - 프론트 CD 아이템을 추가하려면 Jenkins 서버 용량이 더 필요해서 백엔드 CI 아이템을 지워야함

