### PR TITLE
feat: 인터셉터에 커스텀 어노테이션 적용

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthenticationConfig.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthenticationConfig.java
@@ -17,8 +17,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class AuthenticationConfig implements WebMvcConfigurer {
 
+    private final LoginInterceptor loginInterceptor;
     private final LoginMemberResolver loginMemberResolver;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public OAuthClient oAuthClient(@Value("${security.github.client-id}") final String clientId,
@@ -28,9 +28,8 @@ public class AuthenticationConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
-                .excludePathPatterns("/api/auth/**", "/api/feedback/**", "/api/levellogs/**")
-                .addPathPatterns("/api/members");
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/api/**");
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/NoAuthentication.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/NoAuthentication.java
@@ -1,0 +1,11 @@
+package com.woowacourse.levellog.authentication.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface NoAuthentication {
+}

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/LoginInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/LoginInterceptor.java
@@ -2,23 +2,32 @@ package com.woowacourse.levellog.authentication.presentation;
 
 import static org.springframework.web.cors.CorsUtils.isPreFlightRequest;
 
+import com.woowacourse.levellog.authentication.config.NoAuthentication;
 import com.woowacourse.levellog.authentication.domain.JwtTokenProvider;
 import com.woowacourse.levellog.authentication.exception.InvalidTokenException;
 import com.woowacourse.levellog.authentication.support.AuthorizationExtractor;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@Component
 @RequiredArgsConstructor
 public class LoginInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
-            throws Exception {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
         if (isPreFlightRequest(request)) {
+            return true;
+        }
+
+        if (isAnnotatedNoAuthentication((HandlerMethod) handler)) {
             return true;
         }
 
@@ -29,5 +38,12 @@ public class LoginInterceptor implements HandlerInterceptor {
         }
 
         return true;
+    }
+
+    private boolean isAnnotatedNoAuthentication(HandlerMethod handler) {
+        NoAuthentication classTypeNoAuthentication = handler.getBeanType().getAnnotation(NoAuthentication.class);
+        NoAuthentication methodNoAuthentication = handler.getMethodAnnotation(NoAuthentication.class);
+
+        return !Objects.isNull(classTypeNoAuthentication) || !Objects.isNull(methodNoAuthentication);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.authentication.presentation;
 
 import com.woowacourse.levellog.authentication.application.OAuthService;
+import com.woowacourse.levellog.authentication.config.NoAuthentication;
 import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
 import com.woowacourse.levellog.authentication.dto.LoginResponse;
 import javax.validation.Valid;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@NoAuthentication
 public class OAuthController {
 
     private final OAuthService oAuthService;

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.presentation;
 
 import com.woowacourse.levellog.application.LevellogService;
+import com.woowacourse.levellog.authentication.config.NoAuthentication;
 import com.woowacourse.levellog.authentication.support.LoginMember;
 import com.woowacourse.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.dto.LevellogResponse;
@@ -33,6 +34,7 @@ public class LevellogController {
     }
 
     @GetMapping("/{levellogId}")
+    @NoAuthentication
     public ResponseEntity<LevellogResponse> find(@PathVariable final Long teamId,
                                                  @PathVariable final Long levellogId) {
         final LevellogResponse response = levellogService.findById(levellogId);

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/TeamController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.presentation;
 
 import com.woowacourse.levellog.application.TeamService;
+import com.woowacourse.levellog.authentication.config.NoAuthentication;
 import com.woowacourse.levellog.authentication.support.LoginMember;
 import com.woowacourse.levellog.dto.TeamRequest;
 import com.woowacourse.levellog.dto.TeamResponse;
@@ -31,12 +32,14 @@ public class TeamController {
     }
 
     @GetMapping
+    @NoAuthentication
     public ResponseEntity<TeamsResponse> findAll() {
         final TeamsResponse response = teamService.findAll();
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{id}")
+    @NoAuthentication
     public ResponseEntity<TeamResponse> findById(@PathVariable final Long id) {
         final TeamResponse response = teamService.findById(id);
         return ResponseEntity.ok(response);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -115,6 +115,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
                 .body(request)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("levellog/update"))
@@ -146,6 +147,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
                 .filter(document("levellog/delete"))
                 .when()
                 .delete("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -75,26 +75,6 @@ class LevellogAcceptanceTest extends AcceptanceTest {
     }
 
     /*
-     * Scenario: 레벨로그 상세 조회
-     *   when: 존재하지 않는 레벨로그를 조회한다.
-     *   then: 500 상태 코드를 응답 받는다.
-     */
-    @Test
-    @DisplayName("존재하지 않는 레벨로그 상세 조회")
-    void findLevellog_notExistId_500() {
-        // given
-        final ValidatableResponse teamResponse = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브");
-        final String teamId = getTeamId(teamResponse);
-
-        // when
-        final ValidatableResponse response = requestFindLevellog(Long.parseLong(teamId), 999L);
-
-        // then
-        response.statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", equalTo("레벨로그가 존재하지 않습니다."));
-    }
-
-    /*
      * Scenario: 레벨로그 수정
      *   given: 레벨로그가 등록되어있다.
      *   when: 레벨로그를 수정한다.

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -1,14 +1,19 @@
 package com.woowacourse.levellog.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.levellog.dto.LevellogRequest;
+import com.woowacourse.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.support.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -44,6 +49,32 @@ class LevellogControllerTest extends ControllerTest {
     }
 
     @Nested
+    @DisplayName("find 메서드는")
+    class find {
+
+        @Test
+        @DisplayName("존재하지 않는 레벨로그를 조회하면 404 예외를 던진다.")
+        void levellogNoExist_Exception() throws Exception {
+            // given
+            doThrow(new LevellogNotFoundException())
+                    .when(levellogService)
+                    .findById(any());
+
+            Long teamId = 1L;
+            Long levellogId = 1000L;
+
+            // when
+            final ResultActions perform = mockMvc
+                    .perform(get("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
+                            .contentType(MediaType.APPLICATION_JSON))
+                            .andDo(print());
+
+            // then
+            perform.andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
     @DisplayName("update 메서드는")
     class update {
 
@@ -59,9 +90,10 @@ class LevellogControllerTest extends ControllerTest {
             final String requestContent = objectMapper.writeValueAsString(request);
 
             // when
-            final ResultActions perform = mockMvc.perform(put("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
+            final ResultActions perform = mockMvc.perform(
+                            put("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(requestContent))
                     .andDo(print());
 
             // then
@@ -69,3 +101,5 @@ class LevellogControllerTest extends ControllerTest {
         }
     }
 }
+
+


### PR DESCRIPTION
## 구현 기능
- NoAuthentication 어노테이션 구현 후 로그인 인터셉터와 컨트롤러에 적용
- rebase 후 깨지는 테스트 수정

## 논의하고 싶은 내용
- 어노테이션 이름 (@NoAuthentication)

Close #99 