### PR TITLE
feat: 특정 레벨로그에 내가 작성한 사전 질문 조회 기능

### DIFF
--- a/backend/src/docs/asciidoc/prequestion.adoc
+++ b/backend/src/docs/asciidoc/prequestion.adoc
@@ -45,20 +45,15 @@ operation::pre-question/find-my[]
 [[find-my-exception]]
 === 사전 질문 상세 조회 예외
 
-[[find-my-exception-wrong-levellog]]
-==== url의 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
+[[find-my-exception-not-exist-levellog]]
+==== 레벨로그가 존재하지 않는 경우
 
-operation::pre-question/find-my/exception/wrong-levellog[]
+operation::pre-question/find-my/exception/not-exist-levellog[]
 
-[[find-my-exception-notfound]]
-==== 없는 사전 질문을 상세 조회하는 경우
+[[find-my-exception-not-exist-pre-question]]
+==== 레벨로그에 대한 사전 질문이 존재하지 않는 경우
 
-operation::pre-question/find-my/exception/notfound[]
-
-[[find-my-exception-not-my-pre-question]]
-==== 타인의 사전 질문을 조회하는 경우
-
-operation::pre-question/find-my/exception/not-my-pre-question[]
+operation::pre-question/find-my/exception/not-exist-pre-question[]
 
 [[update]]
 == 사전 질문 수정

--- a/backend/src/docs/asciidoc/prequestion.adoc
+++ b/backend/src/docs/asciidoc/prequestion.adoc
@@ -34,31 +34,31 @@ operation::pre-question/create/exception/not-participant[]
 
 operation::pre-question/create/exception/levellog-is-mine[]
 
-[[find]]
+[[find-my]]
 == 사전 질문 상세 조회
 
-[[find-success]]
+[[find-my-success]]
 === 사전 질문 상세 조회 성공
 
-operation::pre-question/find[]
+operation::pre-question/find-my[]
 
-[[find-exception]]
+[[find-my-exception]]
 === 사전 질문 상세 조회 예외
 
-[[find-exception-wrong-levellog]]
+[[find-my-exception-wrong-levellog]]
 ==== url의 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
 
-operation::pre-question/findbyid/exception/wrong-levellog[]
+operation::pre-question/find-my/exception/wrong-levellog[]
 
-[[find-exception-notfound]]
+[[find-my-exception-notfound]]
 ==== 없는 사전 질문을 상세 조회하는 경우
 
-operation::pre-question/findbyid/exception/notfound[]
+operation::pre-question/find-my/exception/notfound[]
 
-[[find-exception-not-my-pre-question]]
+[[find-my-exception-not-my-pre-question]]
 ==== 타인의 사전 질문을 조회하는 경우
 
-operation::pre-question/findbyid/exception/not-my-pre-question[]
+operation::pre-question/find-my/exception/not-my-pre-question[]
 
 [[update]]
 == 사전 질문 수정

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
@@ -38,13 +38,12 @@ public class PreQuestionService {
                 .getId();
     }
 
