### PR TITLE
fix: 사전 질문이 이미 등록되었을 때 사전 질문을 등록하는 경우 예외 처리 추가

### DIFF
--- a/backend/src/docs/asciidoc/prequestion.adoc
+++ b/backend/src/docs/asciidoc/prequestion.adoc
@@ -34,6 +34,11 @@ operation::pre-question/create/exception/not-participant[]
 
 operation::pre-question/create/exception/levellog-is-mine[]
 
+[[create-exception-already-exist]]
+==== 사전 질문이 이미 등록되었을 때 사전 질문을 등록하는 경우
+
+operation::pre-question/create/exception/already-exist[]
+
 [[find-my]]
 == 사전 질문 상세 조회
 

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
@@ -32,12 +32,11 @@ public class PreQuestionService {
     public Long save(final PreQuestionDto request, final Long levellogId, final Long memberId) {
         final Levellog levellog = getLevellog(levellogId);
         final Member questioner = getMember(memberId);
-        final PreQuestion preQuestion = request.toEntity(levellog, questioner);
 
         validatePreQuestionExistence(levellog, questioner);
         validateSameTeamMember(levellog.getTeam(), questioner);
 
-        return preQuestionRepository.save(preQuestion)
+        return preQuestionRepository.save(request.toEntity(levellog, questioner))
                 .getId();
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
@@ -12,4 +12,6 @@ public interface PreQuestionRepository extends JpaRepository<PreQuestion, Long> 
     Optional<PreQuestion> findByLevellogAndAuthor(Levellog levellog, Member author);
 
     Optional<PreQuestion> findByLevellogAndAuthorId(Levellog levellog, Long memberId);
+
+    boolean existsByLevellogAndAuthor(Levellog levellog, Member author);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionAlreadyExistException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionAlreadyExistException.java
@@ -1,0 +1,13 @@
+package com.woowacourse.levellog.prequestion.dto;
+
+import com.woowacourse.levellog.common.exception.LevellogException;
+import org.springframework.http.HttpStatus;
+
+public class PreQuestionAlreadyExistException extends LevellogException {
+
+    private static final String CLIENT_MESSAGE = "레벨로그의 사전 질문을 이미 작성했습니다.";
+
+    public PreQuestionAlreadyExistException(final String message) {
+        super(message, CLIENT_MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.levellog.domain.Levellog;
@@ -14,6 +16,7 @@ import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -91,5 +94,45 @@ class PreQuestionRepositoryTest {
 
         // then
         assertThat(actual).hasValue(preQuestion);
+    }
+
+    @Nested
+    @DisplayName("existsByLevellogAndAuthor 메서드는")
+    class ExistsByLevellogAndAuthorTest {
+
+        @Test
+        @DisplayName("levellogId와 authorId가 모두 일치하는 레벨로그가 존재하는 경우 true를 반환한다.")
+        void exists() {
+            // given
+            final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
+            final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
+            final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+
+            final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
+            final String content = "로마가 쓴 사전 질문입니다.";
+            preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+
+            // when
+            final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);
+
+            // then
+            assertTrue(actual);
+        }
+
+        @Test
+        @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하지 않는 경우 false를 반환한다.")
+        void notExists() {
+            // given
+            final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
+            final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
+            final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+            final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
+
+            // when
+            final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);
+
+            // then
+            assertFalse(actual);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -101,7 +101,7 @@ class PreQuestionRepositoryTest {
     class ExistsByLevellogAndAuthorTest {
 
         @Test
-        @DisplayName("levellogId와 authorId가 모두 일치하는 레벨로그가 존재하는 경우 true를 반환한다.")
+        @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하는 경우 true를 반환한다.")
         void exists() {
             // given
             final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
@@ -120,7 +120,7 @@ class PreQuestionRepositoryTest {
         }
 
         @Test
-        @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하지 않는 경우 false를 반환한다.")
+        @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하지 않는 경우 false를 반환한다.")
         void notExists() {
             // given
             final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));


### PR DESCRIPTION
## 구현 기능
- 사전 질문 중복 등록 시 예외 처리 추가

## 공유하고 싶은 내용
- 피드백, 레벨로그에서도 이미 작성했으면 `XXXAlreadyExistException`이 발생하여 사전 질문에서도 `PreQuestionAlreadyExistException`가 발생하도록 했습니다.
