### PR TITLE
fix: 레벨로그 수정, 삭제 시 자기 레벨로그가 아니면 권한 없음 예외가 발생하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
@@ -12,6 +12,7 @@ import com.woowacourse.levellog.dto.LevellogResponse;
 import com.woowacourse.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.exception.TeamNotFoundException;
+import com.woowacourse.levellog.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,8 +46,11 @@ public class LevellogService {
         return new LevellogResponse(levellog.getContent());
     }
 
-    public void update(final Long id, final LevellogRequest request) {
-        final Levellog levellog = getById(id);
+    public void update(final Long levellogId, final Long memberId, final LevellogRequest request) {
+        final Levellog levellog = getById(levellogId);
+        if (!levellog.getAuthor().getId().equals(memberId)) {
+            throw new UnauthorizedException("레벨로그를 수정할 권한이 없습니다.");
+        }
         levellog.updateContent(request.getContent());
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/application/LevellogService.java
@@ -48,14 +48,20 @@ public class LevellogService {
 
     public void update(final Long levellogId, final Long memberId, final LevellogRequest request) {
         final Levellog levellog = getById(levellogId);
-        if (!levellog.getAuthor().getId().equals(memberId)) {
-            throw new UnauthorizedException("레벨로그를 수정할 권한이 없습니다.");
-        }
+        validateAuthor(levellog, memberId, "레벨로그를 수정할 권한이 없습니다.");
         levellog.updateContent(request.getContent());
     }
 
-    public void deleteById(final Long id) {
-        levellogRepository.deleteById(id);
+    public void deleteById(final Long levellogId, final Long memberId) {
+        final Levellog levellog = getById(levellogId);
+        validateAuthor(levellog, memberId, "레벨로그를 삭제할 권한이 없습니다.");
+        levellogRepository.deleteById(levellogId);
+    }
+
+    private void validateAuthor(final Levellog levellog, final Long memberId, final String message) {
+        if (!levellog.isAuthorId(memberId)) {
+            throw new UnauthorizedException(message);
+        }
     }
 
     private Levellog getById(final Long id) {

--- a/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/domain/Levellog.java
@@ -33,4 +33,8 @@ public class Levellog extends BaseEntity {
     public void updateContent(final String content) {
         this.content = content;
     }
+
+    public boolean isAuthorId(final Long memberId) {
+        return author.getId().equals(memberId);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/exception/UnauthorizedException.java
@@ -1,0 +1,16 @@
+package com.woowacourse.levellog.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends LevellogException {
+
+    private static final String ERROR_MESSAGE = "권한이 없습니다.";
+
+    public UnauthorizedException(final String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException() {
+        super(ERROR_MESSAGE, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
@@ -44,8 +44,10 @@ public class LevellogController {
     @PutMapping("/{levellogId}")
     public ResponseEntity<Void> update(@PathVariable final Long teamId,
                                        @PathVariable final Long levellogId,
-                                       @RequestBody @Valid final LevellogRequest request) {
-        levellogService.update(levellogId, request);
+                                       @LoginMember final Long memberId,
+                                       @RequestBody @Valid final LevellogRequest request
+    ) {
+        levellogService.update(levellogId, memberId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/presentation/LevellogController.java
@@ -53,8 +53,9 @@ public class LevellogController {
 
     @DeleteMapping("/{levellogId}")
     public ResponseEntity<Void> delete(@PathVariable final Long teamId,
-                                       @PathVariable final Long levellogId) {
-        levellogService.deleteById(levellogId);
+                                       @PathVariable final Long levellogId,
+                                       @LoginMember final Long memberId) {
+        levellogService.deleteById(levellogId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -83,7 +83,7 @@ class LevellogServiceTest {
 
         @Test
         @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
-        void unauthorize_Exception() {
+        void unAuthorize_Exception() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
             final Team team = teamRepository.save(
@@ -97,21 +97,40 @@ class LevellogServiceTest {
         }
     }
 
-    @Test
-    @DisplayName("deleteById 메서드는 id에 해당하는 레벨로그를 삭제한다.")
-    void deleteById() {
-        // given
-        final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
-        final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
+    @Nested
+    @DisplayName("deleteById 메서드는")
+    class deleteById {
 
-        // when
-        levellogService.deleteById(levellog.getId());
+        @Test
+        @DisplayName("id에 해당하는 레벨로그를 삭제한다.")
+        void success() {
+            // given
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
+            final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
 
-        // then
-        final Optional<Levellog> actual = levellogRepository.findById(levellog.getId());
-        assertThat(actual).isEmpty();
+            // when
+            levellogService.deleteById(levellog.getId(), author.getId());
+
+            // then
+            final Optional<Levellog> actual = levellogRepository.findById(levellog.getId());
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
+        @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
+        void unAuthorize_Exception() {
+            // given
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
+            final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
+
+            // when & then
+            assertThatThrownBy(() -> levellogService.deleteById(levellog.getId(), 12345L))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -12,10 +12,10 @@ import com.woowacourse.levellog.domain.TeamRepository;
 import com.woowacourse.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.dto.LevellogResponse;
 import com.woowacourse.levellog.exception.LevellogAlreadyExistException;
+import com.woowacourse.levellog.exception.UnauthorizedException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import javax.transaction.Transactional;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,21 +29,18 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DisplayName("LevellogService의")
 class LevellogServiceTest {
+
     @Autowired
     private LevellogService levellogService;
+
     @Autowired
     private LevellogRepository levellogRepository;
+
     @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
     private TeamRepository teamRepository;
-
-    @AfterEach
-    void tearDown() {
-        memberRepository.deleteAll();
-        teamRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("findById 메서드는 id에 해당하는 레벨로그를 조회한다.")
@@ -62,22 +59,42 @@ class LevellogServiceTest {
         assertThat(response.getContent()).isEqualTo(content);
     }
 
-    @Test
-    @DisplayName("update 메서드는 id에 해당하는 레벨로그를 변경한다.")
-    void update() {
-        // given
-        final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
-        final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
-        final LevellogRequest request = new LevellogRequest("update content");
+    @Nested
+    @DisplayName("update 메서드는")
+    class update {
 
-        // when
-        levellogService.update(levellog.getId(), request);
+        @Test
+        @DisplayName("id에 해당하는 레벨로그를 변경한다.")
+        void success() {
+            // given
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
+            final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
+            final LevellogRequest request = new LevellogRequest("update content");
 
-        // then
-        final Levellog actual = levellogRepository.findById(levellog.getId()).orElseThrow();
-        assertThat(actual.getContent()).isEqualTo(request.getContent());
+            // when
+            levellogService.update(levellog.getId(), author.getId(), request);
+
+            // then
+            final Levellog actual = levellogRepository.findById(levellog.getId()).orElseThrow();
+            assertThat(actual.getContent()).isEqualTo(request.getContent());
+        }
+
+        @Test
+        @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
+        void unauthorize_Exception() {
+            // given
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "잠실 트랙룸", LocalDateTime.now(), "profileUrl"));
+            final Levellog levellog = levellogRepository.save(new Levellog(author, team, "original content"));
+            final LevellogRequest request = new LevellogRequest("update content");
+
+            // when & then
+            assertThatThrownBy(() -> levellogService.update(levellog.getId(), 100L, request))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -1,6 +1,9 @@
 package com.woowacourse.levellog.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.exception.LevellogNotFoundException;
+import com.woowacourse.levellog.exception.UnauthorizedException;
 import com.woowacourse.levellog.support.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -33,7 +38,7 @@ class LevellogControllerTest extends ControllerTest {
         @DisplayName("내용으로 공백이나 null이 들어오면 예외를 던진다.")
         void nameNullOrEmpty_Exception(final String content) throws Exception {
             // given
-            Long teamId = 1L;
+            final Long teamId = 1L;
             final LevellogRequest request = new LevellogRequest(content);
             final String requestContent = objectMapper.writeValueAsString(request);
 
@@ -60,14 +65,14 @@ class LevellogControllerTest extends ControllerTest {
                     .when(levellogService)
                     .findById(any());
 
-            Long teamId = 1L;
-            Long levellogId = 1000L;
+            final Long teamId = 1L;
+            final Long levellogId = 1000L;
 
             // when
             final ResultActions perform = mockMvc
                     .perform(get("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
                             .contentType(MediaType.APPLICATION_JSON))
-                            .andDo(print());
+                    .andDo(print());
 
             // then
             perform.andExpect(status().isNotFound());
@@ -84,20 +89,50 @@ class LevellogControllerTest extends ControllerTest {
         @DisplayName("내용으로 공백이나 null이 들어오면 예외를 던진다.")
         void nameNullOrEmpty_Exception(final String content) throws Exception {
             // given
-            Long teamId = 1L;
-            Long levellogId = 2L;
+            given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+            given(jwtTokenProvider.validateToken(any())).willReturn(true);
+
+            final Long teamId = 1L;
+            final Long levellogId = 2L;
             final LevellogRequest request = new LevellogRequest(content);
             final String requestContent = objectMapper.writeValueAsString(request);
 
             // when
             final ResultActions perform = mockMvc.perform(
                             put("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
+                                    .header(HttpHeaders.AUTHORIZATION, "Bearer: token")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(requestContent))
                     .andDo(print());
 
             // then
             perform.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작성하지 않은 레벨로그를 수정하려는 경우 예외를 던진다.")
+        void unauthorized_Exception() throws Exception {
+            // given
+            given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+            given(jwtTokenProvider.validateToken(any())).willReturn(true);
+
+            final Long teamId = 1L;
+            final Long levellogId = 2L;
+            final LevellogRequest request = new LevellogRequest("content");
+            final String requestContent = objectMapper.writeValueAsString(request);
+            doThrow(new UnauthorizedException("레벨로그를 수정할 권한이 없습니다.")).when(levellogService)
+                    .update(anyLong(), anyLong(), any());
+
+            // when
+            final ResultActions perform = mockMvc.perform(
+                            put("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
+                                    .header(HttpHeaders.AUTHORIZATION, "Bearer: token")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(requestContent))
+                    .andDo(print());
+
+            // then
+            perform.andExpect(status().isUnauthorized());
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -40,6 +40,8 @@ class MyInfoControllerTest extends ControllerTest {
         void nicknameInvalidLength_Exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+            given(jwtTokenProvider.validateToken(any())).willReturn(true);
+
             doThrow(new InvalidFieldException("닉네임은 50자 이하여야합니다.", BAD_REQUEST))
                     .when(memberService)
                     .updateNickname(any(), any());
@@ -68,6 +70,7 @@ class MyInfoControllerTest extends ControllerTest {
         void nicknameNullAndEmpty_Exception(final String invalidNickname) throws Exception {
             // given
             given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
+            given(jwtTokenProvider.validateToken(any())).willReturn(true);
 
             final NicknameUpdateDto nicknameUpdateDto = new NicknameUpdateDto(invalidNickname);
             final String requestContent = objectMapper.writeValueAsString(nicknameUpdateDto);


### PR DESCRIPTION
## 구현 기능
- 레벨로그 수정, 삭제 시 자기 레벨로그가 아니면 권한 없음 예외가 발생하도록 수정

## 논의하고 싶은 내용
## 공유하고 싶은 내용
