### PR TITLE
refactor: Auth 도메인 리팩토링

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -12,6 +12,11 @@
 == 로그인
 
 [[login-success]]
-=== 성공
+=== 로그인 성공
 
 operation::auth/login[]
+
+[[login-fail-blank-token]]
+=== 로그인 실패 - 유효하지 않은 authorizationCode
+
+operation::auth/login/null[]

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -6,17 +6,24 @@
 
 [[home]]
 == home
+
 * link:index.html[목록으로 가기]
 
 [[login]]
 == 로그인
 
 [[login-success]]
-=== 로그인 성공
+=== 깃허브 로그인 성공
 
 operation::auth/login[]
 
-[[login-fail-blank-token]]
-=== 로그인 실패 - 유효하지 않은 authorizationCode
+[[login-exception]]
+=== 깃허브 로그인 예외
+
+==== 유효하지 않은 authorizationCode
 
 operation::auth/login/null[]
+
+==== 깃허브에서 토큰 받아오기 실패
+
+operation::auth/login/github-fail[]

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OAuthService {
 
@@ -19,6 +19,7 @@ public class OAuthService {
     private final OAuthClient oAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Transactional
     public LoginDto login(final GithubCodeDto request) {
         final String code = request.getAuthorizationCode();
         final String githubAccessToken = oAuthClient.getAccessToken(code);

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
@@ -1,9 +1,9 @@
 package com.woowacourse.levellog.authentication.application;
 
 import com.woowacourse.levellog.authentication.domain.OAuthClient;
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
-import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import com.woowacourse.levellog.authentication.dto.LoginDto;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
 import com.woowacourse.levellog.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +19,8 @@ public class OAuthService {
     private final OAuthClient oAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public LoginResponse login(final GithubCodeRequest codeRequest) {
-        final String code = codeRequest.getAuthorizationCode();
+    public LoginDto login(final GithubCodeDto request) {
+        final String code = request.getAuthorizationCode();
         final String githubAccessToken = oAuthClient.getAccessToken(code);
 
         final GithubProfileDto githubProfile = oAuthClient.getProfile(githubAccessToken);
@@ -28,7 +28,7 @@ public class OAuthService {
 
         final String token = jwtTokenProvider.createToken(memberId.toString());
 
-        return new LoginResponse(memberId, token, githubProfile.getProfileUrl());
+        return new LoginDto(memberId, token, githubProfile.getProfileUrl());
     }
 
     private Long getMemberIdByGithubProfile(final GithubProfileDto githubProfile) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
@@ -15,9 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OAuthService {
 
-    private final MemberService memberService;
     private final OAuthClient oAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
 
     @Transactional
     public LoginDto login(final GithubCodeDto request) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
@@ -40,8 +40,11 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private boolean isPublicAPI(final HandlerMethod handler) {
         final PublicAPI classTypePublicAPI = handler.getBeanType().getAnnotation(PublicAPI.class);
-        final PublicAPI methodPublicAPI = handler.getMethodAnnotation(PublicAPI.class);
+        final boolean isPublicClass = classTypePublicAPI != null;
 
-        return classTypePublicAPI == null && methodPublicAPI == null;
+        final PublicAPI methodPublicAPI = handler.getMethodAnnotation(PublicAPI.class);
+        final boolean isPublicMethod = methodPublicAPI != null;
+
+        return isPublicClass || isPublicMethod;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
@@ -6,7 +6,6 @@ import com.woowacourse.levellog.authentication.exception.InvalidTokenException;
 import com.woowacourse.levellog.authentication.support.AuthorizationExtractor;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
 import com.woowacourse.levellog.authentication.support.PublicAPI;
-import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,12 +26,11 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (isAnnotatedNoAuthentication((HandlerMethod) handler)) {
+        if (isPublicAPI((HandlerMethod) handler)) {
             return true;
         }
 
         final String token = AuthorizationExtractor.extract(request);
-
         if (!jwtTokenProvider.validateToken(token)) {
             throw new InvalidTokenException("토큰 인증 실패 - token:" + token);
         }
@@ -40,10 +38,10 @@ public class AuthInterceptor implements HandlerInterceptor {
         return true;
     }
 
-    private boolean isAnnotatedNoAuthentication(final HandlerMethod handler) {
+    private boolean isPublicAPI(final HandlerMethod handler) {
         final PublicAPI classTypePublicAPI = handler.getBeanType().getAnnotation(PublicAPI.class);
         final PublicAPI methodPublicAPI = handler.getMethodAnnotation(PublicAPI.class);
 
-        return !Objects.isNull(classTypePublicAPI) || !Objects.isNull(methodPublicAPI);
+        return classTypePublicAPI == null && methodPublicAPI == null;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
@@ -34,7 +34,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         final String token = AuthorizationExtractor.extract(request);
 
         if (!jwtTokenProvider.validateToken(token)) {
-            throw new InvalidTokenException();
+            throw new InvalidTokenException("토큰 인증 실패 - token:" + token);
         }
 
         return true;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/AuthInterceptor.java
@@ -5,7 +5,7 @@ import static org.springframework.web.cors.CorsUtils.isPreFlightRequest;
 import com.woowacourse.levellog.authentication.exception.InvalidTokenException;
 import com.woowacourse.levellog.authentication.support.AuthorizationExtractor;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
-import com.woowacourse.levellog.authentication.support.NoAuthentication;
+import com.woowacourse.levellog.authentication.support.PublicAPI;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,9 +41,9 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private boolean isAnnotatedNoAuthentication(final HandlerMethod handler) {
-        final NoAuthentication classTypeNoAuthentication = handler.getBeanType().getAnnotation(NoAuthentication.class);
-        final NoAuthentication methodNoAuthentication = handler.getMethodAnnotation(NoAuthentication.class);
+        final PublicAPI classTypePublicAPI = handler.getBeanType().getAnnotation(PublicAPI.class);
+        final PublicAPI methodPublicAPI = handler.getMethodAnnotation(PublicAPI.class);
 
-        return !Objects.isNull(classTypeNoAuthentication) || !Objects.isNull(methodNoAuthentication);
+        return !Objects.isNull(classTypePublicAPI) || !Objects.isNull(methodPublicAPI);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/LoginMemberResolver.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/LoginMemberResolver.java
@@ -2,7 +2,7 @@ package com.woowacourse.levellog.authentication.config;
 
 import com.woowacourse.levellog.authentication.support.AuthorizationExtractor;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
-import com.woowacourse.levellog.authentication.support.LoginMember;
+import com.woowacourse.levellog.authentication.support.Authentic;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -20,7 +20,7 @@ public class LoginMemberResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(LoginMember.class);
+        return parameter.hasParameterAnnotation(Authentic.class);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/config/LoginMemberResolver.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/config/LoginMemberResolver.java
@@ -1,8 +1,8 @@
 package com.woowacourse.levellog.authentication.config;
 
+import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.AuthorizationExtractor;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
-import com.woowacourse.levellog.authentication.support.Authentic;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -25,10 +25,10 @@ public class LoginMemberResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Long resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
-                                final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
-            throws Exception {
+                                final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final String token = AuthorizationExtractor.extract(request);
+
         return Long.parseLong(jwtTokenProvider.getPayload(token));
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
@@ -3,7 +3,6 @@ package com.woowacourse.levellog.authentication.domain;
 import com.woowacourse.levellog.authentication.dto.GithubAccessTokenDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.authentication.dto.TokenDto;
-import java.util.Objects;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -35,8 +34,8 @@ public class GithubOAuthClient implements OAuthClient {
                 .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, TokenDto.class)
                 .getBody();
 
-        if (Objects.isNull(response)) {
-            throw new IllegalStateException("Github 요청에 실패했습니다.");
+        if (response == null) {
+            throw new IllegalStateException("Github 로그인 요청 실패 - authorizationCode:" + code);
         }
 
         return response.getAccessToken();

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
@@ -1,8 +1,8 @@
 package com.woowacourse.levellog.authentication.domain;
 
-import com.woowacourse.levellog.authentication.dto.GithubAccessTokenRequest;
-import com.woowacourse.levellog.authentication.dto.GithubAccessTokenResponse;
+import com.woowacourse.levellog.authentication.dto.GithubAccessTokenDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
+import com.woowacourse.levellog.authentication.dto.TokenDto;
 import java.util.Objects;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -25,16 +25,14 @@ public class GithubOAuthClient implements OAuthClient {
 
     @Override
     public String getAccessToken(final String code) {
-        final GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(clientId, clientSecret,
-                code);
+        final GithubAccessTokenDto githubAccessTokenDto = new GithubAccessTokenDto(clientId, clientSecret, code);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
-        final HttpEntity<GithubAccessTokenRequest> httpEntity =
-                new HttpEntity<>(githubAccessTokenRequest, headers);
+        final HttpEntity<GithubAccessTokenDto> httpEntity = new HttpEntity<>(githubAccessTokenDto, headers);
 
-        final GithubAccessTokenResponse response = new RestTemplate()
-                .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
+        final TokenDto response = new RestTemplate()
+                .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, TokenDto.class)
                 .getBody();
 
         if (Objects.isNull(response)) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
@@ -23,19 +23,18 @@ public class GithubOAuthClient implements OAuthClient {
     }
 
     @Override
-    public String getAccessToken(final String code) {
-        final GithubAccessTokenDto githubAccessTokenDto = new GithubAccessTokenDto(clientId, clientSecret, code);
+    public String getAccessToken(final String authorizationCode) {
+        final GithubAccessTokenDto request = new GithubAccessTokenDto(clientId, clientSecret, authorizationCode);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
-        final HttpEntity<GithubAccessTokenDto> httpEntity = new HttpEntity<>(githubAccessTokenDto, headers);
-
+        final HttpEntity<GithubAccessTokenDto> httpEntity = new HttpEntity<>(request, headers);
         final TokenDto response = new RestTemplate()
                 .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, TokenDto.class)
                 .getBody();
 
         if (response == null) {
-            throw new IllegalStateException("Github 로그인 요청 실패 - authorizationCode:" + code);
+            throw new IllegalStateException("Github 로그인 요청 실패 - authorizationCode:" + authorizationCode);
         }
 
         return response.getAccessToken();

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/domain/GithubOAuthClient.java
@@ -2,7 +2,7 @@ package com.woowacourse.levellog.authentication.domain;
 
 import com.woowacourse.levellog.authentication.dto.GithubAccessTokenDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
-import com.woowacourse.levellog.authentication.dto.TokenDto;
+import com.woowacourse.levellog.authentication.dto.GithubTokenDto;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -29,8 +29,8 @@ public class GithubOAuthClient implements OAuthClient {
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
         final HttpEntity<GithubAccessTokenDto> httpEntity = new HttpEntity<>(request, headers);
-        final TokenDto response = new RestTemplate()
-                .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, TokenDto.class)
+        final GithubTokenDto response = new RestTemplate()
+                .exchange(TOKEN_URL, HttpMethod.POST, httpEntity, GithubTokenDto.class)
                 .getBody();
 
         if (response == null) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/domain/OAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/domain/OAuthClient.java
@@ -4,7 +4,7 @@ import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 
 public interface OAuthClient {
 
-    String getAccessToken(String code);
+    String getAccessToken(String authorizationCode);
 
     GithubProfileDto getProfile(String accessToken);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubAccessTokenDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubAccessTokenDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class GithubAccessTokenRequest {
+public class GithubAccessTokenDto {
 
     @JsonProperty("client_id")
     private String clientId;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubAccessTokenDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubAccessTokenDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.authentication.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class GithubAccessTokenDto {
 
     @JsonProperty("client_id")

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubCodeDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubCodeDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.authentication.dto;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class GithubCodeDto {
 
     @NotBlank

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubCodeDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubCodeDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class GithubCodeRequest {
+public class GithubCodeDto {
 
     @NotBlank
     private String authorizationCode;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubProfileDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubProfileDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.authentication.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class GithubProfileDto {
 
     @JsonProperty("id")

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubTokenDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/GithubTokenDto.java
@@ -7,11 +7,15 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * Github OAuth로부터 access token을 받기 위한 dto
+ * 더 적절한 이름있으면 고쳐주세요.
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class TokenDto {
+public class GithubTokenDto {
 
     @JsonProperty("access_token")
     private String accessToken;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
@@ -2,12 +2,14 @@ package com.woowacourse.levellog.authentication.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class LoginDto {
 
     private Long id;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
@@ -1,6 +1,5 @@
 package com.woowacourse.levellog.authentication.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,13 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class GithubAccessTokenResponse {
+public class LoginDto {
 
-    @JsonProperty("access_token")
+    private Long id;
     private String accessToken;
-
-    private String scope;
-
-    @JsonProperty("token_type")
-    private String tokenType;
+    private String profileUrl;
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/TokenDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/TokenDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.authentication.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class TokenDto {
 
     @JsonProperty("access_token")

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/TokenDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/TokenDto.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.authentication.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,9 +9,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class LoginResponse {
+public class TokenDto {
 
-    private Long id;
+    @JsonProperty("access_token")
     private String accessToken;
-    private String profileUrl;
+
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidTokenException.java
@@ -8,13 +8,9 @@ import org.springframework.http.HttpStatus;
  */
 public class InvalidTokenException extends LevellogException {
 
-    private static final String ERROR_MESSAGE = "유효하지 않은 토큰입니다.";
-
-    public InvalidTokenException() {
-        super(ERROR_MESSAGE, HttpStatus.BAD_REQUEST);
-    }
+    private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
 
     public InvalidTokenException(final String message) {
-        super(message, HttpStatus.BAD_REQUEST);
+        super(message, HttpStatus.BAD_REQUEST, CLIENT_MESSAGE);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/exception/InvalidTokenException.java
@@ -11,6 +11,6 @@ public class InvalidTokenException extends LevellogException {
     private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
 
     public InvalidTokenException(final String message) {
-        super(message, HttpStatus.BAD_REQUEST, CLIENT_MESSAGE);
+        super(message, CLIENT_MESSAGE, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
@@ -3,7 +3,7 @@ package com.woowacourse.levellog.authentication.presentation;
 import com.woowacourse.levellog.authentication.application.OAuthService;
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.LoginDto;
-import com.woowacourse.levellog.authentication.support.NoAuthentication;
+import com.woowacourse.levellog.authentication.support.PublicAPI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-@NoAuthentication
+@PublicAPI
 public class OAuthController {
 
     private final OAuthService oAuthService;

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
@@ -1,8 +1,8 @@
 package com.woowacourse.levellog.authentication.presentation;
 
 import com.woowacourse.levellog.authentication.application.OAuthService;
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
-import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
+import com.woowacourse.levellog.authentication.dto.LoginDto;
 import com.woowacourse.levellog.authentication.support.NoAuthentication;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class OAuthController {
 
     @CrossOrigin
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody @Valid final GithubCodeRequest request) {
+    public ResponseEntity<LoginDto> login(@RequestBody @Valid final GithubCodeDto request) {
         return ResponseEntity.ok(oAuthService.login(request));
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/presentation/OAuthController.java
@@ -7,7 +7,6 @@ import com.woowacourse.levellog.authentication.support.PublicAPI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +20,6 @@ public class OAuthController {
 
     private final OAuthService oAuthService;
 
-    @CrossOrigin
     @PostMapping("/login")
     public ResponseEntity<LoginDto> login(@RequestBody @Valid final GithubCodeDto request) {
         return ResponseEntity.ok(oAuthService.login(request));

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/support/Authentic.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/support/Authentic.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LoginMember {
+public @interface Authentic {
 }

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/support/JwtTokenProvider.java
@@ -46,7 +46,7 @@ public class JwtTokenProvider {
                     .getBody()
                     .getSubject();
         } catch (final JwtException e) {
-            throw new InvalidTokenException();
+            throw new InvalidTokenException("token에서 payload 추출 실패 - token:" + token);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/support/PublicAPI.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/support/PublicAPI.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(value = RetentionPolicy.RUNTIME)
-public @interface NoAuthentication {
+public @interface PublicAPI {
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
@@ -8,9 +8,17 @@ import org.springframework.http.HttpStatus;
 public abstract class LevellogException extends RuntimeException {
 
     private final HttpStatus httpStatus;
+    private final String clientMessage;
 
     protected LevellogException(final String message, final HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
+        this.clientMessage = null;
+    }
+
+    protected LevellogException(final String message, final HttpStatus httpStatus, final String clientMessage) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.clientMessage = clientMessage;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
@@ -3,13 +3,16 @@ package com.woowacourse.levellog.common.exception;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-// TODO: 2022/07/26 clientMessage 필드 추가 & ControllerAdvice 수정
+// TODO: 2022/07/26 clientMessage 필드 추가 ControllerAdvice 수정
+// TODO: 2022/07/26 ControllerAdvice 수정
 @Getter
 public abstract class LevellogException extends RuntimeException {
 
     private final HttpStatus httpStatus;
     private final String clientMessage;
 
+    // TODO: 2022/07/28 삭제되어야함 
+    @Deprecated
     protected LevellogException(final String message, final HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;

--- a/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/exception/LevellogException.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public abstract class LevellogException extends RuntimeException {
 
-    private final HttpStatus httpStatus;
     private final String clientMessage;
+    private final HttpStatus httpStatus;
 
-    // TODO: 2022/07/28 삭제되어야함 
+    // TODO: 2022/07/28 삭제되어야함
     @Deprecated
     protected LevellogException(final String message, final HttpStatus httpStatus) {
         super(message);
@@ -19,9 +19,9 @@ public abstract class LevellogException extends RuntimeException {
         this.clientMessage = null;
     }
 
-    protected LevellogException(final String message, final HttpStatus httpStatus, final String clientMessage) {
+    protected LevellogException(final String message, final String clientMessage, final HttpStatus httpStatus) {
         super(message);
-        this.httpStatus = httpStatus;
         this.clientMessage = clientMessage;
+        this.httpStatus = httpStatus;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
@@ -18,7 +18,7 @@ public class ControllerAdvice {
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
         log.info("[{}]{} : {}", getCorrelationId(), e.getClass().getSimpleName(), e.getMessage());
-        return toResponseEntity(e.getMessage(), e.getHttpStatus());
+        return toResponseEntity(e.getClientMessage(), e.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.feedback.presentation;
 
-import com.woowacourse.levellog.authentication.support.LoginMember;
+import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.feedback.application.FeedbackService;
 import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
 import com.woowacourse.levellog.feedback.dto.FeedbacksResponse;
@@ -27,14 +27,14 @@ public class FeedbackController {
     @PostMapping
     public ResponseEntity<Void> save(@PathVariable final Long levellogId,
                                      @RequestBody @Valid final FeedbackRequest request,
-                                     @LoginMember final Long memberId) {
+                                     @Authentic final Long memberId) {
         final Long id = feedbackService.save(levellogId, memberId, request);
         return ResponseEntity.created(URI.create("/api/levellogs/" + levellogId + "/feedbacks/" + id)).build();
     }
 
     @GetMapping
     public ResponseEntity<FeedbacksResponse> findAll(@PathVariable final Long levellogId,
-                                                     @LoginMember final Long memberId) {
+                                                     @Authentic final Long memberId) {
         final FeedbacksResponse response = feedbackService.findAll(levellogId);
         return ResponseEntity.ok(response);
     }
@@ -50,7 +50,7 @@ public class FeedbackController {
     @DeleteMapping("/{feedbackId}")
     public ResponseEntity<Void> delete(@PathVariable final Long levellogId,
                                        @PathVariable final Long feedbackId,
-                                       @LoginMember final Long memberId) {
+                                       @Authentic final Long memberId) {
         feedbackService.deleteById(feedbackId, memberId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
@@ -1,7 +1,7 @@
 package com.woowacourse.levellog.levellog.presentation;
 
 import com.woowacourse.levellog.authentication.support.Authentic;
-import com.woowacourse.levellog.authentication.support.NoAuthentication;
+import com.woowacourse.levellog.authentication.support.PublicAPI;
 import com.woowacourse.levellog.levellog.application.LevellogService;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.levellog.dto.LevellogResponse;
@@ -34,7 +34,7 @@ public class LevellogController {
     }
 
     @GetMapping("/{levellogId}")
-    @NoAuthentication
+    @PublicAPI
     public ResponseEntity<LevellogResponse> find(@PathVariable final Long teamId,
                                                  @PathVariable final Long levellogId) {
         final LevellogResponse response = levellogService.findById(levellogId);

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.levellog.presentation;
 
-import com.woowacourse.levellog.authentication.support.LoginMember;
+import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.NoAuthentication;
 import com.woowacourse.levellog.levellog.application.LevellogService;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
@@ -28,7 +28,7 @@ public class LevellogController {
     @PostMapping
     public ResponseEntity<Void> save(@PathVariable final Long teamId,
                                      @RequestBody @Valid final LevellogRequest request,
-                                     @LoginMember final Long authorId) {
+                                     @Authentic final Long authorId) {
         final Long id = levellogService.save(authorId, teamId, request);
         return ResponseEntity.created(URI.create("/api/teams/" + teamId + "/levellogs/" + id)).build();
     }
@@ -44,7 +44,7 @@ public class LevellogController {
     @PutMapping("/{levellogId}")
     public ResponseEntity<Void> update(@PathVariable final Long teamId,
                                        @PathVariable final Long levellogId,
-                                       @LoginMember final Long memberId,
+                                       @Authentic final Long memberId,
                                        @RequestBody @Valid final LevellogRequest request
     ) {
         levellogService.update(levellogId, memberId, request);
@@ -54,7 +54,7 @@ public class LevellogController {
     @DeleteMapping("/{levellogId}")
     public ResponseEntity<Void> delete(@PathVariable final Long teamId,
                                        @PathVariable final Long levellogId,
-                                       @LoginMember final Long memberId) {
+                                       @Authentic final Long memberId) {
         levellogService.deleteById(levellogId, memberId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.member.presentation;
 
-import com.woowacourse.levellog.authentication.support.LoginMember;
+import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.feedback.application.FeedbackService;
 import com.woowacourse.levellog.feedback.dto.FeedbacksResponse;
 import com.woowacourse.levellog.member.application.MemberService;
@@ -24,19 +24,19 @@ public class MyInfoController {
     private final MemberService memberService;
 
     @GetMapping("/feedbacks")
-    public ResponseEntity<FeedbacksResponse> findAllFeedbackToMe(@LoginMember final Long memberId) {
+    public ResponseEntity<FeedbacksResponse> findAllFeedbackToMe(@Authentic final Long memberId) {
         final FeedbacksResponse feedbacksResponse = feedbackService.findAllByTo(memberId);
         return ResponseEntity.ok(feedbacksResponse);
     }
 
     @GetMapping
-    public ResponseEntity<MemberDto> myInfo(@LoginMember final Long memberId) {
+    public ResponseEntity<MemberDto> myInfo(@Authentic final Long memberId) {
         final MemberDto memberDto = memberService.findMemberById(memberId);
         return ResponseEntity.ok(memberDto);
     }
 
     @PutMapping
-    public ResponseEntity<Void> updateNickname(@LoginMember final Long memberId,
+    public ResponseEntity<Void> updateNickname(@Authentic final Long memberId,
                                                @RequestBody @Valid final NicknameUpdateDto nicknameUpdateDto) {
         memberService.updateNickname(memberId, nicknameUpdateDto);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.team.presentation;
 
-import com.woowacourse.levellog.authentication.support.LoginMember;
+import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.NoAuthentication;
 import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.dto.TeamRequest;
@@ -29,7 +29,7 @@ public class TeamController {
 
     @PostMapping
     public ResponseEntity<Void> save(@RequestBody @Valid final TeamRequest teamRequest,
-                                     @LoginMember final Long hostId) {
+                                     @Authentic final Long hostId) {
         final Long id = teamService.save(hostId, teamRequest);
         return ResponseEntity.created(URI.create("/api/teams/" + id)).build();
     }
@@ -51,13 +51,13 @@ public class TeamController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> update(@PathVariable final Long id,
                                        @RequestBody @Valid final TeamUpdateRequest request,
-                                       @LoginMember final Long memberId) {
+                                       @Authentic final Long memberId) {
         teamService.update(id, request, memberId);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable final Long id, @LoginMember final Long memberId) {
+    public ResponseEntity<Void> delete(@PathVariable final Long id, @Authentic final Long memberId) {
         teamService.deleteById(id, memberId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -1,7 +1,7 @@
 package com.woowacourse.levellog.team.presentation;
 
 import com.woowacourse.levellog.authentication.support.Authentic;
-import com.woowacourse.levellog.authentication.support.NoAuthentication;
+import com.woowacourse.levellog.authentication.support.PublicAPI;
 import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.dto.TeamRequest;
 import com.woowacourse.levellog.team.dto.TeamResponse;
@@ -35,14 +35,14 @@ public class TeamController {
     }
 
     @GetMapping
-    @NoAuthentication
+    @PublicAPI
     public ResponseEntity<TeamsResponse> findAll() {
         final TeamsResponse response = teamService.findAll();
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{id}")
-    @NoAuthentication
+    @PublicAPI
     public ResponseEntity<TeamResponse> findById(@PathVariable final Long id) {
         final TeamResponse response = teamService.findById(id);
         return ResponseEntity.ok(response);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -10,7 +10,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.config.TestAuthenticationConfig;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
@@ -119,7 +119,7 @@ abstract class AcceptanceTest {
                     ((int) System.currentTimeMillis())), nickname,
                     nickname + ".com");
             final String code = objectMapper.writeValueAsString(response);
-            return post("/api/auth/login", new GithubCodeRequest(code));
+            return post("/api/auth/login", new GithubCodeDto(code));
         } catch (final JsonProcessingException e) {
             e.printStackTrace();
         }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -33,10 +33,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Import(TestAuthenticationConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 @ActiveProfiles("test")
@@ -48,7 +49,7 @@ abstract class AcceptanceTest {
     protected RequestSpecification specification;
     private Long masterId;
     @Autowired
-    private ObjectMapper objectMapper;
+    protected ObjectMapper objectMapper;
 
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -43,13 +43,19 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 abstract class AcceptanceTest {
 
+    @Deprecated
     protected static final String MASTER = "토미";
 
+    @Deprecated
     protected String masterToken;
+
     protected RequestSpecification specification;
-    private Long masterId;
+
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @Deprecated
+    private Long masterId;
 
     @LocalServerPort
     private int port;
@@ -91,6 +97,7 @@ abstract class AcceptanceTest {
                 .getMemberId();
     }
 
+    @Deprecated
     protected RestAssuredResponse requestCreateTeam(final String title, final String host,
                                                     final String... participants) {
         final List<Long> participantIds = Arrays.stream(participants)
@@ -106,6 +113,7 @@ abstract class AcceptanceTest {
         return post("/api/teams", token, request);
     }
 
+    @Deprecated
     protected RestAssuredResponse requestCreateTeam(final String title, final String token,
                                                     final Long... participantIds) {
         final ParticipantIdsRequest participantIdsRequest = new ParticipantIdsRequest(List.of(participantIds));
@@ -114,6 +122,7 @@ abstract class AcceptanceTest {
         return post("/api/teams", token, request);
     }
 
+    @Deprecated
     protected RestAssuredResponse login(final String nickname) {
         try {
             final GithubProfileDto response = new GithubProfileDto(String.valueOf(
@@ -127,6 +136,7 @@ abstract class AcceptanceTest {
         return null;
     }
 
+    @Deprecated
     protected RestAssuredResponse requestCreateLevellog(final String teamId, final String content) {
         final LevellogRequest request = new LevellogRequest(content);
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -115,6 +116,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
      *   when: 레벨로그를 삭제한다.
      *   then: 204 No Content 상태 코드를 응답 받는다.
      */
+    @Disabled // TODO: 2022/07/26 Delete before merge
     @Test
     @DisplayName("레벨로그 삭제")
     void deleteLevellog() {

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
@@ -4,22 +4,17 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("깃허브 로그인 관련 기능")
 class OAuthAcceptanceTest extends AcceptanceTest {
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     /*
      * Scenario: 깃허브 로그인
@@ -49,5 +44,4 @@ class OAuthAcceptanceTest extends AcceptanceTest {
                 .body("profileUrl", is("profile_url"))
                 .body("id", notNullValue());
     }
-
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
@@ -32,11 +32,11 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     void login() throws Exception {
         // given
         final String code = objectMapper.writeValueAsString(new GithubProfileDto("11111", "test", "profile_url"));
-        final GithubCodeRequest codeRequest = new GithubCodeRequest(code);
+        final GithubCodeDto request = new GithubCodeDto(code);
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
-                .body(codeRequest)
+                .body(request)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("auth/login"))
                 .when()

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.levellog.feedback.application.FeedbackService;
 import com.woowacourse.levellog.feedback.domain.Feedback;
-import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
 import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
 import com.woowacourse.levellog.feedback.dto.FeedbackResponse;
@@ -14,49 +12,20 @@ import com.woowacourse.levellog.feedback.dto.FeedbacksResponse;
 import com.woowacourse.levellog.feedback.exception.FeedbackAlreadyExistException;
 import com.woowacourse.levellog.feedback.exception.InvalidFeedbackException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.member.dto.MemberDto;
 import com.woowacourse.levellog.team.domain.Participant;
-import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
 @DisplayName("FeedbackService의")
-class FeedbackServiceTest {
-
-    @Autowired
-    private FeedbackService feedbackService;
-
-    @Autowired
-    private FeedbackRepository feedbackRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private LevellogRepository levellogRepository;
-
-    @Autowired
-    private TeamRepository teamRepository;
-
-    @Autowired
-    private ParticipantRepository participantRepository;
+class FeedbackServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("findAll 메서드는 모든 피드백을 조회한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -3,45 +3,21 @@ package com.woowacourse.levellog.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.woowacourse.levellog.levellog.application.LevellogService;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.levellog.dto.LevellogResponse;
 import com.woowacourse.levellog.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.levellog.exception.UnauthorizedException;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
 @DisplayName("LevellogService의")
-class LevellogServiceTest {
-
-    @Autowired
-    private LevellogService levellogService;
-
-    @Autowired
-    private LevellogRepository levellogRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private TeamRepository teamRepository;
+class LevellogServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("findById 메서드는 id에 해당하는 레벨로그를 조회한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -3,29 +3,16 @@ package com.woowacourse.levellog.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.levellog.member.application.MemberService;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.member.dto.MemberCreateDto;
 import com.woowacourse.levellog.member.dto.MemberDto;
 import com.woowacourse.levellog.member.dto.MembersDto;
 import com.woowacourse.levellog.member.dto.NicknameUpdateDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
 @DisplayName("MemberService의")
-class MemberServiceTest {
-
-    @Autowired
-    private MemberService memberService;
-
-    @Autowired
-    private MemberRepository memberRepository;
+class MemberServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("save 메서드는 새로운 멤버를 저장한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -5,9 +5,9 @@ import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.levellog.authentication.application.OAuthService;
 import com.woowacourse.levellog.authentication.domain.OAuthClient;
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
-import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import com.woowacourse.levellog.authentication.dto.LoginDto;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
 import com.woowacourse.levellog.member.application.MemberService;
 import com.woowacourse.levellog.member.dto.MemberCreateDto;
@@ -49,7 +49,7 @@ class OAuthServiceTest {
                     new GithubProfileDto("12345", "로마", "imageUrl"));
 
             // when
-            final LoginResponse tokenResponse = oAuthService.login(new GithubCodeRequest("githubCode"));
+            final LoginDto tokenResponse = oAuthService.login(new GithubCodeDto("githubCode"));
             final String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
             final Long savedMemberId = memberService.findMemberById(Long.parseLong(payload))
                     .getId();
@@ -71,7 +71,7 @@ class OAuthServiceTest {
                     new GithubProfileDto("12345", "로마", "imageUrl"));
 
             // when
-            final LoginResponse tokenResponse = oAuthService.login(new GithubCodeRequest("githubCode"));
+            final LoginDto tokenResponse = oAuthService.login(new GithubCodeDto("githubCode"));
             final String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
 
             // then

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -3,38 +3,16 @@ package com.woowacourse.levellog.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-import com.woowacourse.levellog.authentication.application.OAuthService;
-import com.woowacourse.levellog.authentication.domain.OAuthClient;
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.authentication.dto.LoginDto;
-import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
-import com.woowacourse.levellog.member.application.MemberService;
 import com.woowacourse.levellog.member.dto.MemberCreateDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
 @DisplayName("OAuthService의")
-class OAuthServiceTest {
-
-    @MockBean
-    private OAuthClient oAuthClient;
-
-    @Autowired
-    private MemberService memberService;
-
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Autowired
-    private OAuthService oAuthService;
+class OAuthServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("login 메서드는")

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -20,10 +20,13 @@ class OAuthServiceTest extends ServiceTest {
         @Test
         @DisplayName("첫 로그인 시 회원가입하고 id, 토큰, 이미지 URL를 반환한다.")
         void login_first_signUp() throws Exception {
-            // when
+            // given
             final GithubProfileDto request = new GithubProfileDto("1234", "릭", "rick.org");
+
+            // when
             final LoginDto tokenResponse = oAuthService.login(
                     new GithubCodeDto(objectMapper.writeValueAsString(request)));
+
             final String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
             final Long savedMemberId = memberService.findMemberById(Long.parseLong(payload))
                     .getId();

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.levellog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
@@ -20,36 +19,32 @@ class OAuthServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("첫 로그인 시 회원가입하고 id, 토큰, 이미지 URL를 반환한다.")
-        void loginFirst() {
-            // given
-            given(oAuthClient.getAccessToken("githubCode")).willReturn("accessToken");
-            given(oAuthClient.getProfile("accessToken")).willReturn(
-                    new GithubProfileDto("12345", "로마", "imageUrl"));
-
+        void login_first_signUp() throws Exception {
             // when
-            final LoginDto tokenResponse = oAuthService.login(new GithubCodeDto("githubCode"));
+            final GithubProfileDto request = new GithubProfileDto("1234", "릭", "rick.org");
+            final LoginDto tokenResponse = oAuthService.login(
+                    new GithubCodeDto(objectMapper.writeValueAsString(request)));
             final String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
             final Long savedMemberId = memberService.findMemberById(Long.parseLong(payload))
                     .getId();
 
             // then
             assertThat(Long.parseLong(payload)).isEqualTo(savedMemberId);
-            assertThat(tokenResponse.getProfileUrl()).isEqualTo("imageUrl");
+            assertThat(tokenResponse.getProfileUrl()).isEqualTo("rick.org");
             assertThat(tokenResponse.getId()).isNotNull();
         }
 
         @Test
         @DisplayName("첫 로그인이 아닌 경우 회원가입 하지 않고 토큰과 이미지 URL를 반환한다.")
-        void loginNotFirst() {
+        void login_notFirst_signIn() throws Exception {
             // given
             final Long savedId = memberService.save(new MemberCreateDto("로마", 12345, "imageUrl"));
 
-            given(oAuthClient.getAccessToken("githubCode")).willReturn("accessToken");
-            given(oAuthClient.getProfile("accessToken")).willReturn(
-                    new GithubProfileDto("12345", "로마", "imageUrl"));
+            final GithubProfileDto request = new GithubProfileDto("12345", "로마", "imageUrl");
 
             // when
-            final LoginDto tokenResponse = oAuthService.login(new GithubCodeDto("githubCode"));
+            final LoginDto tokenResponse = oAuthService.login(
+                    new GithubCodeDto(objectMapper.writeValueAsString(request)));
             final String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
 
             // then

--- a/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
@@ -1,8 +1,9 @@
 package com.woowacourse.levellog.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.application.OAuthService;
-import com.woowacourse.levellog.authentication.domain.OAuthClient;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
+import com.woowacourse.levellog.config.TestAuthenticationConfig;
 import com.woowacourse.levellog.feedback.application.FeedbackService;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
 import com.woowacourse.levellog.levellog.application.LevellogService;
@@ -14,17 +15,18 @@ import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.TeamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@Import(TestAuthenticationConfig.class)
 abstract class ServiceTest {
 
-    @MockBean
-    protected OAuthClient oAuthClient;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     @Autowired
     protected JwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
@@ -1,0 +1,61 @@
+package com.woowacourse.levellog.application;
+
+import com.woowacourse.levellog.authentication.application.OAuthService;
+import com.woowacourse.levellog.authentication.domain.OAuthClient;
+import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
+import com.woowacourse.levellog.feedback.application.FeedbackService;
+import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
+import com.woowacourse.levellog.levellog.application.LevellogService;
+import com.woowacourse.levellog.levellog.domain.LevellogRepository;
+import com.woowacourse.levellog.member.application.MemberService;
+import com.woowacourse.levellog.member.domain.MemberRepository;
+import com.woowacourse.levellog.team.application.TeamService;
+import com.woowacourse.levellog.team.domain.ParticipantRepository;
+import com.woowacourse.levellog.team.domain.TeamRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+abstract class ServiceTest {
+
+    @MockBean
+    protected OAuthClient oAuthClient;
+
+    @Autowired
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected MemberService memberService;
+
+    @Autowired
+    protected OAuthService oAuthService;
+
+    @Autowired
+    protected LevellogService levellogService;
+
+    @Autowired
+    protected FeedbackService feedbackService;
+
+    @Autowired
+    protected TeamService teamService;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected LevellogRepository levellogRepository;
+
+    @Autowired
+    protected TeamRepository teamRepository;
+
+    @Autowired
+    protected FeedbackRepository feedbackRepository;
+
+    @Autowired
+    protected ParticipantRepository participantRepository;
+}

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -6,12 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
-import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.domain.Participant;
-import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import com.woowacourse.levellog.team.dto.ParticipantIdsRequest;
 import com.woowacourse.levellog.team.dto.TeamRequest;
 import com.woowacourse.levellog.team.dto.TeamResponse;
@@ -22,31 +18,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
 @DisplayName("TeamService의")
-class TeamServiceTest {
-
-    @Autowired
-    private TeamService teamService;
-
-    @Autowired
-    private TeamRepository teamRepository;
-
-    @Autowired
-    private ParticipantRepository participantRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
+class TeamServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("save 메서드는 팀을 생성한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/config/FakeGithubOAuthClient.java
+++ b/backend/src/test/java/com/woowacourse/levellog/config/FakeGithubOAuthClient.java
@@ -14,9 +14,9 @@ public class FakeGithubOAuthClient implements OAuthClient {
     }
 
     @Override
-    public String getAccessToken(final String code) {
-        if (!code.isBlank()) {
-            return code;
+    public String getAccessToken(final String authorizationCode) {
+        if (!authorizationCode.isBlank()) {
+            return authorizationCode;
         }
         throw new IllegalStateException("[TEST] code가 비어있습니다.");
     }

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredResponse.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/RestAssuredResponse.java
@@ -1,6 +1,6 @@
 package com.woowacourse.levellog.fixture;
 
-import com.woowacourse.levellog.authentication.dto.LoginResponse;
+import com.woowacourse.levellog.authentication.dto.LoginDto;
 import io.restassured.response.ValidatableResponse;
 import org.springframework.http.HttpHeaders;
 
@@ -29,14 +29,14 @@ public class RestAssuredResponse {
     public Long getMemberId() {
         return response
                 .extract()
-                .as(LoginResponse.class)
+                .as(LoginDto.class)
                 .getId();
     }
 
     public String getToken() {
         return response
                 .extract()
-                .as(LoginResponse.class)
+                .as(LoginDto.class)
                 .getAccessToken();
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
@@ -62,7 +62,7 @@ public abstract class ControllerTest {
     protected ObjectMapper objectMapper;
 
     @MockBean
-    private OAuthService oAuthService;
+    protected OAuthService oAuthService;
 
     @BeforeEach
     void setUp(final WebApplicationContext context, final RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
@@ -53,6 +53,9 @@ public abstract class ControllerTest {
     protected TeamService teamService;
 
     @MockBean
+    protected OAuthService oAuthService;
+
+    @MockBean
     protected JwtTokenProvider jwtTokenProvider;
 
     @Autowired
@@ -60,9 +63,6 @@ public abstract class ControllerTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
-
-    @MockBean
-    protected OAuthService oAuthService;
 
     @BeforeEach
     void setUp(final WebApplicationContext context, final RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest({
         FeedbackController.class,
@@ -87,7 +86,6 @@ public abstract class ControllerTest {
                                         "Connection"),
                                 prettyPrint()
                         )
-                ).addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
-                .build();
+                ).build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -23,7 +23,7 @@ class OAuthControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("login 메서드는")
-    class login {
+    class Login {
 
         @ParameterizedTest
         @ValueSource(strings = {" "})

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.presentation;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,6 +32,7 @@ class OAuthControllerTest extends ControllerTest {
                 .andDo(print());
 
         // then
-        perform.andExpect(status().isBadRequest());
+        perform.andExpect(status().isBadRequest())
+                .andDo(document("auth/login/null"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -4,7 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.levellog.authentication.dto.GithubCodeRequest;
+import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -21,7 +21,7 @@ class OAuthControllerTest extends ControllerTest {
     @DisplayName("login 메서드는 코드에 공백이나 null이 들어오면 예외를 던진다.")
     void login(final String code) throws Exception {
         // given
-        final GithubCodeRequest request = new GithubCodeRequest(code);
+        final GithubCodeDto request = new GithubCodeDto(code);
         final String requestContent = objectMapper.writeValueAsString(request);
 
         // when

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.presentation;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -7,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -16,23 +19,51 @@ import org.springframework.test.web.servlet.ResultActions;
 @DisplayName("OAuthController의")
 class OAuthControllerTest extends ControllerTest {
 
-    @ParameterizedTest
-    @ValueSource(strings = {" "})
-    @NullAndEmptySource
-    @DisplayName("login 메서드는 코드에 공백이나 null이 들어오면 예외를 던진다.")
-    void login(final String code) throws Exception {
-        // given
-        final GithubCodeDto request = new GithubCodeDto(code);
-        final String requestContent = objectMapper.writeValueAsString(request);
+    private static final String AUTHORIZATION_CODE = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODk3MjQ0LCJleHAiOjE2NTg5MzMyNDR9";
 
-        // when
-        final ResultActions perform = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestContent))
-                .andDo(print());
+    @Nested
+    @DisplayName("login 메서드는")
+    class login {
 
-        // then
-        perform.andExpect(status().isBadRequest())
-                .andDo(document("auth/login/null"));
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        @NullAndEmptySource
+        @DisplayName("코드에 공백이나 null이 들어오면 예외를 던진다.")
+        void login_nullAndEmptyCode_exceptionThrown(final String code) throws Exception {
+            // given
+            final GithubCodeDto request = new GithubCodeDto(code);
+            final String requestContent = objectMapper.writeValueAsString(request);
+
+            // when
+            final ResultActions perform = mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestContent))
+                    .andDo(print());
+
+            // then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(document("auth/login/null"));
+        }
+
+        @Test
+        @DisplayName("깃허브에 accessToken 요청에 실패하면 예외를 던진다.")
+        void login_failToGetAccessToken_exceptionThrown() throws Exception {
+            // given
+            final GithubCodeDto request = new GithubCodeDto(AUTHORIZATION_CODE);
+            final String requestContent = objectMapper.writeValueAsString(request);
+
+            given(oAuthService.login(request))
+                    .willThrow(new IllegalStateException("Github 로그인 요청 실패 - authorizationCode:" + AUTHORIZATION_CODE));
+
+            // when
+            final ResultActions perform = mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestContent))
+                    .andDo(print());
+
+            // then
+            perform.andExpect(status().isInternalServerError())
+                    .andDo(document("auth/login/github-fail"));
+        }
     }
 }


### PR DESCRIPTION
## 구현 기능
- [x] DTO 클래스명 변경
- [x] 서비스에서 `@Transactional` 추가하기
- [x] 커스텀 예외에 대한 구체 메세지 작성
  - [x] 예외 로그에 많은 정보를 담되, 간단한 메세지로 표현
- [x] 인수테스트 예외케이스 추가
- [x] 서비스테스트 보강

## 논의하고 싶은 내용
- `@LoginMember` -> `@Authentic` & `@NoAuthentication` -> `@PublicAPI`
  - 어노테이션 이름 변경했는데 관련한 의견 or 더 좋은 이름 추천받아용


Close #132 
