### PR TITLE
chore: mockMvc에 Rest Docs 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,8 +40,10 @@ dependencies {
 
 	// rest docs
 	testImplementation'org.springframework.restdocs:spring-restdocs-restassured'
+	testImplementation'org.springframework.restdocs:spring-restdocs-mockmvc'
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
+	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'


### PR DESCRIPTION
## 구현 기능
- API 예외 케이스 문서화를 위한 rest docs 설정 구현

## 공유하고 싶은 내용
- snippet 생성 -> asciidoc 문서 작성 (기존 인수 테스트 방식과 동일합니당)
- 아래와 같이 사용하세용
### AS-IS
```java
    @ParameterizedTest
    @ValueSource(strings = {" "})
    @NullAndEmptySource
    @DisplayName("login 메서드는 코드에 공백이나 null이 들어오면 예외를 던진다.")
    void login(final String code) throws Exception {
        // given
        final GithubCodeRequest request = new GithubCodeRequest(code);
        final String requestContent = objectMapper.writeValueAsString(request);

        // when
        final ResultActions perform = mockMvc.perform(post("/api/auth/login")
                        .contentType(MediaType.APPLICATION_JSON)
                        .content(requestContent))
                .andDo(print());

        // then
        perform.andExpect(status().isBadRequest());
```

### TO-BE
```java
    @ParameterizedTest
    @ValueSource(strings = {" "})
    @NullAndEmptySource
    @DisplayName("login 메서드는 코드에 공백이나 null이 들어오면 예외를 던진다.")
    void login(final String code) throws Exception {
        // given
        final GithubCodeRequest request = new GithubCodeRequest(code);
        final String requestContent = objectMapper.writeValueAsString(request);

        // when
        final ResultActions perform = mockMvc.perform(post("/api/auth/login")
                        .contentType(MediaType.APPLICATION_JSON)
                        .content(requestContent))
                .andDo(print());

        // then
        perform.andExpect(status().isBadRequest());

        // docs
        perform.andDo(document("auth/login/null"));
```

## 참고 자료
[참고자료 1](https://backtony.github.io/spring/2021-10-15-spring-test-3/)
[참고자료 2](https://luvstudy.tistory.com/75)