### PR TITLE
fix: 팀 생성 성공시 라우팅 변경

### DIFF
--- a/frontend/src/hooks/useTeams.ts
+++ b/frontend/src/hooks/useTeams.ts
@@ -66,6 +66,7 @@ export const useTeam = () => {
       teamInfo.participants.ids = teamInfo.participants.ids.filter((id) => id !== loginUserId);
       await requestPostTeam({ teamInfo, accessToken });
       alert(MESSAGE.TEAM_CREATE);
+      navigate(ROUTES_PATH.HOME);
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
         const responseBody: AxiosResponse = err.response!;
@@ -127,7 +128,6 @@ export const useTeam = () => {
       },
     };
     await postTeam({ teamInfo });
-    navigate(ROUTES_PATH.HOME);
   };
 
   const onSubmitTeamEditForm = async () => {

--- a/frontend/src/pages/feedback/FeedbackAdd.tsx
+++ b/frontend/src/pages/feedback/FeedbackAdd.tsx
@@ -8,15 +8,12 @@ import useLevellog from 'hooks/useLevellog';
 import useRole from 'hooks/useRole';
 import { useTeam } from 'hooks/useTeams';
 
-import InterviewerImage from 'assets/images/group.png';
-import MicImage from 'assets/images/mic.png';
 import { ROUTES_PATH } from 'constants/constants';
 import { MESSAGE } from 'constants/constants';
 
 import Button from 'components/@commons/Button';
 import ContentHeader from 'components/@commons/ContentHeader';
 import FlexBox from 'components/@commons/FlexBox';
-import Image from 'components/@commons/Image';
 import FeedbackFormat from 'components/feedbacks/FeedbackFormat';
 import LevellogReport from 'components/levellogs/LevellogReport';
 import { InterviewTeamType } from 'types/team';
@@ -25,7 +22,7 @@ const FeedbackAdd = () => {
   const { feedbackRef, onClickFeedbackAddButton } = useFeedback();
   const { levellog, getLevellog } = useLevellog();
   const { teamId, levellogId } = useParams();
-  const { team, getTeam } = useTeam();
+  const { getTeam } = useTeam();
   const { loginUserRole, getLoginUserRole } = useRole();
   const navigate = useNavigate();
   const [writer, setWriter] = useState('');


### PR DESCRIPTION
## 구현 기능
- 팀 생성시 `Home`으로 이동한다
- 팀 생성 오류시 현재 페이지를 유지한다.

