### PR TITLE
fix: 팀 생성 시 중복된 참가자 예외 처리 로직 추가

### DIFF
--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -19,6 +19,16 @@ operation::team/create[]
 [[create-exception]]
 === 팀 생성 예외
 
+[[create-exception-participants-duplicate]]
+==== 저장 시 중복된 참가자가 존재하는 경우
+
+operation::team/create/exception/participants/duplicate[]
+
+[[create-exception-participants-host]]
+==== 저장 시 참가자 목록에 Host가 포함된 경우 (hostId = 1)
+
+operation::team/create/exception/participants/host[]
+
 [[create-exception-title-null]]
 ==== 저장 시 title이 null 또는 공백인 경우
 

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -14,10 +14,13 @@ import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
 import com.woowacourse.levellog.team.dto.TeamsDto;
+import com.woowacourse.levellog.team.exception.DuplicateParticipantsException;
 import com.woowacourse.levellog.team.exception.HostUnauthorizedException;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -82,11 +85,28 @@ public class TeamService {
     }
 
     private List<Participant> getParticipants(final Team team, final Long hostId, final List<Long> memberIds) {
+        validateParticipantDuplication(memberIds, hostId);
+
+        return generatePaticipants(team, hostId, memberIds);
+    }
+
+    private List<Participant> generatePaticipants(final Team team, final Long hostId, final List<Long> memberIds) {
         final List<Participant> participants = new ArrayList<>();
         participants.add(new Participant(team, getMember(hostId), true));
         participants.addAll(toParticipants(team, memberIds));
 
         return participants;
+    }
+
+    private void validateParticipantDuplication(final List<Long> memberIds, final Long hostId) {
+        final List<Long> participantIds = new ArrayList<>(memberIds);
+        participantIds.add(hostId);
+
+        final Set<Long> distinct = new HashSet<>(participantIds);
+        if (distinct.size() != participantIds.size()) {
+            throw new DuplicateParticipantsException(
+                    "참가자 중복 [participants : " + participantIds + " hostId : " + hostId + "]");
+        }
     }
 
     private List<Participant> toParticipants(final Team team, final List<Long> memberIds) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/exception/DuplicateParticipantsException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/exception/DuplicateParticipantsException.java
