### PR TITLE
refactor: Member 도메인 리팩토링 

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -11,3 +11,4 @@
 * link:team.html[Team]
 * link:auth.html[Auth]
 * link:myinfo.html[MyInfo]
+* link:member.html[Member]

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -1,0 +1,19 @@
+= MyInfo
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+
+* link:index.html[목록으로 가기]
+
+[[search]]
+== 멤버 검색
+
+[[search-success]]
+=== 성공
+
+operation::member/search[]
+

--- a/backend/src/docs/asciidoc/myinfo.adoc
+++ b/backend/src/docs/asciidoc/myinfo.adoc
@@ -23,3 +23,11 @@ operation::myinfo/read[]
 === 성공
 
 operation::myinfo/update-nickname[]
+
+[[findAllToMe]]
+== 받은 피드백 전체 조회
+
+[[findAllToMe-success]]
+=== 성공
+
+operation::myinfo/findAllToMe[]

--- a/backend/src/docs/asciidoc/myinfo.adoc
+++ b/backend/src/docs/asciidoc/myinfo.adoc
@@ -24,6 +24,16 @@ operation::myinfo/read[]
 
 operation::myinfo/update-nickname[]
 
+[[update-nickname-fail]]
+=== 실패
+
+50자를 초과한 닉네임으로 요청 보낼 경우
+
+operation::myinfo/update-nickname-invalid-length[]
+
+빈 문자열 혹은 공백으로 요청 보낼 경우
+
+operation::myinfo/update-nickname-blank[]
 [[findAllToMe]]
 == 받은 피드백 전체 조회
 

--- a/backend/src/docs/asciidoc/myinfo.adoc
+++ b/backend/src/docs/asciidoc/myinfo.adoc
@@ -22,18 +22,18 @@ operation::myinfo/read[]
 [[update-nickname-success]]
 === 성공
 
-operation::myinfo/update-nickname[]
+operation::myinfo/update/nickname[]
 
 [[update-nickname-fail]]
 === 실패
 
 50자를 초과한 닉네임으로 요청 보낼 경우
 
-operation::myinfo/update-nickname-invalid-length[]
+operation::myinfo/update/nickname-invalid-length[]
 
 빈 문자열 혹은 공백으로 요청 보낼 경우
 
-operation::myinfo/update-nickname-blank[]
+operation::myinfo/update/nickname-blank[]
 [[findAllToMe]]
 == 받은 피드백 전체 조회
 

