### PR TITLE
refactor: 팀 목록 조회, 상세 조회 응답 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
@@ -10,4 +10,6 @@ public interface PreQuestionRepository extends JpaRepository<PreQuestion, Long> 
     Optional<PreQuestion> findByIdAndAuthor(Long id, Member author);
 
     Optional<PreQuestion> findByLevellogAndAuthor(Levellog levellog, Member author);
+
+    Optional<PreQuestion> findByLevellogAndAuthorId(Levellog levellog, Long memberId);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -15,6 +15,7 @@ import com.woowacourse.levellog.team.domain.TeamRepository;
 import com.woowacourse.levellog.team.dto.InterviewRoleDto;
 import com.woowacourse.levellog.team.dto.ParticipantDto;
 import com.woowacourse.levellog.team.dto.TeamAndRoleDto;
+import com.woowacourse.levellog.team.dto.TeamAndRolesDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
@@ -56,8 +57,13 @@ public class TeamService {
         return savedTeam.getId();
     }
 
-    public TeamsDto findAll(final Long memberId) {
-        return new TeamsDto(getTeamResponses(teamRepository.findAll(), memberId));
+    public TeamAndRolesDto findAll(final Long memberId) {
+        final List<Team> teams = teamRepository.findAll();
+        final List<TeamAndRoleDto> teamAndRoles = teams.stream()
+                .map(it -> findByTeamIdAndMemberId(it.getId(), memberId))
+                .collect(Collectors.toList());
+
+        return new TeamAndRolesDto(teamAndRoles);
     }
 
     public TeamsDto findAllByMemberId(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/ParticipantDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/ParticipantDto.java
@@ -17,13 +17,15 @@ public class ParticipantDto {
 
     private Long memberId;
     private Long levellogId;
+    private Long preQuestionId;
     private String nickname;
     private String profileUrl;
 
-    public static ParticipantDto from(final Participant participant, final Long levellogId) {
+    public static ParticipantDto from(final Participant participant, final Long levellogId, final Long preQuestionId) {
         return new ParticipantDto(
                 participant.getMember().getId(),
                 levellogId,
+                preQuestionId,
                 participant.getMember().getNickname(),
                 participant.getMember().getProfileUrl());
     }

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRolesDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRolesDto.java
@@ -1,0 +1,19 @@
+package com.woowacourse.levellog.team.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@ToString
+public class TeamAndRolesDto {
+
+    private List<TeamAndRoleDto> teams;
+}

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -5,9 +5,9 @@ import com.woowacourse.levellog.authentication.support.PublicAPI;
 import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.dto.InterviewRoleDto;
 import com.woowacourse.levellog.team.dto.TeamAndRoleDto;
+import com.woowacourse.levellog.team.dto.TeamAndRolesDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
-import com.woowacourse.levellog.team.dto.TeamsDto;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +37,8 @@ public class TeamController {
 
     @GetMapping
     @PublicAPI
-    public ResponseEntity<TeamsDto> findAll(@Authentic final Long memberId) {
-        final TeamsDto response = teamService.findAll(memberId);
+    public ResponseEntity<TeamAndRolesDto> findAll(@Authentic final Long memberId) {
+        final TeamAndRolesDto response = teamService.findAll(memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.common.exception.InvalidFieldException;
+import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.domain.InterviewRole;
@@ -15,10 +15,10 @@ import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.dto.InterviewRoleDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamAndRoleDto;
+import com.woowacourse.levellog.team.dto.TeamAndRolesDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
-import com.woowacourse.levellog.team.dto.TeamsDto;
 import com.woowacourse.levellog.team.exception.DuplicateParticipantsException;
 import com.woowacourse.levellog.team.exception.HostUnauthorizedException;
 import com.woowacourse.levellog.team.exception.ParticipantNotFoundException;
@@ -54,32 +54,32 @@ class TeamServiceTest extends ServiceTest {
         team2.close(LocalDateTime.now().plusDays(5));
 
         //when
-        final TeamsDto response = teamService.findAll(member1.getId());
+        final TeamAndRolesDto response = teamService.findAll(member1.getId());
 
         //then
         final List<String> actualTitles = response.getTeams()
                 .stream()
-                .map(TeamDto::getTitle)
+                .map(TeamAndRoleDto::getTitle)
                 .collect(Collectors.toList());
 
         final List<Long> actualHostIds = response.getTeams()
                 .stream()
-                .map(TeamDto::getHostId)
+                .map(TeamAndRoleDto::getHostId)
                 .collect(Collectors.toList());
 
         final List<Integer> actualParticipantSizes = response.getTeams()
                 .stream()
-                .map(TeamDto::getParticipants)
+                .map(TeamAndRoleDto::getParticipants)
                 .map(List::size)
                 .collect(Collectors.toList());
 
         final List<Boolean> actualCloseStatuses = response.getTeams()
                 .stream()
-                .map(TeamDto::getIsClosed)
+                .map(TeamAndRoleDto::getIsClosed)
                 .collect(Collectors.toList());
 
         final List<Boolean> actualIsParticipants = response.getTeams()
-                .stream().map(TeamDto::getIsParticipant)
+                .stream().map(TeamAndRoleDto::getIsParticipant)
                 .collect(Collectors.toList());
 
         assertAll(

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -73,4 +73,23 @@ class PreQuestionRepositoryTest {
         // then
         assertThat(actual).hasValue(preQuestion);
     }
+
+    @Test
+    @DisplayName("findByLevellogAndAuthorId 메서드는 Levellog와 AuthorId가 같은 사전 질문을 반환한다.")
+    void findByLevellogAndAuthorId() {
+        // given
+        final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
+        final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
+        final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+
+        final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
+        final String content = "로마가 쓴 사전 질문입니다.";
+        final PreQuestion preQuestion = preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+
+        // when
+        final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthorId(levellog, questioner.getId());
+
+        // then
+        assertThat(actual).hasValue(preQuestion);
+    }
 }


### PR DESCRIPTION
## 구현 기능
- 팀 목록 조회 시에도 TeamAndRoleDto 를 이용하도록 수정
- 팀 조회 시에도 preQuestionId 를 포함하여 반환하도록 수정

Close #197 
Close #202 