@@ -1,0 +1,13 @@
+package com.woowacourse.levellog.team.exception;
+
+import com.woowacourse.levellog.common.exception.LevellogException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateParticipantsException extends LevellogException {
+
+    private static final String CLIENT_MESSAGE = "중복되는 참가자가 존재합니다.";
+
+    public DuplicateParticipantsException(final String message) {
+        super(message, CLIENT_MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -38,7 +38,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final Long roma_id = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
         final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
@@ -84,7 +84,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final Long roma_id = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
         final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
@@ -136,7 +136,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final Long roma_id = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id).getTeamId();
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id).getTeamId();
 
         final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
         final String rick_levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
@@ -199,7 +199,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final Long roma_id = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final String teamId = requestCreateTeam("릭 and 로마", rickToken, rick_id, roma_id)
+        final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
         final LevellogDto levellogRequest = LevellogDto.from("레벨로그");

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -102,8 +102,8 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final String pepperToken = pepperLoginResponse.getToken();
 
         // 팀 생성
-        final String team1Id = requestCreateTeam("릭,로마", rickToken, rick_id, roma_id).getTeamId();
-        final String team2Id = requestCreateTeam("릭,로마,페퍼", romaToken, rick_id, roma_id, pepper_id).getTeamId();
+        final String team1Id = requestCreateTeam("릭,로마", rickToken, roma_id).getTeamId();
+        final String team2Id = requestCreateTeam("릭,로마,페퍼", romaToken, rick_id, pepper_id).getTeamId();
 
         // 레벨로그 생성
         final LevellogDto levellogRequest = LevellogDto.from("레벨로그1,2 내용");

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -13,6 +13,7 @@ import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
 import com.woowacourse.levellog.team.dto.TeamsDto;
+import com.woowacourse.levellog.team.exception.DuplicateParticipantsException;
 import com.woowacourse.levellog.team.exception.HostUnauthorizedException;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
 import java.time.LocalDateTime;
@@ -25,24 +26,6 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("TeamService의")
 class TeamServiceTest extends ServiceTest {
-
-    @Test
-    @DisplayName("save 메서드는 팀을 생성한다.")
-    void save() {
-        //given
-        final Long participant1 = memberRepository.save(new Member("알린", 1111, "alien.png")).getId();
-        final Long participant2 = memberRepository.save(new Member("페퍼", 2222, "pepper.png")).getId();
-        final Long participant3 = memberRepository.save(new Member("로마", 3333, "roma.png")).getId();
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 준조", "트랙룸", LocalDateTime.now().plusDays(3),
-                new ParticipantIdsDto(List.of(participant1, participant2, participant3)));
-
-        //when
-        final Long id = teamService.save(teamCreateDto, participant1);
-
-        //then
-        final Optional<Team> team = teamRepository.findById(id);
-        assertThat(team).isPresent();
-    }
 
     @Test
     @DisplayName("findAll 메서드는 전체 팀 목록을 조회한다.")
@@ -84,6 +67,53 @@ class TeamServiceTest extends ServiceTest {
                 () -> assertThat(actualParticipantSizes).contains(2, 2),
                 () -> assertThat(response.getTeams()).hasSize(2)
         );
+    }
+
+    private Member saveAndGetMember(final String nickname) {
+        return memberRepository.save(new Member(nickname, (int) System.nanoTime(), "profile.png"));
+    }
+
+    private Team saveAndGetTeam(final String title) {
+        return teamRepository.save(new Team(title, "피니시방", LocalDateTime.now().plusDays(3), "jason.png"));
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class Save {
+
+        @Test
+        @DisplayName("팀을 생성한다.")
+        void save() {
+            //given
+            final Long participant1 = memberRepository.save(new Member("알린", 1111, "alien.png")).getId();
+            final Long participant2 = memberRepository.save(new Member("페퍼", 2222, "pepper.png")).getId();
+            final Long participant3 = memberRepository.save(new Member("로마", 3333, "roma.png")).getId();
+            final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 준조", "트랙룸", LocalDateTime.now().plusDays(3),
+                    new ParticipantIdsDto(List.of(participant2, participant3)));
+
+            //when
+            final Long id = teamService.save(teamCreateDto, participant1);
+
+            //then
+            final Optional<Team> team = teamRepository.findById(id);
+            assertThat(team).isPresent();
+        }
+
+        @Test
+        @DisplayName("참가자가 중복되면 예외가 발생한다.")
+        void save_duplicate_exceptionThrown() {
+            //given
+            final Long participant1 = memberRepository.save(new Member("알린", 1111, "alien.png")).getId();
+            final Long participant2 = memberRepository.save(new Member("페퍼", 2222, "pepper.png")).getId();
+            final Long participant3 = memberRepository.save(new Member("로마", 3333, "roma.png")).getId();
+            final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 준조", "트랙룸", LocalDateTime.now().plusDays(3),
+                    new ParticipantIdsDto(List.of(participant1, participant2, participant3)));
+
+            //when & then
+            assertThatThrownBy(() -> teamService.save(teamCreateDto, participant1))
+                    .isInstanceOf(DuplicateParticipantsException.class)
+                    .hasMessageContaining("참가자 중복");
+        }
     }
 
     @Nested
@@ -242,13 +272,5 @@ class TeamServiceTest extends ServiceTest {
                     .isInstanceOf(TeamNotFoundException.class)
                     .hasMessageContaining("팀이 존재하지 않습니다. 입력한 팀 id : [1000]");
         }
-    }
-
-    private Member saveAndGetMember(final String nickname) {
-        return memberRepository.save(new Member(nickname, (int) System.nanoTime(), "profile.png"));
-    }
-
-    private Team saveAndGetTeam(final String title) {
-        return teamRepository.save(new Team(title, "피니시방", LocalDateTime.now().plusDays(3), "jason.png"));
     }
 }


### PR DESCRIPTION
## 구현 기능
- 팀 생성 시 중복된 참가자 예외 처리 로직 추가

## 공유하고 싶은 내용
- 팀 생성 시 Participants에 hostId가 들어가거나 중복된 참가자 Id가 존재할 경우 예외를 터트립니다.

Close #165 