### PR TITLE
refactor: 픽스처를 사용해서 인수 테스트 리팩토링

### DIFF
--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -15,6 +15,7 @@ import com.woowacourse.levellog.authentication.dto.LoginResponse;
 import com.woowacourse.levellog.config.TestAuthenticationConfig;
 import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
+import com.woowacourse.levellog.fixture.RestAssuredTemplate;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.team.dto.ParticipantIdsRequest;
 import com.woowacourse.levellog.team.dto.TeamRequest;
@@ -34,7 +35,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.annotation.DirtiesContext;
@@ -106,13 +106,7 @@ abstract class AcceptanceTest {
 
         final String token = getToken(login(host));
 
-        return RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                .body(request)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams")
-                .then().log().all();
+        return RestAssuredTemplate.post("/api/teams", token, request);
     }
 
     protected ValidatableResponse requestCreateTeam(final String title, final String token,
@@ -120,13 +114,7 @@ abstract class AcceptanceTest {
         final ParticipantIdsRequest participantIdsRequest = new ParticipantIdsRequest(List.of(participantIds));
         final TeamRequest request = new TeamRequest(title, title + "place", LocalDateTime.now(), participantIdsRequest);
 
-        return RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                .body(request)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams")
-                .then().log().all();
+        return RestAssuredTemplate.post("/api/teams", token, request);
     }
 
     protected ValidatableResponse login(final String nickname) {
@@ -135,12 +123,7 @@ abstract class AcceptanceTest {
                     ((int) System.currentTimeMillis())), nickname,
                     nickname + ".com");
             final String code = objectMapper.writeValueAsString(response);
-            return RestAssured.given().log().all()
-                    .body(new GithubCodeRequest(code))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .when()
-                    .post("/api/auth/login")
-                    .then().log().all();
+            return RestAssuredTemplate.post("/api/auth/login", new GithubCodeRequest(code));
         } catch (final JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -177,13 +160,7 @@ abstract class AcceptanceTest {
     protected ValidatableResponse requestCreateLevellog(final String teamId, final String content) {
         final LevellogRequest request = new LevellogRequest(content);
 
-        return RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
-                .body(request)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams/{teamId}/levellogs", teamId)
-                .then().log().all();
+        return RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", masterToken, request);
     }
 
     protected String getLevellogId(final ValidatableResponse levellogResponse) {
@@ -203,12 +180,6 @@ abstract class AcceptanceTest {
         final ValidatableResponse loginResponse = login(from);
         final String token = getToken(loginResponse);
 
-        return RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                .body(request)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                .then().log().all();
+        return RestAssuredTemplate.post("/api/levellogs/" + levellogId + "/feedbacks", token, request);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.acceptance;
 
+import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
 import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
 import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
@@ -11,18 +12,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
 import com.woowacourse.levellog.authentication.dto.GithubProfileResponse;
-import com.woowacourse.levellog.authentication.dto.LoginResponse;
 import com.woowacourse.levellog.config.TestAuthenticationConfig;
-import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
-import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
-import com.woowacourse.levellog.fixture.RestAssuredTemplate;
+import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.team.dto.ParticipantIdsRequest;
 import com.woowacourse.levellog.team.dto.TeamRequest;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.response.ValidatableResponse;
-import io.restassured.response.ValidatableResponseOptions;
 import io.restassured.specification.RequestSpecification;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -34,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.annotation.DirtiesContext;
@@ -89,97 +84,51 @@ abstract class AcceptanceTest {
                                 )
                 ).build();
 
-        masterToken = getToken(login(MASTER));
-        masterId = getMemberId(login(MASTER));
+        masterToken = login(MASTER)
+                .getToken();
+        masterId = login(MASTER)
+                .getMemberId();
     }
 
-    protected ValidatableResponse requestCreateTeam(final String title, final String host,
+    protected RestAssuredResponse requestCreateTeam(final String title, final String host,
                                                     final String... participants) {
         final List<Long> participantIds = Arrays.stream(participants)
                 .map(this::login)
-                .map(ValidatableResponseOptions::extract)
-                .map(it -> it.as(LoginResponse.class))
-                .map(LoginResponse::getId)
+                .map(RestAssuredResponse::getMemberId)
                 .collect(Collectors.toList());
         final ParticipantIdsRequest participantIdsRequest = new ParticipantIdsRequest(participantIds);
         final TeamRequest request = new TeamRequest(title, title + "place", LocalDateTime.now(), participantIdsRequest);
 
-        final String token = getToken(login(host));
+        final String token = login(host)
+                .getToken();
 
-        return RestAssuredTemplate.post("/api/teams", token, request);
+        return post("/api/teams", token, request);
     }
 
-    protected ValidatableResponse requestCreateTeam(final String title, final String token,
+    protected RestAssuredResponse requestCreateTeam(final String title, final String token,
                                                     final Long... participantIds) {
         final ParticipantIdsRequest participantIdsRequest = new ParticipantIdsRequest(List.of(participantIds));
         final TeamRequest request = new TeamRequest(title, title + "place", LocalDateTime.now(), participantIdsRequest);
 
-        return RestAssuredTemplate.post("/api/teams", token, request);
+        return post("/api/teams", token, request);
     }
 
-    protected ValidatableResponse login(final String nickname) {
+    protected RestAssuredResponse login(final String nickname) {
         try {
             final GithubProfileResponse response = new GithubProfileResponse(String.valueOf(
                     ((int) System.currentTimeMillis())), nickname,
                     nickname + ".com");
             final String code = objectMapper.writeValueAsString(response);
-            return RestAssuredTemplate.post("/api/auth/login", new GithubCodeRequest(code));
+            return post("/api/auth/login", new GithubCodeRequest(code));
         } catch (final JsonProcessingException e) {
             e.printStackTrace();
         }
         return null;
     }
 
-    protected String getToken(final ValidatableResponse loginResponse) {
-        return loginResponse.extract()
-                .as(LoginResponse.class)
-                .getAccessToken();
-    }
-
-    protected Long getMemberId(final ValidatableResponse loginResponse) {
-        return loginResponse.extract()
-                .as(LoginResponse.class)
-                .getId();
-    }
-
-    protected String getTeamId(final ValidatableResponse teamResponse) {
-        return teamResponse
-                .extract()
-                .header(HttpHeaders.LOCATION)
-                .split("/api/teams/")[1];
-    }
-
-    protected ValidatableResponse requestCreateLevellog(final String content, final String title, final String host,
-                                                        final String... participants) {
-        final ValidatableResponse teamResponse = requestCreateTeam(title, host, participants);
-        final String teamId = getTeamId(teamResponse);
-
-        return requestCreateLevellog(teamId, content);
-    }
-
-    protected ValidatableResponse requestCreateLevellog(final String teamId, final String content) {
+    protected RestAssuredResponse requestCreateLevellog(final String teamId, final String content) {
         final LevellogRequest request = new LevellogRequest(content);
 
-        return RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", masterToken, request);
-    }
-
-    protected String getLevellogId(final ValidatableResponse levellogResponse) {
-        return levellogResponse
-                .extract()
-                .header(HttpHeaders.LOCATION)
-                .split("/levellogs/")[1];
-    }
-
-    protected ValidatableResponse requestCreateFeedback(final String levellogId, final String content,
-                                                        final String from) {
-        final FeedbackContentDto feedbackContentDto = new FeedbackContentDto("study - " + content,
-                "speak - " + content,
-                "etc - " + content);
-        final FeedbackRequest request = new FeedbackRequest(feedbackContentDto);
-
-        final ValidatableResponse loginResponse = login(from);
-        final String token = getToken(loginResponse);
-
-        return RestAssuredTemplate.post("/api/levellogs/" + levellogId + "/feedbacks", token, request);
+        return post("/api/teams/" + teamId + "/levellogs", masterToken, request);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -8,6 +8,8 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
 import com.woowacourse.levellog.feedback.dto.FeedbacksResponse;
+import com.woowacourse.levellog.fixture.RestAssuredResponse;
+import com.woowacourse.levellog.fixture.RestAssuredTemplate;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
@@ -29,26 +31,20 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드백 작성")
     void createFeedback() {
         // given
-        final ValidatableResponse hostLoginResponse = login("릭");
-        final Long rick_id = getMemberId(hostLoginResponse);
-        final String rickToken = getToken(hostLoginResponse);
+        final RestAssuredResponse hostLoginResponse = login("릭");
+        final Long rick_id = hostLoginResponse.getMemberId();
+        final String rickToken = hostLoginResponse.getToken();
 
-        final ValidatableResponse romaLoginResponse = login("로마");
-        final Long roma_id = getMemberId(romaLoginResponse);
-        final String romaToken = getToken(romaLoginResponse);
+        final RestAssuredResponse romaLoginResponse = login("로마");
+        final Long roma_id = romaLoginResponse.getMemberId();
+        final String romaToken = romaLoginResponse.getToken();
 
-        final ValidatableResponse teamResponse = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id);
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+                .getTeamId();
 
         final LevellogRequest levellogRequest = new LevellogRequest("레벨로그");
-        final ValidatableResponse levellogResponse = RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + rickToken)
-                .body(levellogRequest)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams/{teamId}/levellogs", teamId)
-                .then().log().all();
-        final String levellogId = getLevellogId(levellogResponse);
+        final String levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken, levellogRequest)
+                .getLevellogId();
 
         final FeedbackContentDto feedbackContentDto = new FeedbackContentDto("Spring에 대한 학습을 충분히 하였습니다.",
                 "아이 컨텍이 좋습니다.",
@@ -80,26 +76,20 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드백 조회")
     void findAllFeedbacks() {
         // given
-        final ValidatableResponse hostLoginResponse = login("릭");
-        final Long rick_id = getMemberId(hostLoginResponse);
-        final String rickToken = getToken(hostLoginResponse);
+        final RestAssuredResponse hostLoginResponse = login("릭");
+        final Long rick_id = hostLoginResponse.getMemberId();
+        final String rickToken = hostLoginResponse.getToken();
 
-        final ValidatableResponse romaLoginResponse = login("로마");
-        final Long roma_id = getMemberId(romaLoginResponse);
-        final String romaToken = getToken(romaLoginResponse);
+        final RestAssuredResponse romaLoginResponse = login("로마");
+        final Long roma_id = romaLoginResponse.getMemberId();
+        final String romaToken = romaLoginResponse.getToken();
 
-        final ValidatableResponse teamResponse = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id);
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+                .getTeamId();
 
         final LevellogRequest levellogRequest = new LevellogRequest("레벨로그");
-        final ValidatableResponse levellogResponse = RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + rickToken)
-                .body(levellogRequest)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams/{teamId}/levellogs", teamId)
-                .then().log().all();
-        final String levellogId = getLevellogId(levellogResponse);
+        final String levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken, levellogRequest)
+                .getLevellogId();
 
         final FeedbackContentDto feedbackContentDto = new FeedbackContentDto("Spring에 대한 학습을 충분히 하였습니다.",
                 "아이 컨텍이 좋습니다.",
@@ -143,27 +133,20 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드백 삭제")
     void deleteFeedback() {
         // given
-        // given
-        final ValidatableResponse hostLoginResponse = login("릭");
-        final Long rick_id = getMemberId(hostLoginResponse);
-        final String rickToken = getToken(hostLoginResponse);
+        final RestAssuredResponse hostLoginResponse = login("릭");
+        final Long rick_id = hostLoginResponse.getMemberId();
+        final String rickToken = hostLoginResponse.getToken();
 
-        final ValidatableResponse romaLoginResponse = login("로마");
-        final Long roma_id = getMemberId(romaLoginResponse);
-        final String romaToken = getToken(romaLoginResponse);
+        final RestAssuredResponse romaLoginResponse = login("로마");
+        final Long roma_id = romaLoginResponse.getMemberId();
+        final String romaToken = romaLoginResponse.getToken();
 
-        final ValidatableResponse teamResponse = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id);
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+                .getTeamId();
 
         final LevellogRequest levellogRequest = new LevellogRequest("레벨로그");
-        final ValidatableResponse levellogResponse = RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + rickToken)
-                .body(levellogRequest)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/api/teams/{teamId}/levellogs", teamId)
-                .then().log().all();
-        final String rick_levellogId = getLevellogId(levellogResponse);
+        final String rick_levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken, levellogRequest)
+                .getLevellogId();
 
         final FeedbackContentDto feedbackContentDto = new FeedbackContentDto("Spring에 대한 학습을 충분히 하였습니다.",
                 "아이 컨텍이 좋습니다.",

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -25,8 +25,8 @@ class LevellogAcceptanceTest extends AcceptanceTest {
     @DisplayName("레벨로그 작성")
     void createLevellog() {
         // given
-        final ValidatableResponse teamResponse = requestCreateTeam("레벨로그팀", MASTER, MASTER, "로마", "알린");
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("레벨로그팀", MASTER, MASTER, "로마", "알린")
+                .getTeamId();
 
         final LevellogRequest request = new LevellogRequest("Spring과 React를 학습했습니다.");
 
@@ -55,11 +55,11 @@ class LevellogAcceptanceTest extends AcceptanceTest {
     @DisplayName("레벨로그 상세 조회")
     void findLevellog() {
         // given
-        final ValidatableResponse teamResponse = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브");
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브")
+                .getTeamId();
 
-        final ValidatableResponse levellogResponse = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.");
-        final String levellogId = getLevellogId(levellogResponse);
+        final String levellogId = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.")
+                .getLevellogId();
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -84,11 +84,11 @@ class LevellogAcceptanceTest extends AcceptanceTest {
     @DisplayName("레벨로그 수정")
     void updateLevellog() {
         // given
-        final ValidatableResponse teamResponse = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브");
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브")
+                .getTeamId();
 
-        final ValidatableResponse levellogResponse = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.");
-        final String levellogId = getLevellogId(levellogResponse);
+        final String levellogId = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.")
+                .getLevellogId();
 
         final String updateContent = "update content";
         final LevellogRequest request = new LevellogRequest(updateContent);
@@ -119,11 +119,11 @@ class LevellogAcceptanceTest extends AcceptanceTest {
     @DisplayName("레벨로그 삭제")
     void deleteLevellog() {
         // given
-        final ValidatableResponse teamResponse = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브");
-        final String teamId = getTeamId(teamResponse);
+        final String teamId = requestCreateTeam("레벨로그팀", MASTER, MASTER, "클레이", "이브")
+                .getTeamId();
 
-        final ValidatableResponse levellogResponse = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.");
-        final String levellogId = getLevellogId(levellogResponse);
+        final String levellogId = requestCreateLevellog(teamId, "트렌젝션에 대해 학습함.")
+                .getLevellogId();
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -26,8 +26,8 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
     @DisplayName("내 정보 조회")
     void readMyInfo() {
         // given
-        final ValidatableResponse loginResponse = login("로마");
-        final String token = getToken(loginResponse);
+        final String token = login("로마")
+                .getToken();
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -54,8 +54,8 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
     @DisplayName("내 닉네임 변경하기")
     void updateMyNickname() {
         // given
-        final ValidatableResponse loginResponse = login("로마");
-        final String token = getToken(loginResponse);
+        final String token = login("로마")
+                .getToken();
 
         final NicknameUpdateDto nicknameDto = new NicknameUpdateDto("새이름");
 

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredResponse.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredResponse.java
@@ -1,0 +1,46 @@
+package com.woowacourse.levellog.fixture;
+
+import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import io.restassured.response.ValidatableResponse;
+import org.springframework.http.HttpHeaders;
+
+public class RestAssuredResponse {
+
+    private final ValidatableResponse response;
+
+    public RestAssuredResponse(ValidatableResponse response) {
+        this.response = response;
+    }
+
+    public String getLevellogId() {
+        return response
+                .extract()
+                .header(HttpHeaders.LOCATION)
+                .split("/levellogs/")[1];
+    }
+
+    public String getTeamId() {
+        return response
+                .extract()
+                .header(HttpHeaders.LOCATION)
+                .split("/api/teams/")[1];
+    }
+
+    public Long getMemberId() {
+        return response
+                .extract()
+                .as(LoginResponse.class)
+                .getId();
+    }
+
+    public String getToken() {
+        return response
+                .extract()
+                .as(LoginResponse.class)
+                .getAccessToken();
+    }
+
+    public ValidatableResponse getResponse() {
+        return response;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredTemplate.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredTemplate.java
@@ -7,52 +7,58 @@ import org.springframework.http.MediaType;
 
 public class RestAssuredTemplate {
 
-    public static ValidatableResponse get(final String url) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse get(final String url) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .when()
                 .get(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 
-    public static ValidatableResponse get(final String url, final String token) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse get(final String url, final String token) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .when()
                 .get(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 
-    public static ValidatableResponse post(final String url) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse post(final String url) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .when()
                 .post(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 
-    public static ValidatableResponse post(final String url, final String token) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse post(final String url, final String token) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .when()
                 .post(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 
-    public static ValidatableResponse post(final String url, final Object body) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse post(final String url, final Object body) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(body)
                 .when()
                 .post(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 
-    public static ValidatableResponse post(final String url, final String token, final Object body) {
-        return RestAssured.given().log().all()
+    public static RestAssuredResponse post(final String url, final String token, final Object body) {
+        final ValidatableResponse response = RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(body)
                 .when()
                 .post(url)
                 .then().log().all();
+        return new RestAssuredResponse(response);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredTemplate.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredTemplate.java
@@ -1,0 +1,58 @@
+package com.woowacourse.levellog.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class RestAssuredTemplate {
+
+    public static ValidatableResponse get(final String url) {
+        return RestAssured.given().log().all()
+                .when()
+                .get(url)
+                .then().log().all();
+    }
+
+    public static ValidatableResponse get(final String url, final String token) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .when()
+                .get(url)
+                .then().log().all();
+    }
+
+    public static ValidatableResponse post(final String url) {
+        return RestAssured.given().log().all()
+                .when()
+                .post(url)
+                .then().log().all();
+    }
+
+    public static ValidatableResponse post(final String url, final String token) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .when()
+                .post(url)
+                .then().log().all();
+    }
+
+    public static ValidatableResponse post(final String url, final Object body) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .when()
+                .post(url)
+                .then().log().all();
+    }
+
+    public static ValidatableResponse post(final String url, final String token, final Object body) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .when()
+                .post(url)
+                .then().log().all();
+    }
+}


### PR DESCRIPTION
## 구현 기능
- fixture 패키지에 `RestAssuredTemplate` & `RestAssuredResponse` 구현
- 구현한 fixture를 활용해서 인수 테스트 리팩토링
  - 주로 테스트를 위한 데이터 적재를 위해서 요청날리는 부분을 리팩토링했음

## 논의하고 싶은 내용
- `RestAssuredTemplate` & `RestAssuredResponse` 네이밍
- `RestAssuredTemplate` 메서드를 오버로딩해서 구현했는데 가독성 측면에서 피드백
- `RestAssuredResponse`의 getXXX 메서드 네이밍
- 문서화를 하는 RestAssured요청도 template으로 추상화하는게 좋을지?

Close #101 