-    public PreQuestionDto findById(final Long preQuestionId, final Long levellogId, final Long memberId) {
-        final PreQuestion preQuestion = getPreQuestion(preQuestionId);
+    public PreQuestionDto findMy(final Long levellogId, final Long questionerId) {
         final Levellog levellog = getLevellog(levellogId);
-        final Member questioner = getMember(memberId);
-
-        validateLevellog(preQuestion, levellog);
-        validateMyQuestion(preQuestion, questioner);
+        final Member questioner = getMember(questionerId);
+        final PreQuestion preQuestion = preQuestionRepository.findByLevellogAndAuthor(levellog, questioner)
+                .orElseThrow(() -> new PreQuestionNotFoundException("사전 질문이 존재하지 않습니다. "
+                        + "[ levellogId : " + levellogId + " memberId : " + questionerId + " ]"));
 
         return PreQuestionDto.from(preQuestion.getContent());
     }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.prequestion.domain;
 
+import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PreQuestionRepository extends JpaRepository<PreQuestion, Long> {
 
     Optional<PreQuestion> findByIdAndAuthor(Long id, Member author);
+
+    Optional<PreQuestion> findByLevellogAndAuthor(Levellog levellog, Member author);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
@@ -32,11 +32,9 @@ public class PreQuestionController {
                 URI.create("/api/levellogs/" + levellogId + "/pre-questions/" + preQuestionId)).build();
     }
 
-    @GetMapping("/{preQuestionId}")
-    public ResponseEntity<PreQuestionDto> findById(@PathVariable final Long levellogId,
-                                                   @PathVariable final Long preQuestionId,
-                                                   @Authentic final Long memberId) {
-        final PreQuestionDto response = preQuestionService.findById(preQuestionId, levellogId, memberId);
+    @GetMapping("/my")
+    public ResponseEntity<PreQuestionDto> findMy(@PathVariable final Long levellogId, @Authentic final Long memberId) {
+        final PreQuestionDto response = preQuestionService.findById(levellogId, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
@@ -34,7 +34,7 @@ public class PreQuestionController {
 
     @GetMapping("/my")
     public ResponseEntity<PreQuestionDto> findMy(@PathVariable final Long levellogId, @Authentic final Long memberId) {
-        final PreQuestionDto response = preQuestionService.findById(levellogId, memberId);
+        final PreQuestionDto response = preQuestionService.findMy(levellogId, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("사전 질문 관련 기능")
-public class PreQuestionAcceptanceTest extends AcceptanceTest {
+class PreQuestionAcceptanceTest extends AcceptanceTest {
 
     /*
      * Scenario: 사전 질문 등록하기
@@ -107,21 +107,20 @@ public class PreQuestionAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
-        get(baseUrl + preQuestionId, eveToken).getResponse()
+        get(baseUrl + "my", eveToken).getResponse()
                 .body("preQuestion", equalTo("이브가 수정한 사전 질문"));
     }
 
     /*
-     * Scenario: 사전 질문 조회하기
+     * Scenario: 내가 작성한 사전 질문 조회하기
      *   given: 1개의 레벨로그와 2명의 사용자(페퍼, 이브)가 있다.
      *   given: 이브가 페퍼에게 작성한 사전 질문이 있다.
      *   when: 이브가 페퍼의 레벨로그에 쓴 사전 질문 조회를 요청한다.
      *   then: 200 ok 상태 코드와 사전 질문 데이터를 응답받는다.
      */
-
     @Test
-    @DisplayName("사전 질문 조회하기")
-    void findById() {
+    @DisplayName("내가 작성한 사전 질문 조회하기")
+    void findMy() {
         // given
         final RestAssuredResponse pepperResponse = login("페퍼");
         final RestAssuredResponse eveResponse = login("이브");
@@ -138,8 +137,7 @@ public class PreQuestionAcceptanceTest extends AcceptanceTest {
 
         final PreQuestionDto saveRequestDto = PreQuestionDto.from("이브가 쓴 사전 질문");
         final String baseUrl = "/api/levellogs/" + levellogId + "/pre-questions/";
-        final String preQuestionId = post(baseUrl, eveToken, saveRequestDto)
-                .getPreQuestionId();
+        post(baseUrl, eveToken, saveRequestDto);
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -147,7 +145,7 @@ public class PreQuestionAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("pre-question/find"))
                 .when()
-                .get(baseUrl + preQuestionId)
+                .get(baseUrl + "my")
                 .then().log().all();
 
         // then
@@ -195,7 +193,7 @@ public class PreQuestionAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
-        get(baseUrl + preQuestionId, eveToken).getResponse()
+        get(baseUrl + "my", eveToken).getResponse()
                 .statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
@@ -143,7 +143,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + eveToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("pre-question/find"))
+                .filter(document("pre-question/find-my"))
                 .when()
                 .get(baseUrl + "my")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Import;
 @DataJpaTest
 @Import(JpaConfig.class)
 @DisplayName("PreQuestionRepository의")
-public class PreQuestionRepositoryTest {
+class PreQuestionRepositoryTest {
 
     @Autowired
     PreQuestionRepository preQuestionRepository;
@@ -50,6 +50,25 @@ public class PreQuestionRepositoryTest {
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByIdAndAuthor(preQuestion.getId(), questioner);
+
+        // then
+        assertThat(actual).hasValue(preQuestion);
+    }
+
+    @Test
+    @DisplayName("findByLevellogAndAuthor 메서드는 Levellog와 Author가 같은 사전 질문을 반환한다.")
+    void findByLevellogAndAuthor() {
+        // given
+        final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
+        final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
+        final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+
+        final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
+        final String content = "로마가 쓴 사전 질문입니다.";
+        final PreQuestion preQuestion = preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+
+        // when
+        final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthor(levellog, questioner);
 
         // then
         assertThat(actual).hasValue(preQuestion);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/ControllerTest.java
@@ -6,6 +6,11 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.application.OAuthService;
@@ -28,9 +33,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -99,5 +107,41 @@ public abstract class ControllerTest {
                                 prettyPrint()
                         )
                 ).build();
+    }
+
+    protected ResultActions requestGet(final String url, final String token) throws Exception {
+        return mockMvc.perform(get(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    protected ResultActions requestPost(final String url, final String token, final Object request)
+            throws Exception {
+        final String content = objectMapper.writeValueAsString(request);
+
+        return mockMvc.perform(post(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andDo(print());
+    }
+
+    protected ResultActions requestPut(final String url, final String token, final Object request)
+            throws Exception {
+        final String content = objectMapper.writeValueAsString(request);
+
+        return mockMvc.perform(put(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andDo(print());
+    }
+
+    protected ResultActions requestDelete(final String url, final String token) throws Exception {
+        return mockMvc.perform(delete(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+@DisplayName("MyInfoController의")
 class MyInfoControllerTest extends ControllerTest {
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -28,9 +28,45 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("PreQuestionController의")
-public class PreQuestionControllerTest extends ControllerTest {
+class PreQuestionControllerTest extends ControllerTest {
 
     private static final String TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
+
+    private ResultActions requestPost(final String url, final String token, final Object request)
+            throws Exception {
+        final String content = objectMapper.writeValueAsString(request);
+
+        return mockMvc.perform(post(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andDo(print());
+    }
+
+    private ResultActions requestPut(final String url, final String token, final Object request)
+            throws Exception {
+        final String content = objectMapper.writeValueAsString(request);
+
+        return mockMvc.perform(put(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andDo(print());
+    }
+
+    private ResultActions requestGet(final String url, final String token) throws Exception {
+        return mockMvc.perform(get(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    private ResultActions requestDelete(final String url, final String token) throws Exception {
+        return mockMvc.perform(delete(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
 
     @Nested
     @DisplayName("save 메서드는")
@@ -93,7 +129,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
             final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
 
-            willThrow(new InvalidPreQuestionException(" [levellogId : 1]", "자기 자신에게 사전 질문을 등록할 수 없습니다."))
+            willThrow(new InvalidPreQuestionException("[levellogId : 1]", "자기 자신에게 사전 질문을 등록할 수 없습니다."))
                     .given(preQuestionService)
                     .save(preQuestionDto, 1L, 4L);
 
@@ -146,8 +182,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
             final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
 
-            willThrow(
-                            new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
+            willThrow(new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
                     .given(preQuestionService)
                     .update(preQuestionDto, 1L, 1L, 4L);
 
@@ -157,8 +192,7 @@ public class PreQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message")
-                            .value("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"));
+                    jsonPath("message").value("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"));
 
             // docs
             perform.andDo(document("pre-question/update/exception/wrong-levellog"));
@@ -228,7 +262,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
             willThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
                     .given(preQuestionService)
-                    .findMy( 999L, 4L);
+                    .findMy(999L, 4L);
 
             // when
             final ResultActions perform = requestGet("/api/levellogs/999/pre-questions/my", TOKEN);
@@ -259,8 +293,7 @@ public class PreQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isNotFound(),
-                    jsonPath("message")
-                            .value("사전 질문이 존재하지 않습니다."));
+                    jsonPath("message").value("사전 질문이 존재하지 않습니다."));
 
             // docs
             perform.andDo(document("pre-question/find-my/exception/not-exist-pre-question"));
@@ -278,8 +311,7 @@ public class PreQuestionControllerTest extends ControllerTest {
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
 
-            willThrow(
-                            new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
+            willThrow(new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
                     .given(preQuestionService)
                     .deleteById(1L, 1L, 4L);
 
@@ -289,8 +321,7 @@ public class PreQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message")
-                            .value("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"));
+                    jsonPath("message").value("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"));
 
             // docs
             perform.andDo(document("pre-question/delete/exception/wrong-levellog"));
@@ -341,41 +372,5 @@ public class PreQuestionControllerTest extends ControllerTest {
             // docs
             perform.andDo(document("pre-question/delete/exception/not-my-pre-question"));
         }
-    }
-
-    private ResultActions requestPost(final String url, final String token, final Object request)
-            throws Exception {
-        final String content = objectMapper.writeValueAsString(request);
-
-        return mockMvc.perform(post(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
-                .andDo(print());
-    }
-
-    private ResultActions requestPut(final String url, final String token, final Object request)
-            throws Exception {
-        final String content = objectMapper.writeValueAsString(request);
-
-        return mockMvc.perform(put(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
-                .andDo(print());
-    }
-
-    private ResultActions requestGet(final String url, final String token) throws Exception {
-        return mockMvc.perform(get(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
-    }
-
-    private ResultActions requestDelete(final String url, final String token) throws Exception {
-        return mockMvc.perform(delete(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -227,7 +227,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
             BDDMockito.willThrow(new UnauthorizedException("자신의 사전 질문이 아닙니다."))
                     .given(preQuestionService)
-                    .findById( 1L, 4L);
+                    .findMy( 1L, 4L);
 
             // when
             final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);
@@ -251,7 +251,7 @@ public class PreQuestionControllerTest extends ControllerTest {
             BDDMockito.willThrow(
                             new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
                     .given(preQuestionService)
-                    .findById(1L, 4L);
+                    .findMy(1L, 4L);
 
             // when
             final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);
@@ -275,7 +275,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
             BDDMockito.willThrow(new PreQuestionNotFoundException("작성한 사전 질문이 존재하지 않습니다."))
                     .given(preQuestionService)
-                    .findById(1L, 4L);
+                    .findMy(1L, 4L);
 
             // when
             final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -215,22 +215,22 @@ public class PreQuestionControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("findById 메서드는")
-    class FindById {
+    @DisplayName("findMy 메서드는")
+    class FindMy {
 
         @Test
         @DisplayName("타인의 사전 질문을 조회하는 경우 예외를 던진다.")
-        void findById_FromNotMyPreQuestion_Exception() throws Exception {
+        void findMy_FromNotMyPreQuestion_Exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
 
             BDDMockito.willThrow(new UnauthorizedException("자신의 사전 질문이 아닙니다."))
                     .given(preQuestionService)
-                    .findById(1L, 1L, 4L);
+                    .findById( 1L, 4L);
 
             // when
-            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/1", TOKEN);
+            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);
 
             // then
             perform.andExpectAll(
@@ -243,7 +243,7 @@ public class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 조회하면 예외를 던진다.")
-        void findById_LevellogWrongId_Exception() throws Exception {
+        void findMy_LevellogWrongId_Exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -251,10 +251,10 @@ public class PreQuestionControllerTest extends ControllerTest {
             BDDMockito.willThrow(
                             new InvalidFieldException("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"))
                     .given(preQuestionService)
-                    .findById(1L, 1L, 4L);
+                    .findById(1L, 4L);
 
             // when
-            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/1", TOKEN);
+            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);
 
             // then
             perform.andExpectAll(
@@ -268,17 +268,17 @@ public class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("저장되어있지 않은 사전 질문을 조회하는 경우 예외를 던진다.")
-        void findById_PreQuestionNotFound_Exception() throws Exception {
+        void findMy_PreQuestionNotFound_Exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
 
             BDDMockito.willThrow(new PreQuestionNotFoundException("작성한 사전 질문이 존재하지 않습니다."))
                     .given(preQuestionService)
-                    .findById(1L, 1L, 4L);
+                    .findById(1L, 4L);
 
             // when
-            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/1", TOKEN);
+            final ResultActions perform = requestGet("/api/levellogs/1/pre-questions/my", TOKEN);
 
             // then
             perform.andExpectAll(

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -32,42 +32,6 @@ class PreQuestionControllerTest extends ControllerTest {
 
     private static final String TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
 
-    private ResultActions requestPost(final String url, final String token, final Object request)
-            throws Exception {
-        final String content = objectMapper.writeValueAsString(request);
-
-        return mockMvc.perform(post(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
-                .andDo(print());
-    }
-
-    private ResultActions requestPut(final String url, final String token, final Object request)
-            throws Exception {
-        final String content = objectMapper.writeValueAsString(request);
-
-        return mockMvc.perform(put(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
-                .andDo(print());
-    }
-
-    private ResultActions requestGet(final String url, final String token) throws Exception {
-        return mockMvc.perform(get(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
-    }
-
-    private ResultActions requestDelete(final String url, final String token) throws Exception {
-        return mockMvc.perform(delete(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
-    }
-
     @Nested
     @DisplayName("save 메서드는")
     class Save {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -238,7 +238,7 @@ public class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("권한이 없습니다."));
 
             // docs
-            perform.andDo(document("pre-question/findbyid/exception/not-my-pre-question"));
+            perform.andDo(document("pre-question/find-my/exception/not-my-pre-question"));
         }
 
         @Test
@@ -263,7 +263,7 @@ public class PreQuestionControllerTest extends ControllerTest {
                             .value("입력한 levellogId와 사전 질문의 levellogId가 다릅니다. 입력한 levellogId : 1"));
 
             // docs
-            perform.andDo(document("pre-question/findbyid/exception/wrong-levellog"));
+            perform.andDo(document("pre-question/find-my/exception/wrong-levellog"));
         }
 
         @Test
@@ -286,7 +286,7 @@ public class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("사전 질문이 존재하지 않습니다."));
 
             // docs
-            perform.andDo(document("pre-question/findbyid/exception/notfound"));
+            perform.andDo(document("pre-question/find-my/exception/notfound"));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,28 +42,6 @@ class TeamControllerTest extends ControllerTest {
     private void mockLogin() {
         given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
         given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
-    }
-
-    private ResultActions requestPost(final String url, final String token, final Object body) throws Exception {
-        final String json = objectMapper.writeValueAsString(body);
-
-        return mockMvc.perform(post(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .accept(MediaType.ALL)
-                        .content(json))
-                .andDo(print());
-    }
-
-    private ResultActions requestPut(final String url, final String token, final Object body) throws Exception {
-        final String json = objectMapper.writeValueAsString(body);
-
-        return mockMvc.perform(put(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .accept(MediaType.ALL)
-                        .content(json))
-                .andDo(print());
     }
 
     private void mockCreateTeam() {


### PR DESCRIPTION
## 구현 기능
- 특정 레벨로그에 내가 작성한 사전 질문 조회 기능
  - 레벨로그 아이디 & 토큰만 있으면 사전 질문 조회가 가능하다.

## 논의하고 싶은 내용
- 기존 사전 질문 상세 조회 API는 사전 질문 id가 필요하다. 하지만 프론트가 사전 질문 id를 몰라서 요청을 보내지 못했다.
  - 이 부분을 해결하기 위해서 새로운 API를 뚫었다.

## 공유하고 싶은 내용
- API url이 변경되었습니다. 확인 해주세요.

Close #196 
