### PR TITLE
fix: 속하지 않은 팀의 피드백 조회를 요청시 예외 발생

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -50,7 +50,7 @@ public class FeedbackService {
                 .getId();
     }
 
-    public FeedbacksDto findAll(final Long levellogId) {
+    public FeedbacksDto findAll(final Long levellogId, final Long memberId) {
         final Levellog levellog = getLevellog(levellogId);
         final List<FeedbackDto> responses = getFeedbackResponses(feedbackRepository.findAllByLevellog(levellog));
 

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -35,7 +35,7 @@ public class FeedbackController {
     @GetMapping
     public ResponseEntity<FeedbacksDto> findAll(@PathVariable final Long levellogId,
                                                 @Authentic final Long memberId) {
-        final FeedbacksDto response = feedbackService.findAll(levellogId, 1L);
+        final FeedbacksDto response = feedbackService.findAll(levellogId, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -33,8 +33,9 @@ public class FeedbackController {
     }
 
     @GetMapping
-    public ResponseEntity<FeedbacksDto> findAll(@PathVariable final Long levellogId) {
-        final FeedbacksDto response = feedbackService.findAll(levellogId);
+    public ResponseEntity<FeedbacksDto> findAll(@PathVariable final Long levellogId,
+                                                @Authentic final Long memberId) {
+        final FeedbacksDto response = feedbackService.findAll(levellogId, 1L);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -14,16 +14,13 @@ import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.config.TestAuthenticationConfig;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,19 +40,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 abstract class AcceptanceTest {
 
-    @Deprecated
-    protected static final String MASTER = "토미";
-
-    @Deprecated
-    protected String masterToken;
-
     protected RequestSpecification specification;
 
     @Autowired
     protected ObjectMapper objectMapper;
-
-    @Deprecated
-    private Long masterId;
 
     @LocalServerPort
     private int port;
@@ -90,28 +78,6 @@ abstract class AcceptanceTest {
                                         prettyPrint()
                                 )
                 ).build();
-
-        masterToken = login(MASTER)
-                .getToken();
-        masterId = login(MASTER)
-                .getMemberId();
-    }
-
-    @Deprecated
-    protected RestAssuredResponse requestCreateTeam(final String title, final String host,
-                                                    final String... participants) {
-        final List<Long> participantIds = Arrays.stream(participants)
-                .map(this::login)
-                .map(RestAssuredResponse::getMemberId)
-                .collect(Collectors.toList());
-        final ParticipantIdsDto participantIdsDto = new ParticipantIdsDto(participantIds);
-        final TeamCreateDto request = new TeamCreateDto(title, title + "place", 1, LocalDateTime.now().plusDays(3),
-                participantIdsDto);
-
-        final String token = login(host)
-                .getToken();
-
-        return post("/api/teams", token, request);
     }
 
     @Deprecated
@@ -136,12 +102,5 @@ abstract class AcceptanceTest {
             e.printStackTrace();
         }
         return null;
-    }
-
-    @Deprecated
-    protected RestAssuredResponse requestCreateLevellog(final String teamId, final String content) {
-        final LevellogDto request = LevellogDto.from(content);
-
-        return post("/api/teams/" + teamId + "/levellogs", masterToken, request);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -31,7 +31,6 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     void createFeedback() {
         // given
         final RestAssuredResponse hostLoginResponse = login("릭");
-        final Long rick_id = hostLoginResponse.getMemberId();
         final String rickToken = hostLoginResponse.getToken();
 
         final RestAssuredResponse romaLoginResponse = login("로마");
@@ -77,7 +76,6 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     void findAllFeedbacks() {
         // given
         final RestAssuredResponse hostLoginResponse = login("릭");
-        final Long rick_id = hostLoginResponse.getMemberId();
         final String rickToken = hostLoginResponse.getToken();
 
         final RestAssuredResponse romaLoginResponse = login("로마");
@@ -102,7 +100,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .filter(document("feedback/find-all"))
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
                 .when()
                 .get("/api/levellogs/{levellogId}/feedbacks", levellogId)
                 .then().log().all();
@@ -129,7 +127,6 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     void updateFeedback() {
         // given
         final RestAssuredResponse hostLoginResponse = login("릭");
-        final Long rick_id = hostLoginResponse.getMemberId();
         final String rickToken = hostLoginResponse.getToken();
 
         final RestAssuredResponse romaLoginResponse = login("로마");
@@ -172,7 +169,8 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
-        requestFindAllFeedbacks(rick_levellogId)
+        RestAssuredTemplate.get("/api/levellogs/" + rick_levellogId + "/feedbacks", romaToken)
+                .getResponse()
                 .body("feedbacks.feedback.study", contains("수정된 Study 피드백"),
                         "feedbacks.feedback.speak", contains("수정된 Speak 피드백"),
                         "feedbacks.feedback.etc", contains("수정된 Etc 피드백")
@@ -192,7 +190,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
     void deleteFeedback() {
         // given
         final RestAssuredResponse hostLoginResponse = login("릭");
-        final Long rick_id = hostLoginResponse.getMemberId();
+        hostLoginResponse.getMemberId();
         final String rickToken = hostLoginResponse.getToken();
 
         final RestAssuredResponse romaLoginResponse = login("로마");
@@ -230,15 +228,8 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
-        requestFindAllFeedbacks(rick_levellogId)
+        RestAssuredTemplate.get("/api/levellogs/" + rick_levellogId + "/feedbacks", romaToken)
+                .getResponse()
                 .body("feedbacks.id", not(contains(deleteId)));
-    }
-
-    private ValidatableResponse requestFindAllFeedbacks(final String levellogId) {
-        return RestAssured.given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
-                .when()
-                .get("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                .then().log().all();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -40,7 +40,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + masterToken)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginResponse1.getToken())
                 .body(request)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("levellog/save"))

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.feedback.domain.Feedback;
 import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackDto;
@@ -27,24 +28,20 @@ import org.junit.jupiter.api.Test;
 @DisplayName("FeedbackService의")
 class FeedbackServiceTest extends ServiceTest {
 
-    @Test
-    @DisplayName("findAll 메서드는 모든 피드백을 조회한다.")
-    void findAll() {
-        // given
-        final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
-        final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
-        final Member alien = memberRepository.save(new Member("알린", 3333, "alien.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(3), "progile.img", 1));
-        final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
-        feedbackRepository.save(new Feedback(roma, eve, levellog, "로마 스터디", "로마 말하기", "로마 기타"));
-        feedbackRepository.save(new Feedback(alien, eve, levellog, "알린 스터디", "알린 말하기", "알린 기타"));
+    private Member saveAndGetMember(final String nickname) {
+        return memberRepository.save(new Member(nickname, (int) System.nanoTime(), "profile.png"));
+    }
 
-        // when
-        final FeedbacksDto feedbacksResponse = feedbackService.findAll(levellog.getId(), 1L);
+    private Team saveAndGetTeam(final String title, final int interviewerNumber) {
+        return teamRepository.save(
+                new Team(title, "피니시방", LocalDateTime.now().plusDays(3), "jason.png", interviewerNumber));
+    }
 
-        // then
-        assertThat(feedbacksResponse.getFeedbacks()).hasSize(2);
+    private void saveAllParticipant(final Team team, final Member host, final Member... participants) {
+        participantRepository.save(new Participant(team, host, true));
+        for (final Member participant : participants) {
+            participantRepository.save(new Participant(team, participant, false));
+        }
     }
 
     @Test
@@ -74,6 +71,53 @@ class FeedbackServiceTest extends ServiceTest {
 
         // then
         assertThat(fromNicknames).contains("로마", "알린");
+    }
+
+    @Nested
+    @DisplayName("findAll 메서드는")
+    class FindAll {
+
+        @Test
+        @DisplayName("모든 피드백을 조회한다.")
+        void success() {
+            // given
+            final Member eve = saveAndGetMember("이브");
+            final Member roma = saveAndGetMember("로마");
+            final Member alien = saveAndGetMember("알린");
+            final Team team = saveAndGetTeam("잠실 네오조", 1);
+            saveAllParticipant(team, eve, roma);
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+            saveAllParticipant(team, eve, roma, alien);
+            feedbackRepository.save(new Feedback(roma, eve, levellog, "로마 스터디", "로마 말하기", "로마 기타"));
+            feedbackRepository.save(new Feedback(alien, eve, levellog, "알린 스터디", "알린 말하기", "알린 기타"));
+
+            // when
+            final FeedbacksDto feedbacksResponse = feedbackService.findAll(levellog.getId(), eve.getId());
+
+            // then
+            assertThat(feedbacksResponse.getFeedbacks()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("속하지 않은 팀의 피드백 조회를 요청하면 예외가 발생한다.")
+        void findAll_notMyTeam_exception() {
+            // given
+            final Member eve = saveAndGetMember("이브");
+            final Member roma = saveAndGetMember("로마");
+            final Member alien = saveAndGetMember("알린");
+            final Team team = saveAndGetTeam("잠실 네오조", 1);
+            saveAllParticipant(team, eve, roma);
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+            feedbackRepository.save(new Feedback(roma, eve, levellog, "로마 스터디", "로마 말하기", "로마 기타"));
+
+            // when & then
+            final Long memberId = alien.getId();
+            final Long levellogId = levellog.getId();
+            assertThatThrownBy(() -> feedbackService.findAll(levellogId, memberId))
+                    .isInstanceOf(UnauthorizedException.class)
+                    .hasMessageContainingAll("자신이 속한 팀의 피드백만 조회할 수 있습니다.", String.valueOf(team.getId()),
+                            String.valueOf(memberId), String.valueOf(levellogId));
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -41,7 +41,7 @@ class FeedbackServiceTest extends ServiceTest {
         feedbackRepository.save(new Feedback(alien, eve, levellog, "알린 스터디", "알린 말하기", "알린 기타"));
 
         // when
-        final FeedbacksDto feedbacksResponse = feedbackService.findAll(levellog.getId());
+        final FeedbacksDto feedbacksResponse = feedbackService.findAll(levellog.getId(), 1L);
 
         // then
         assertThat(feedbacksResponse.getFeedbacks()).hasSize(2);


### PR DESCRIPTION
## 구현 기능
- 속하지 않은 팀의 피드백 조회를 요청하면 예외가 발생하도록 처리하였습니다.

## 공유하고 싶은 내용
- AcceptanceTest에서 `@Deprecated`인 `masterToken` 및 `requestTeam` 메서드도 제거하였습니다!!!!!!!!!!!!!!!!!!!!!!!!

Close #159
