### PR TITLE
fix: 팀에 레벨로그가 이미 존재할 때 레벨로그를 작성하면 예외를 던진다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
@@ -9,8 +9,10 @@ import com.woowacourse.levellog.domain.Team;
 import com.woowacourse.levellog.domain.TeamRepository;
 import com.woowacourse.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.dto.LevellogResponse;
+import com.woowacourse.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.exception.TeamNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,11 @@ public class LevellogService {
     private final MemberRepository memberRepository;
 
     public Long save(final Long authorId, final Long groupId, final LevellogRequest request) {
+        final Optional<Levellog> possibleLevellog = levellogRepository.findByAuthorIdAndTeamId(authorId, groupId);
+        if (possibleLevellog.isPresent()) {
+            throw new LevellogAlreadyExistException();
+        }
+
         final Team team = getTeam(groupId);
         final Member author = getMember(authorId);
         final Levellog levellog = new Levellog(author, team, request.getContent());

--- a/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
@@ -12,7 +12,6 @@ import com.woowacourse.levellog.dto.LevellogResponse;
 import com.woowacourse.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.exception.TeamNotFoundException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,10 +26,10 @@ public class LevellogService {
     private final MemberRepository memberRepository;
 
     public Long save(final Long authorId, final Long groupId, final LevellogRequest request) {
-        final Optional<Levellog> possibleLevellog = levellogRepository.findByAuthorIdAndTeamId(authorId, groupId);
-        if (possibleLevellog.isPresent()) {
-            throw new LevellogAlreadyExistException();
-        }
+        levellogRepository.findByAuthorIdAndTeamId(authorId, groupId)
+                .ifPresent(it -> {
+                    throw new LevellogAlreadyExistException();
+                });
 
         final Team team = getTeam(groupId);
         final Member author = getMember(authorId);

--- a/backend/src/main/java/com/woowacourse/levellog/exception/LevellogAlreadyExistException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/LevellogAlreadyExistException.java
@@ -1,0 +1,16 @@
+package com.woowacourse.levellog.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class LevellogAlreadyExistException extends LevellogException {
+
+    private static final String ERROR_MESSAGE = "팀에 레벨로그를 이미 작성했습니다.";
+
+    public LevellogAlreadyExistException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public LevellogAlreadyExistException() {
+        super(ERROR_MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 레벨로그 작성 Service 로직에 방어 로직을 추가

## 공유하고 싶은 내용
- author_id와 team_id가 동일한 레벨로그가 2개 이상 존재하면 아래 예외가 터집니다.
  ```
  [WARN ][2022-07-21 14:37:13.879][http-nio-8080-exec-8][c.w.l.e.ControllerAdvice] - [d479623d]
  org.springframework.dao.IncorrectResultSizeDataAccessException: query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2
  ```

Close #이슈번호