--- a/backend/src/main/java/com/woowacourse/levellog/common/exception/InvalidFieldException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/exception/InvalidFieldException.java
@@ -8,6 +8,6 @@ import org.springframework.http.HttpStatus;
 public class InvalidFieldException extends LevellogException {
 
     public InvalidFieldException(final String message) {
-        super(message, HttpStatus.BAD_REQUEST);
+        super(message, message, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -104,7 +104,7 @@ public class FeedbackService {
                 .orElseThrow(FeedbackNotFoundException::new);
 
         final Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [memberId : " + memberId + "]"));
         if (!feedback.isAssociatedWith(member)) {
             throw new InvalidFeedbackException("자신이 남기거나 받은 피드백만 삭제할 수 있습니다.");
         }
@@ -123,7 +123,8 @@ public class FeedbackService {
 
     private Member getMember(final Long memberId) {
         return memberRepository
-                .findById(memberId).orElseThrow(MemberNotFoundException::new);
+                .findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [memberId : " + memberId + "]"));
     }
 
     private Levellog getLevellog(final Long levellogId) {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -74,6 +74,7 @@ public class LevellogService {
 
     private Member getMember(final Long memberId) {
         return memberRepository
-                .findById(memberId).orElseThrow(MemberNotFoundException::new);
+                .findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [memberId : " + memberId + "]"));
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -56,15 +56,6 @@ public class MemberService {
         return MemberDto.from(member);
     }
 
-    public MembersDto findAll() {
-        final List<MemberDto> responses = memberRepository.findAll()
-                .stream()
-                .map(MemberDto::from)
-                .collect(Collectors.toList());
-
-        return new MembersDto(responses);
-    }
-
     public MembersDto searchByNickname(final String nickname) {
         final List<MemberDto> responses = memberRepository.findAllByNicknameContains(nickname)
                 .stream()

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     public Long save(final MemberCreateDto request) {
         checkSameGithubId(request);
 
-        final Member member = new Member(request.getNickname(), request.getGithubId(), request.getProfileUrl());
+        final Member member = request.toEntity();
         final Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateNickname(final Long memberId, final NicknameUpdateDto request) {
+    public void updateNickname(final NicknameUpdateDto request, final Long memberId) {
         final Member member = getById(memberId);
         member.updateNickname(request.getNickname());
     }

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -7,6 +7,7 @@ import com.woowacourse.levellog.member.dto.MemberCreateDto;
 import com.woowacourse.levellog.member.dto.MemberDto;
 import com.woowacourse.levellog.member.dto.MembersDto;
 import com.woowacourse.levellog.member.dto.NicknameUpdateDto;
+import com.woowacourse.levellog.member.exception.MemberAlreadyExistException;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,14 +24,24 @@ public class MemberService {
 
     @Transactional
     public Long save(final MemberCreateDto request) {
+        checkSameGithubId(request);
+
         final Member member = new Member(request.getNickname(), request.getGithubId(), request.getProfileUrl());
         final Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();
     }
 
+    private void checkSameGithubId(final MemberCreateDto request) {
+        final boolean isExistSameGithubId = memberRepository.existsByGithubId(request.getGithubId());
+        if (isExistSameGithubId) {
+            throw new MemberAlreadyExistException("멤버 중복 [githubId : " + request.getGithubId() + "]");
+        }
+    }
+
     @Transactional
     public Long saveIfNotExist(final GithubProfileDto request, final int githubId) {
+        // TODO githubId를 안받아도 될듯? GithubProfileDto에 이미 정보가 존재함. + save의 예외 발생을 이용하면 로직 간단해질듯
         final boolean isExist = memberRepository.existsByGithubId(githubId);
         if (isExist) {
             return getByGithubId(githubId).getId();

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -71,11 +71,11 @@ public class MemberService {
 
     private Member getById(final Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [memberId : " + memberId + "]"));
     }
 
     private Member getByGithubId(final int githubId) {
         return memberRepository.findByGithubId(githubId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [githubId : " + githubId + "]"));
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/application/MemberService.java
@@ -32,13 +32,6 @@ public class MemberService {
         return savedMember.getId();
     }
 
-    private void checkSameGithubId(final MemberCreateDto request) {
-        final boolean isExistSameGithubId = memberRepository.existsByGithubId(request.getGithubId());
-        if (isExistSameGithubId) {
-            throw new MemberAlreadyExistException("멤버 중복 [githubId : " + request.getGithubId() + "]");
-        }
-    }
-
     @Transactional
     public Long saveIfNotExist(final GithubProfileDto request, final int githubId) {
         // TODO githubId를 안받아도 될듯? GithubProfileDto에 이미 정보가 존재함. + save의 예외 발생을 이용하면 로직 간단해질듯
@@ -69,6 +62,13 @@ public class MemberService {
     public void updateNickname(final NicknameUpdateDto request, final Long memberId) {
         final Member member = getById(memberId);
         member.updateNickname(request.getNickname());
+    }
+
+    private void checkSameGithubId(final MemberCreateDto request) {
+        final boolean isExistSameGithubId = memberRepository.existsByGithubId(request.getGithubId());
+        if (isExistSameGithubId) {
+            throw new MemberAlreadyExistException("멤버 중복 [githubId : " + request.getGithubId() + "]");
+        }
     }
 
     private Member getById(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
@@ -7,18 +7,17 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
 public class Member extends BaseEntity {
 
-    public static final int NICKNAME_MAX_LENGTH = 50;
+    private static final int NICKNAME_MAX_LENGTH = 50;
+    private static final int PROFILE_URL_MAX_LENGTH = 2048;
 
     @Column(nullable = false, length = 50)
     private String nickname;
@@ -29,25 +28,52 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 2048)
     private String profileUrl;
 
-    public void updateNickname(final String nickname) {
-        validateNickname(nickname);
+    public Member(final String nickname, final Integer githubId, final String profileUrl) {
         this.nickname = nickname;
+        this.githubId = githubId;
+        this.profileUrl = profileUrl;
+
+        validateNickname(this.nickname);
+        validateGithubId(this.githubId);
+        validateProfileUrl(this.profileUrl);
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
+        validateNickname(this.nickname);
     }
 
     private void validateNickname(final String nickname) {
-        validateBlank(nickname);
-        validateNicknameLength(nickname);
+        checkBlank(nickname, "닉네임은 공백이나 null일 수 없습니다.");
+        checkLength(nickname, NICKNAME_MAX_LENGTH,
+                "닉네임은 " + NICKNAME_MAX_LENGTH + "자 이하여야합니다. [현재 길이:" + nickname.length() + "]");
     }
 
-    private void validateBlank(final String nickname) {
-        if (nickname == null || nickname.isBlank()) {
-            throw new InvalidFieldException("닉네임은 공백이나 null일 수 없습니다.");
+    private void validateGithubId(final Integer githubId) {
+        checkNull(githubId, "깃허브 ID는 null일 수 없습니다.");
+    }
+
+    private void validateProfileUrl(final String profileUrl) {
+        checkBlank(profileUrl, "프로필 url은 공백이나 null일 수 없습니다.");
+        checkLength(profileUrl, PROFILE_URL_MAX_LENGTH,
+                "프로필 url은 " + PROFILE_URL_MAX_LENGTH + "자 이하여야합니다. [현재 길이:" + profileUrl.length() + "]");
+    }
+
+    private void checkLength(final String target, final int length, final String message) {
+        if (target.length() > length) {
+            throw new InvalidFieldException(message);
         }
     }
 
-    private void validateNicknameLength(final String nickname) {
-        if (nickname.length() > NICKNAME_MAX_LENGTH) {
-            throw new InvalidFieldException("닉네임은 " + NICKNAME_MAX_LENGTH + "자 이하여야합니다.");
+    private void checkBlank(final String target, final String message) {
+        if (target == null || target.isBlank()) {
+            throw new InvalidFieldException(message);
+        }
+    }
+
+    private void checkNull(final Object target, final String message) {
+        if (target == null) {
+            throw new InvalidFieldException(message);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
@@ -19,28 +19,23 @@ public class Member extends BaseEntity {
     private static final int NICKNAME_MAX_LENGTH = 50;
     private static final int PROFILE_URL_MAX_LENGTH = 2048;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = NICKNAME_MAX_LENGTH)
     private String nickname;
 
     @Column(nullable = false)
     private Integer githubId;
 
-    @Column(nullable = false, length = 2048)
+    @Column(nullable = false, length = PROFILE_URL_MAX_LENGTH)
     private String profileUrl;
 
     public Member(final String nickname, final Integer githubId, final String profileUrl) {
+        validateNickname(nickname);
+        validateGithubId(githubId);
+        validateProfileUrl(profileUrl);
+
         this.nickname = nickname;
         this.githubId = githubId;
         this.profileUrl = profileUrl;
-
-        validateNickname(this.nickname);
-        validateGithubId(this.githubId);
-        validateProfileUrl(this.profileUrl);
-    }
-
-    public void updateNickname(final String nickname) {
-        this.nickname = nickname;
-        validateNickname(this.nickname);
     }
 
     private void validateNickname(final String nickname) {
@@ -75,5 +70,10 @@ public class Member extends BaseEntity {
         if (target == null) {
             throw new InvalidFieldException(message);
         }
+    }
+
+    public void updateNickname(final String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberCreateDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberCreateDto.java
@@ -2,12 +2,14 @@ package com.woowacourse.levellog.member.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class MemberCreateDto {
 
     private String nickname;

--- a/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberCreateDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberCreateDto.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.member.dto;
 
+import com.woowacourse.levellog.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -15,4 +16,8 @@ public class MemberCreateDto {
     private String nickname;
     private Integer githubId;
     private String profileUrl;
+
+    public Member toEntity() {
+        return new Member(nickname, githubId, profileUrl);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/dto/MemberDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.member.dto;
 import com.woowacourse.levellog.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
+@EqualsAndHashCode
 public class MemberDto {
 
     private Long id;

--- a/backend/src/main/java/com/woowacourse/levellog/member/dto/MembersDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/dto/MembersDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.member.dto;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
+@EqualsAndHashCode
 public class MembersDto {
 
     private List<MemberDto> members;

--- a/backend/src/main/java/com/woowacourse/levellog/member/dto/NicknameUpdateDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/dto/NicknameUpdateDto.java
@@ -3,12 +3,14 @@ package com.woowacourse.levellog.member.dto;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class NicknameUpdateDto {
 
     @NotBlank

--- a/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberAlreadyExistException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberAlreadyExistException.java
@@ -8,6 +8,6 @@ public class MemberAlreadyExistException extends LevellogException {
     private static final String ERROR_MESSAGE = "멤버가 이미 존재합니다.";
 
     public MemberAlreadyExistException(final String message) {
-        super(message, HttpStatus.BAD_REQUEST);
+        super(message, ERROR_MESSAGE, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberAlreadyExistException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberAlreadyExistException.java
@@ -1,0 +1,13 @@
+package com.woowacourse.levellog.member.exception;
+
+import com.woowacourse.levellog.common.exception.LevellogException;
+import org.springframework.http.HttpStatus;
+
+public class MemberAlreadyExistException extends LevellogException {
+
+    private static final String ERROR_MESSAGE = "멤버가 이미 존재합니다.";
+
+    public MemberAlreadyExistException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberNotFoundException.java
@@ -11,6 +11,6 @@ public class MemberNotFoundException extends LevellogException {
     private static final String ERROR_MESSAGE = "멤버가 존재하지 않습니다.";
 
     public MemberNotFoundException(final String message) {
-        super(message, HttpStatus.NOT_FOUND);
+        super(message, ERROR_MESSAGE, HttpStatus.NOT_FOUND);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/exception/MemberNotFoundException.java
@@ -13,8 +13,4 @@ public class MemberNotFoundException extends LevellogException {
     public MemberNotFoundException(final String message) {
         super(message, HttpStatus.NOT_FOUND);
     }
-
-    public MemberNotFoundException() {
-        super(ERROR_MESSAGE, HttpStatus.NOT_FOUND);
-    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/presentation/MemberController.java
@@ -17,13 +17,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<MembersDto> findAll() {
-        final MembersDto response = memberService.findAll();
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping(params = "nickname")
-    public ResponseEntity<MembersDto> searchBy(@RequestParam final String nickname) {
+    public ResponseEntity<MembersDto> searchBy(@RequestParam(defaultValue = "") final String nickname) {
         final MembersDto response = memberService.searchByNickname(nickname);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
@@ -38,7 +38,7 @@ public class MyInfoController {
     @PutMapping
     public ResponseEntity<Void> updateNickname(@Authentic final Long memberId,
                                                @RequestBody @Valid final NicknameUpdateDto nicknameUpdateDto) {
-        memberService.updateNickname(memberId, nicknameUpdateDto);
+        memberService.updateNickname(nicknameUpdateDto, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/presentation/MyInfoController.java
@@ -26,19 +26,22 @@ public class MyInfoController {
     @GetMapping("/feedbacks")
     public ResponseEntity<FeedbacksResponse> findAllFeedbackToMe(@Authentic final Long memberId) {
         final FeedbacksResponse feedbacksResponse = feedbackService.findAllByTo(memberId);
+
         return ResponseEntity.ok(feedbacksResponse);
     }
 
     @GetMapping
     public ResponseEntity<MemberDto> myInfo(@Authentic final Long memberId) {
         final MemberDto memberDto = memberService.findMemberById(memberId);
+
         return ResponseEntity.ok(memberDto);
     }
 
     @PutMapping
     public ResponseEntity<Void> updateNickname(@Authentic final Long memberId,
-                                               @RequestBody @Valid final NicknameUpdateDto nicknameUpdateDto) {
-        memberService.updateNickname(nicknameUpdateDto, memberId);
+                                               @RequestBody @Valid final NicknameUpdateDto request) {
+        memberService.updateNickname(request, memberId);
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -81,7 +81,7 @@ public class TeamService {
 
     private Member getMember(final Long hostId) {
         return memberRepository.findById(hostId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(() -> new MemberNotFoundException("멤버가 존재하지 않음 [memberId : " + hostId + "]"));
     }
 
     private Team getTeam(final Long id) {
@@ -127,7 +127,7 @@ public class TeamService {
         return participants.stream()
                 .filter(Participant::isHost)
                 .findAny()
-                .orElseThrow(MemberNotFoundException::new)
+                .orElseThrow(() -> new MemberNotFoundException("호스트 존재 안함"))
                 .getMember()
                 .getId();
     }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,45 @@
+package com.woowacourse.levellog.acceptance;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("멤버 관련 기능")
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    /*
+     * Scenario: 멤버 검색
+     *   given: 가입된 회원들이 있다.
+     *   when: 특정 닉네임 키워드로 멤버 검색 요청을 보낸다.
+     *   then: 특정 닉네임 키워드가 포함된 멤버의 정보와 200 OK 상태코드를 응답받는다.
+     */
+    @Test
+    @DisplayName("멤버 검색")
+    void searchByNickname() {
+        // given
+        final String eveToken = login("eve1").getToken();
+        login("eve2");
+        login("eve3");
+        login("levellog");
+        login("알린");
+        login("알린2");
+
+        // when
+        final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + eveToken)
+                .filter(document("member/search"))
+                .when()
+                .get("/api/members?nickname=" + "eve")
+                .then().log().all();
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("members.nickname", containsInAnyOrder("eve1", "eve2", "eve3", "levellog"));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -60,8 +60,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
     @DisplayName("내 닉네임 변경")
     void updateMyNickname() {
         // given
-        final String token = login("로마")
-                .getToken();
+        final String token = login("로마").getToken();
 
         final NicknameUpdateDto nicknameDto = new NicknameUpdateDto("새이름");
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -1,8 +1,14 @@
 package com.woowacourse.levellog.acceptance;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
+import com.woowacourse.levellog.feedback.dto.FeedbackRequest;
+import com.woowacourse.levellog.fixture.RestAssuredResponse;
+import com.woowacourse.levellog.fixture.RestAssuredTemplate;
+import com.woowacourse.levellog.levellog.dto.LevellogRequest;
 import com.woowacourse.levellog.member.dto.NicknameUpdateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
@@ -51,7 +57,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
      *   then: 닉네임이 변경되고 204 No Content 상태 코드를 응답받는다.
      */
     @Test
-    @DisplayName("내 닉네임 변경하기")
+    @DisplayName("내 닉네임 변경")
     void updateMyNickname() {
         // given
         final String token = login("로마")
@@ -71,5 +77,67 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    /*
+     * Scenario: 내가 받은 피드백 조회하기
+     *   given: 두 팀에 속해있고 각 팀에서 하나의 피드백을 받았다.
+     *   when: 내가 받은 피드백 조회를 요청한다.
+     *   then: 내가 받은 피드백 (2개) 과 200 OK 상태코드를 응답받는다.
+     */
+    @Test
+    @DisplayName("내가 받은 피드백 조회")
+    void findAllFeedbackToMe() {
+        // given
+        // 회원 로그인
+        final RestAssuredResponse hostLoginResponse = login("릭");
+        final Long rick_id = hostLoginResponse.getMemberId();
+        final String rickToken = hostLoginResponse.getToken();
+
+        final RestAssuredResponse romaLoginResponse = login("로마");
+        final Long roma_id = romaLoginResponse.getMemberId();
+        final String romaToken = romaLoginResponse.getToken();
+
+        final RestAssuredResponse pepperLoginResponse = login("페퍼");
+        final Long pepper_id = pepperLoginResponse.getMemberId();
+        final String pepperToken = pepperLoginResponse.getToken();
+
+        // 팀 생성
+        final String team1Id = requestCreateTeam("릭,로마", rickToken, rick_id, roma_id).getTeamId();
+        final String team2Id = requestCreateTeam("릭,로마,페퍼", romaToken, rick_id, roma_id, pepper_id).getTeamId();
+
+        // 레벨로그 생성
+        final LevellogRequest levellogRequest = new LevellogRequest("레벨로그1,2 내용");
+        final String levellogId1 = RestAssuredTemplate.post("/api/teams/" + team1Id + "/levellogs", rickToken,
+                        levellogRequest)
+                .getLevellogId();
+        final String levellogId2 = RestAssuredTemplate.post("/api/teams/" + team2Id + "/levellogs", rickToken,
+                        levellogRequest)
+                .getLevellogId();
+
+        // 피드백 작성
+        final FeedbackContentDto feedbackContentDto1 = new FeedbackContentDto("로마 study 리뷰", "로마 speak 리뷰",
+                "로마 etc 리뷰");
+        final FeedbackContentDto feedbackContentDto2 = new FeedbackContentDto("페퍼 study 리뷰", "페퍼 speak 리뷰",
+                "페퍼 etc 리뷰");
+        final FeedbackRequest request1 = new FeedbackRequest(feedbackContentDto1);
+        final FeedbackRequest request2 = new FeedbackRequest(feedbackContentDto2);
+        RestAssuredTemplate.post("/api/levellogs/" + levellogId1 + "/feedbacks", romaToken, request1); // 로마 -> 릭 리뷰
+        RestAssuredTemplate.post("/api/levellogs/" + levellogId2 + "/feedbacks", pepperToken, request2); // 페퍼 -> 릭 리뷰
+
+        // when
+        final ValidatableResponse response = RestAssured.given(specification).log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + rickToken)
+                .filter(document("myinfo/findAllToMe"))
+                .when()
+                .get("/api/myInfo/feedbacks")
+                .then().log().all();
+
+        // then
+        response.statusCode(HttpStatus.OK.value())
+                .body("feedbacks.from.nickname", containsInAnyOrder("페퍼", "로마"),
+                        "feedbacks.feedback.study", containsInAnyOrder("페퍼 study 리뷰", "로마 study 리뷰"),
+                        "feedbacks.feedback.speak", containsInAnyOrder("페퍼 speak 리뷰", "로마 speak 리뷰"),
+                        "feedbacks.feedback.etc", containsInAnyOrder("페퍼 etc 리뷰", "로마 etc 리뷰"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -70,7 +70,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .body(nicknameDto)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("myinfo/update-nickname"))
+                .filter(document("myinfo/update/nickname"))
                 .when()
                 .put("/api/myInfo")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -11,6 +11,7 @@ import com.woowacourse.levellog.member.dto.MemberDto;
 import com.woowacourse.levellog.member.dto.MembersDto;
 import com.woowacourse.levellog.member.dto.NicknameUpdateDto;
 import com.woowacourse.levellog.member.exception.MemberAlreadyExistException;
+import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -127,7 +128,7 @@ class MemberServiceTest extends ServiceTest {
     class SaveIfNotExist {
 
         @Test
-        @DisplayName("saveIfNotExist 메서드는 깃허브 아이디로 저장된 멤버가 있으면 가입된 멤버의 ID를 반환한다.")
+        @DisplayName("깃허브 아이디로 저장된 멤버가 있으면 가입된 멤버의 ID를 반환한다.")
         void ifExist_returnSavedId() {
             // given
             final Member savedMember = memberRepository.save(new Member("로마", 123456, "profileUrl.image"));
@@ -140,7 +141,7 @@ class MemberServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("saveIfNotExist 메서드는 깃허브 아이디로 저장된 멤버가 없으면 새 멤버를 저장하고 멤버의 ID를 반환한다.")
+        @DisplayName("깃허브 아이디로 저장된 멤버가 없으면 새 멤버를 저장하고 멤버의 ID를 반환한다.")
         void ifNotExist_saveAndReturnSavedId() {
             // given
             final Member savedMember = memberRepository.save(new Member("로마", 123456, "profileUrl.image"));
@@ -152,6 +153,4 @@ class MemberServiceTest extends ServiceTest {
             assertThat(id).isEqualTo(savedMember.getId() + 1);
         }
     }
-
-
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -119,4 +119,37 @@ class MemberServiceTest extends ServiceTest {
                 .orElseThrow();
         assertThat(updateMember.getNickname()).isEqualTo("알린");
     }
+
+    @Nested
+    @DisplayName("saveIfNotExist 메서드는")
+    class saveIfNotExist {
+
+        @Test
+        @DisplayName("saveIfNotExist 메서드는 깃허브 아이디로 저장된 멤버가 있으면 가입된 멤버의 ID를 반환한다.")
+        void ifExist_returnSavedId() {
+            // given
+            final Member savedMember = memberRepository.save(new Member("로마", 123456, "profileUrl.image"));
+
+            // when
+            final Long id = memberService.saveIfNotExist(new GithubProfileDto("123456", "test", "test.image"), 123456);
+
+            // then
+            assertThat(savedMember.getId()).isEqualTo(id);
+        }
+
+        @Test
+        @DisplayName("saveIfNotExist 메서드는 깃허브 아이디로 저장된 멤버가 없으면 새 멤버를 저장하고 멤버의 ID를 반환한다.")
+        void ifNotExist_saveAndReturnSavedId() {
+            // given
+            final Member savedMember = memberRepository.save(new Member("로마", 123456, "profileUrl.image"));
+
+            // when
+            final Long id = memberService.saveIfNotExist(new GithubProfileDto("100", "test", "test.image"), 100);
+
+            // then
+            assertThat(id).isEqualTo(savedMember.getId() + 1);
+        }
+    }
+
+
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.dto.MemberCreateDto;
 import com.woowacourse.levellog.member.dto.MemberDto;

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -108,7 +108,7 @@ class MemberServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("saveIfNotExist 메서드는")
-    class saveIfNotExist {
+    class SaveIfNotExist {
 
         @Test
         @DisplayName("saveIfNotExist 메서드는 깃허브 아이디로 저장된 멤버가 있으면 가입된 멤버의 ID를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -51,21 +51,36 @@ class MemberServiceTest extends ServiceTest {
         }
     }
 
-    @Test
-    @DisplayName("findMemberById 메서드는 Id로 멤버의 정보를 조회한다.")
-    void findMemberById() {
-        // given
-        final Member roma = memberRepository.save(new Member("로마", 1234, "image.png"));
+    @Nested
+    @DisplayName("findMemberById 메서드는")
+    class FindMemberById {
 
-        // when
-        final MemberDto memberDto = memberService.findMemberById(roma.getId());
+        @Test
+        @DisplayName("Id로 멤버의 정보를 조회한다.")
+        void success() {
+            // given
+            final Member roma = memberRepository.save(new Member("로마", 1234, "image.png"));
 
-        // then
-        assertAll(
-                () -> assertThat(memberDto.getId()).isEqualTo(roma.getId()),
-                () -> assertThat(memberDto.getNickname()).isEqualTo("로마"),
-                () -> assertThat(memberDto.getProfileUrl()).isEqualTo("image.png")
-        );
+            // when
+            final MemberDto memberDto = memberService.findMemberById(roma.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(memberDto.getId()).isEqualTo(roma.getId()),
+                    () -> assertThat(memberDto.getNickname()).isEqualTo("로마"),
+                    () -> assertThat(memberDto.getProfileUrl()).isEqualTo("image.png")
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 Id로 요청을 보낼 경우 예외를 던진다.")
+        void memberNotFound_exception() {
+            // when & then
+            assertThatThrownBy(() -> memberService.findMemberById(1000L))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessageContainingAll("멤버가 존재하지 않음", "1000");
+        }
+
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -51,20 +51,6 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("findAll 메서드는 모든 멤버를 조회한다.")
-    void findAll() {
-        // given
-        memberRepository.save(new Member("로마", 1234, "image.png"));
-        memberRepository.save(new Member("페퍼", 1245, "image2.png"));
-
-        // when
-        final MembersDto membersDto = memberService.findAll();
-
-        // then
-        assertThat(membersDto.getMembers()).hasSize(2);
-    }
-
-    @Test
     @DisplayName("findMemberById 메서드는 Id로 멤버의 정보를 조회한다.")
     void findMemberById() {
         // given

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -89,7 +89,7 @@ class MemberServiceTest extends ServiceTest {
         final NicknameUpdateDto nicknameUpdateDto = new NicknameUpdateDto("알린");
 
         // when
-        memberService.updateNickname(id, nicknameUpdateDto);
+        memberService.updateNickname(nicknameUpdateDto, id);
 
         // then
         final Member updateMember = memberRepository.findById(id)

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
@@ -3,8 +3,8 @@ package com.woowacourse.levellog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.common.exception.InvalidFieldException;
+import com.woowacourse.levellog.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,12 +16,72 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MemberTest {
 
     @Nested
+    @DisplayName("생성자는")
+    class constructor {
+
+        @Test
+        @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
+        void nicknameInvalidLength_exception() {
+            // given
+            final String invalidNickname = "a".repeat(51);
+
+            // when & then
+            assertThatThrownBy(() -> new Member(invalidNickname, 123456, "validProfileUrl"))
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessageContainingAll("닉네임은 50자 이하여야합니다.", String.valueOf(invalidNickname.length()));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        @NullAndEmptySource
+        @DisplayName("닉네임이 공백이나 null일 경우 예외를 던진다.")
+        void nicknameBlank_exception(final String invalidNickname) {
+            // when & then
+            assertThatThrownBy(() -> new Member(invalidNickname, 123456, "validProfileUrl"))
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessage("닉네임은 공백이나 null일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("githubId가 null일 경우 예외를 던진다.")
+        void githubIdNull_exception() {
+            // when & then
+            assertThatThrownBy(() -> new Member("test", null, "validProfileUrl"))
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessage("깃허브 ID는 null일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("프로필 url은 2048자를 초과할 경우 예외를 던진다.")
+        void profileUrlInvalidLength_exception() {
+            // given
+            final String invalidProfileUrl = "a".repeat(2049);
+
+            // when & then
+            assertThatThrownBy(() -> new Member("test", 123456, invalidProfileUrl))
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessageContainingAll("프로필 url은 2048자 이하여야합니다.", String.valueOf(invalidProfileUrl.length()));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {" "})
+        @NullAndEmptySource
+        @DisplayName("프로필 url이 공백이나 null일 경우 예외를 던진다.")
+        void profileUrlBlank_exception(final String invalidProfileUrl) {
+            // when & then
+            assertThatThrownBy(() -> new Member("test", 123456, invalidProfileUrl))
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessage("프로필 url은 공백이나 null일 수 없습니다.");
+        }
+    }
+
+    @Nested
     @DisplayName("updateNickname 메서드는")
     class updateNickname {
 
         @Test
         @DisplayName("닉네임을 변경한다.")
-        void updateNickname() {
+        void success() {
             // given
             final Member member = new Member("로마", 123456, "image.png");
 
@@ -34,27 +94,29 @@ class MemberTest {
 
         @Test
         @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
-        void nicknameInvalidLength_Exception() {
+        void nicknameInvalidLength_exception() {
             // given
             final Member member = new Member("로마", 123456, "image.png");
             final String invalidNickname = "a".repeat(51);
 
             // when & then
             assertThatThrownBy(() -> member.updateNickname(invalidNickname))
-                    .isInstanceOf(InvalidFieldException.class);
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessageContainingAll("닉네임은 50자 이하여야합니다.", String.valueOf(invalidNickname.length()));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("닉네임이 공백이나 null일 경우 예외를 던진다.")
-        void nicknameBlank_Exception(final String invalidNickname) {
+        void nicknameBlank_exception(final String invalidNickname) {
             // given
             final Member member = new Member("로마", 123456, "image.png");
 
             // when & then
             assertThatThrownBy(() -> member.updateNickname(invalidNickname))
-                    .isInstanceOf(InvalidFieldException.class);
+                    .isInstanceOf(InvalidFieldException.class)
+                    .hasMessage("닉네임은 공백이나 null일 수 없습니다.");
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
@@ -17,7 +17,7 @@ class MemberTest {
 
     @Nested
     @DisplayName("생성자는")
-    class constructor {
+    class Constructor {
 
         @Test
         @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
@@ -77,7 +77,7 @@ class MemberTest {
 
     @Nested
     @DisplayName("updateNickname 메서드는")
-    class updateNickname {
+    class UpdateNickname {
 
         @Test
         @DisplayName("닉네임을 변경한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -55,7 +55,7 @@ class MyInfoControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("닉네임은 50자 이하여야합니다."));
 
             // docs
-            perform.andDo(document("myinfo/update-nickname-invalid-length"));
+            perform.andDo(document("myinfo/update/nickname-invalid-length"));
         }
 
         @ParameterizedTest
@@ -83,7 +83,7 @@ class MyInfoControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("myinfo/update-nickname-blank"));
+            perform.andDo(document("myinfo/update/nickname-blank"));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -26,7 +26,7 @@ class MyInfoControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("updateNickname 메서드는 ")
-    class updateNickname {
+    class UpdateNickname {
 
         @Test
         @DisplayName("닉네임에 50자를 초과한 문자열이 들어올 경우 예외를 던진다.")

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -4,8 +4,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.levellog.common.exception.InvalidFieldException;
@@ -49,9 +51,11 @@ class MyInfoControllerTest extends ControllerTest {
                     .andDo(print());
 
             // then
-            perform.andExpect(
-                    status().isBadRequest()
-            );
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("message").value("닉네임은 50자 이하여야합니다."));
+
+            // docs
+            perform.andDo(document("myinfo/update-nickname-invalid-length"));
         }
 
         @ParameterizedTest
@@ -70,13 +74,16 @@ class MyInfoControllerTest extends ControllerTest {
             final ResultActions perform = mockMvc.perform(put("/api/myInfo")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestContent)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer: token"))
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                     .andDo(print());
 
             // then
             perform.andExpect(
                     status().isBadRequest()
             );
+
+            // docs
+            perform.andDo(document("myinfo/update-nickname-blank"));
         }
     }
 }


### PR DESCRIPTION
## 구현 기능
공통으로 지켜야할 컨벤션
- [x] DTO 클래스명 변경
- [x] DTO 정적 팩터리 메서드 추가(new로 생성 방지)
- [x] 도메인 검증 로직 추가
- [x] 도메인 테스트 추가
- [x] 서비스에서 `@Transactional` 추가하기
- [x] 매개변수에서는 객체 ➡️ id 값들 순서
- [x] 커스텀 예외에 대한 구체 메세지 작성
- [x] 예외 로그에 많은 정보를 담되, 간단한 메세지로 표현
- [x] 컨트롤러테스트에서 문서화를 위한 예외케이스를 추가 (Mocking)
- [x] 서비스테스트 보강

##  논의하고 싶은 내용
- 아직 클라이언트 , 서버 단의 예외 메세지를 분리하지 않았습니다. 해당 부분은 릭꺼 머지되면 할 예정입니다. 👨‍🦽

Close #130
