### PR TITLE
fix: api 문서 링크 수정

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -12,5 +12,5 @@
 * link:auth.html[Auth]
 * link:myinfo.html[MyInfo]
 * link:member.html[Member]
-* link:prequestion[PreQuestion]
+* link:prequestion.html[PreQuestion]
 * link:interviewquestion.html[InterviewQuestion]


### PR DESCRIPTION
## 구현 기능
- index.adoc에 preQuestion html 링크가 잘못되어있어서 수정했어요