### PR TITLE
feat: 피드백 생성, 수정 시 바뀐 정책 적용

### DIFF
--- a/backend/src/docs/asciidoc/feedback.adoc
+++ b/backend/src/docs/asciidoc/feedback.adoc
@@ -31,6 +31,12 @@ include::{snippets}/feedback/save/exception/team/http-response.adoc[]
 ==== 존재하지 않는 레벨로그에 대해 피드백을 작성하려는 경우
 operation::feedback/save/exception/levellog[]
 
+==== 인터뷰 시작 전에 피드백을 작성하려는 경우
+include::{snippets}/feedback/save/exception/before-interview/http-response.adoc[]
+
+==== 인터뷰 종료 후에 피드백을 작성하려는 경우
+include::{snippets}/feedback/save/exception/after-interview/http-response.adoc[]
+
 [[find-all]]
 == 피드백 목록 조회
 
@@ -64,6 +70,12 @@ include::{snippets}/feedback/update/exception/author/http-response.adoc[]
 
 ==== 존재하지 않는 피드백 정보로 피드백을 수정하려는 경우
 operation::feedback/update/exception/feedback[]
+
+==== 인터뷰 시작 전에 피드백을 수정하려는 경우
+include::{snippets}/feedback/update/exception/before-interview/http-response.adoc[]
+
+==== 인터뷰 종료 후에 피드백을 수정하려는 경우
+include::{snippets}/feedback/update/exception/after-interview/http-response.adoc[]
 
 [[delete]]
 == 피드백 삭제

--- a/backend/src/docs/asciidoc/feedback.adoc
+++ b/backend/src/docs/asciidoc/feedback.adoc
@@ -76,20 +76,3 @@ include::{snippets}/feedback/update/exception/before-interview/http-response.ado
 
 ==== 인터뷰 종료 후에 피드백을 수정하려는 경우
 include::{snippets}/feedback/update/exception/after-interview/http-response.adoc[]
-
-[[delete]]
-== 피드백 삭제
-
-[[delete-success]]
-=== 피드백 삭제 성공
-
-operation::feedback/delete[]
-
-[[delete-exception]]
-=== 피드백 삭제 예외
-
-==== 다른 사용자가 작성한 피드백을 삭제하려는 경우
-include::{snippets}/feedback/delete/exception/author/http-response.adoc[]
-
-==== 존재하지 않는 피드백 정보로 피드백을 삭제하려는 경우
-operation::feedback/delete/exception/feedback[]

--- a/backend/src/docs/asciidoc/feedback.adoc
+++ b/backend/src/docs/asciidoc/feedback.adoc
@@ -48,9 +48,6 @@ operation::feedback/find-all[]
 [[find-all-exception]]
 === 피드백 목록 조회 예외
 
-==== 존재하지 않는 멤버에 대한 피드백 목록 조회를 요청하는 경우
-include::{snippets}/feedback/find-all/exception/member/http-response.adoc[]
-
 ==== 존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하는 경우
 operation::feedback/find-all/exception/levellog[]
 

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -97,16 +97,6 @@ public class FeedbackService {
                 request.getFeedback().getEtc());
     }
 
-    @Transactional
-    public void deleteById(final Long feedbackId, final Long memberId) {
-        final Feedback feedback = getFeedback(feedbackId);
-        final Member member = getMember(memberId);
-
-        feedback.validateAuthor(member, "자신이 남긴 피드백만 삭제할 수 있습니다.");
-
-        feedbackRepository.deleteById(feedbackId);
-    }
-
     private void validateExistence(final Long levellogId, final Long fromMemberId) {
         if (feedbackRepository.existsByLevellogIdAndFromId(levellogId, fromMemberId)) {
             throw new FeedbackAlreadyExistException("피드백이 이미 존재합니다. levellogId : " + levellogId);

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -1,6 +1,5 @@
 package com.woowacourse.levellog.feedback.application;
 
-import com.woowacourse.levellog.common.domain.BaseEntity;
 import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.feedback.domain.Feedback;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
@@ -9,14 +8,12 @@ import com.woowacourse.levellog.feedback.dto.FeedbackWriteDto;
 import com.woowacourse.levellog.feedback.dto.FeedbacksDto;
 import com.woowacourse.levellog.feedback.exception.FeedbackAlreadyExistException;
 import com.woowacourse.levellog.feedback.exception.FeedbackNotFoundException;
-import com.woowacourse.levellog.feedback.exception.InvalidFeedbackException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
-import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.support.TimeStandard;
@@ -101,7 +98,7 @@ public class FeedbackService {
 
     private void validateFeedbackTime(final Team team) {
         team.validateAfterStartAt(timeStandard.now(), "인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다.");
-        team.validateAlreadyClosed();
+        team.validateBeforeClose();
     }
 
     private List<FeedbackDto> getFeedbackResponses(final List<Feedback> feedbacks) {

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -83,11 +83,10 @@ public class FeedbackService {
     }
 
     @Transactional
-    public void update(final FeedbackWriteDto request, final Long levellogId, final Long feedbackId,
-                       final Long memberId) {
+    public void update(final FeedbackWriteDto request, final Long feedbackId, final Long memberId) {
         final Feedback feedback = getFeedback(feedbackId);
         final Member member = getMember(memberId);
-        final Team team = getLevellog(levellogId).getTeam();
+        final Team team = feedback.getLevellog().getTeam();
 
         feedback.validateAuthor(member);
         validateFeedbackTime(team);

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/application/FeedbackService.java
@@ -43,13 +43,14 @@ public class FeedbackService {
 
         final Member member = getMember(fromMemberId);
         final Levellog levellog = getLevellog(levellogId);
-        final Team team = getLevellog(levellogId).getTeam();
+        final Team team = levellog.getTeam();
 
         levellog.validateSelfFeedback(member);
         validateTeamMember(team, member);
         validateFeedbackTime(team);
 
-        final Feedback feedback = request.getFeedback().toFeedback(member, levellog);
+        final Feedback feedback = request.getFeedback()
+                .toFeedback(member, levellog);
 
         return feedbackRepository.save(feedback)
                 .getId();
@@ -88,7 +89,7 @@ public class FeedbackService {
         final Member member = getMember(memberId);
         final Team team = getLevellog(levellogId).getTeam();
 
-        feedback.validateAuthor(member, "자신이 남긴 피드백만 수정할 수 있습니다.");
+        feedback.validateAuthor(member);
         validateFeedbackTime(team);
 
         feedback.updateFeedback(

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
@@ -77,10 +77,10 @@ public class Feedback extends BaseEntity {
         this.etc = etc;
     }
 
-    public void validateAuthor(final Member member, final String message) {
+    public void validateAuthor(final Member member) {
         if (!from.equals(member)) {
-            throw new InvalidFeedbackException(" [feedbackId : " + getId() + ", memberId : " + member.getId() + "]",
-                    message);
+            throw new InvalidFeedbackException("자신이 남긴 피드백만 수정할 수 있습니다.",
+                    " [feedbackId : " + getId() + ", memberId : " + member.getId() + "]");
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/exception/InvalidFeedbackException.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/exception/InvalidFeedbackException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidFeedbackException extends LevellogException {
 
-    public InvalidFeedbackException(final String exceptionInfo, final String clientMessage) {
-        super(clientMessage + exceptionInfo, clientMessage, HttpStatus.BAD_REQUEST);
+    public InvalidFeedbackException(final String clientMessage, final String exceptionInfoForDev) {
+        super(clientMessage + exceptionInfoForDev, clientMessage, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -43,7 +43,7 @@ public class FeedbackController {
                                        @RequestBody @Valid final FeedbackWriteDto request,
                                        @PathVariable final Long feedbackId,
                                        @Authentic final Long memberId) {
-        feedbackService.update(request, levellogId, feedbackId, memberId);
+        feedbackService.update(request, feedbackId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -44,7 +44,7 @@ public class FeedbackController {
                                        @RequestBody @Valid final FeedbackWriteDto request,
                                        @PathVariable final Long feedbackId,
                                        @Authentic final Long memberId) {
-        feedbackService.update(request, feedbackId, memberId);
+        feedbackService.update(request, levellogId, feedbackId, memberId);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/presentation/FeedbackController.java
@@ -8,7 +8,6 @@ import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,14 +44,6 @@ public class FeedbackController {
                                        @PathVariable final Long feedbackId,
                                        @Authentic final Long memberId) {
         feedbackService.update(request, levellogId, feedbackId, memberId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @DeleteMapping("/{feedbackId}")
-    public ResponseEntity<Void> delete(@PathVariable final Long levellogId,
-                                       @PathVariable final Long feedbackId,
-                                       @Authentic final Long memberId) {
-        feedbackService.deleteById(feedbackId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
@@ -119,7 +119,7 @@ public class Team extends BaseEntity {
 
     public void close(final LocalDateTime presentTime) {
         validateAfterStartAt(presentTime, "인터뷰가 시작되기 전에 종료할 수 없습니다.");
-        validateAlreadyClosed();
+        validateBeforeClose();
 
         isClosed = true;
     }
@@ -130,7 +130,7 @@ public class Team extends BaseEntity {
         }
     }
 
-    public void validateAlreadyClosed() {
+    public void validateBeforeClose() {
         if (isClosed) {
             throw new InterviewTimeException("이미 종료된 인터뷰입니다.", "[teamId : " + this.getId() + "]");
         }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
@@ -118,19 +118,19 @@ public class Team extends BaseEntity {
     }
 
     public void close(final LocalDateTime presentTime) {
-        validateInterviewStartTime(presentTime);
+        validateAfterStartAt(presentTime, "인터뷰가 시작되기 전에 종료할 수 없습니다.");
         validateAlreadyClosed();
 
         isClosed = true;
     }
 
-    private void validateInterviewStartTime(final LocalDateTime presentTime) {
+    public void validateAfterStartAt(final LocalDateTime presentTime, final String message) {
         if (presentTime.isBefore(startAt)) {
-            throw new InterviewTimeException("인터뷰가 시작되기 전에 종료할 수 없습니다.", "[teamId : " + this.getId() + "]");
+            throw new InterviewTimeException(message, "[teamId : " + this.getId() + ", startAt : " + startAt + "]");
         }
     }
 
-    private void validateAlreadyClosed() {
+    public void validateAlreadyClosed() {
         if (isClosed) {
             throw new InterviewTimeException("이미 종료된 인터뷰입니다.", "[teamId : " + this.getId() + "]");
         }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.levellog.acceptance;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
@@ -175,61 +174,5 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
                         "feedbacks.feedback.speak", contains("수정된 Speak 피드백"),
                         "feedbacks.feedback.etc", contains("수정된 Etc 피드백")
                 );
-    }
-
-    /*
-     * Scenario: 피드백 삭제
-     *   given: 피드백이 등록되어 있다.
-     *   given: 등록된 피드백을 조회한다.
-     *   when: 조회한 피드백을 삭제한다.
-     *   then: 204 No Content 상태 코드를 응답받는다.
-     */
-
-    @Test
-    @DisplayName("피드백 삭제")
-    void deleteFeedback() {
-        // given
-        final RestAssuredResponse hostLoginResponse = login("릭");
-        hostLoginResponse.getMemberId();
-        final String rickToken = hostLoginResponse.getToken();
-
-        final RestAssuredResponse romaLoginResponse = login("로마");
-        final Long roma_id = romaLoginResponse.getMemberId();
-        final String romaToken = romaLoginResponse.getToken();
-
-        final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
-                .getTeamId();
-
-        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그");
-        final String rick_levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
-                        levellogRequest)
-                .getLevellogId();
-
-        final FeedbackContentDto feedbackContentDto = new FeedbackContentDto("Spring에 대한 학습을 충분히 하였습니다.",
-                "아이 컨텍이 좋습니다.",
-                "윙크하지 마세요.");
-        final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-
-        final RestAssuredResponse saveResponse = RestAssuredTemplate
-                .post("/api/levellogs/" + rick_levellogId + "/feedbacks", romaToken, request);
-
-        final Long deleteId = Long.parseLong(saveResponse.getResponse()
-                .extract()
-                .header(HttpHeaders.LOCATION)
-                .split("/")[5]);
-
-        // when
-        final ValidatableResponse response = RestAssured.given(specification).log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
-                .filter(document("feedback/delete"))
-                .when()
-                .delete("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", rick_levellogId, deleteId)
-                .then().log().all();
-
-        // then
-        response.statusCode(HttpStatus.NO_CONTENT.value());
-        RestAssuredTemplate.get("/api/levellogs/" + rick_levellogId + "/feedbacks", romaToken)
-                .getResponse()
-                .body("feedbacks.id", not(contains(deleteId)));
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -339,6 +339,7 @@ class FeedbackServiceTest extends ServiceTest {
                     .hasMessageContaining("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다.");
         }
 
+        @Test
         @DisplayName("인터뷰 종료 후 피드백을 작성하면 예외를 던진다.")
         void save_alreadyClosed_exceptionThrown() {
             // given

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -17,6 +17,7 @@ import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.dto.MemberDto;
 import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.Team;
+import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -140,7 +141,7 @@ class FeedbackServiceTest extends ServiceTest {
             // when
             feedbackService.update(new FeedbackWriteDto(
                             new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
-                    feedback1.getId(), roma.getId());
+                    levellog.getId(), feedback1.getId(), roma.getId());
 
             // then
             final Feedback feedback = feedbackRepository.findById(feedback1.getId()).get();
@@ -167,9 +168,56 @@ class FeedbackServiceTest extends ServiceTest {
             assertThatThrownBy(() ->
                     feedbackService.update(new FeedbackWriteDto(
                                     new FeedbackContentDto("수정된 스터디", "수정된 말하기", "수정된 기타")),
-                            feedback1.getId(), alien.getId()))
+                            levellog.getId(), feedback1.getId(), alien.getId()))
                     .isInstanceOf(InvalidFeedbackException.class)
                     .hasMessageContaining("자신이 남긴 피드백만 수정할 수 있습니다.");
+        }
+
+        @Test
+        @DisplayName("인터뷰 시작 시간 이전에 피드백을 수정하려는 경우 예외가 발생한다.")
+        void update_beforeStartAt_exceptionThrown() {
+            // given
+            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
+            final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(10), "profile.img", 1));
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+
+            final Feedback feedback1 = feedbackRepository.save(
+                    new Feedback(roma, eve, levellog, "로마가 이브에게 스터디", "로마가 이브에게 말하기", "로마가 이브에게 기타"));
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.update(new FeedbackWriteDto(
+                            new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
+                    levellog.getId(), feedback1.getId(), roma.getId()))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("인터뷰 종료 이후에 피드백을 수정하려는 경우 예외가 발생한다.")
+        void update_alreadyClosed_exceptionThrown() {
+            // given
+            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
+            final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
+
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "트랙룸", startAt, "profile.img", 1));
+
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+
+            final Feedback feedback1 = feedbackRepository.save(
+                    new Feedback(roma, eve, levellog, "로마가 이브에게 스터디", "로마가 이브에게 말하기", "로마가 이브에게 기타"));
+
+            team.close(startAt.plusDays(1));
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.update(new FeedbackWriteDto(
+                            new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
+                    levellog.getId(), feedback1.getId(), roma.getId()))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("이미 종료된 인터뷰입니다.");
         }
     }
 
@@ -313,6 +361,56 @@ class FeedbackServiceTest extends ServiceTest {
                     levellog.getId(), roma.getId()))
                     .isInstanceOf(InvalidFeedbackException.class)
                     .hasMessageContaining("같은 팀에 속한 멤버만 피드백을 작성할 수 있습니다.");
+        }
+
+        @Test
+        @DisplayName("인터뷰 시작 전 피드백을 작성하면 예외를 던진다.")
+        void save_beforeStartAt_exceptionThrown() {
+            // given
+            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
+            final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
+
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(10), "progile.img", 1));
+            participantRepository.save(new Participant(team, eve, true));
+            participantRepository.save(new Participant(team, roma, false));
+
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+
+            final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
+                    "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
+            final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
+
+            // when, then
+            assertThatThrownBy(() -> feedbackService.save(request, levellog.getId(), roma.getId()))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다.");
+        }
+
+        @DisplayName("인터뷰 종료 후 피드백을 작성하면 예외를 던진다.")
+        void save_alreadyClosed_exceptionThrown() {
+            // given
+            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
+            final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
+
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(10);
+            final Team team = teamRepository.save(
+                    new Team("잠실 네오조", "트랙룸", startAt, "progile.img", 1));
+            participantRepository.save(new Participant(team, eve, true));
+            participantRepository.save(new Participant(team, roma, false));
+
+            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
+
+            team.close(startAt.plusDays(1));
+
+            final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
+                    "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
+            final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
+
+            // when, then
+            assertThatThrownBy(() -> feedbackService.save(request, levellog.getId(), roma.getId()))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("이미 종료된 인터뷰입니다.");
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -222,54 +222,6 @@ class FeedbackServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("delete 메서드는")
-    class delete {
-
-        @Test
-        @DisplayName("자신이 남긴 피드백을 삭제한다.")
-        void delete_fromEqualsMe_success() {
-            // given
-            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
-            final Member alien = memberRepository.save(new Member("알린", 3333, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(3), "progile.img", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
-
-            final Feedback alienFeedback = feedbackRepository.save(
-                    new Feedback(alien, eve, levellog, "알린이 이브에게 스터디", "알린이 이브에게 말하기", "알린이 이브에게 기타"));
-            final Long deleteId = alienFeedback.getId();
-
-            // when
-            feedbackService.deleteById(deleteId, alien.getId());
-
-            // then
-            final Optional<Feedback> deletedFeedback = feedbackRepository.findById(deleteId);
-            assertThat(deletedFeedback).isEmpty();
-        }
-
-        @Test
-        @DisplayName("피드백에 관련이 없는 멤버가 삭제하면 예외를 던진다.")
-        void delete_otherMember_exceptionThrown() {
-            // given
-            final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
-            final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
-            final Member alien = memberRepository.save(new Member("알린", 3333, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(3), "progile.img", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(eve, team, "이브의 레벨로그"));
-
-            final Feedback alienFeedback = feedbackRepository.save(
-                    new Feedback(alien, eve, levellog, "알린이 이브에게 스터디", "알린이 이브에게 말하기", "알린이 이브에게 기타"));
-            final Long deleteId = alienFeedback.getId();
-
-            // when, then
-            assertThatThrownBy(() -> feedbackService.deleteById(deleteId, roma.getId()))
-                    .isInstanceOf(InvalidFeedbackException.class)
-                    .hasMessageContaining("자신이 남긴 피드백만 삭제할 수 있습니다.");
-        }
-    }
-
-    @Nested
     @DisplayName("save 메서드는")
     class save {
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -141,7 +141,7 @@ class FeedbackServiceTest extends ServiceTest {
             // when
             feedbackService.update(new FeedbackWriteDto(
                             new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
-                    levellog.getId(), feedback1.getId(), roma.getId());
+                    feedback1.getId(), roma.getId());
 
             // then
             final Feedback feedback = feedbackRepository.findById(feedback1.getId()).get();
@@ -168,7 +168,7 @@ class FeedbackServiceTest extends ServiceTest {
             assertThatThrownBy(() ->
                     feedbackService.update(new FeedbackWriteDto(
                                     new FeedbackContentDto("수정된 스터디", "수정된 말하기", "수정된 기타")),
-                            levellog.getId(), feedback1.getId(), alien.getId()))
+                            feedback1.getId(), alien.getId()))
                     .isInstanceOf(InvalidFeedbackException.class)
                     .hasMessageContaining("자신이 남긴 피드백만 수정할 수 있습니다.");
         }
@@ -189,7 +189,7 @@ class FeedbackServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> feedbackService.update(new FeedbackWriteDto(
                             new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
-                    levellog.getId(), feedback1.getId(), roma.getId()))
+                    feedback1.getId(), roma.getId()))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContaining("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다.");
         }
@@ -215,7 +215,7 @@ class FeedbackServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> feedbackService.update(new FeedbackWriteDto(
                             new FeedbackContentDto("수정된 로마가 이브에게 스터디", "수정된 로마가 이브에게 말하기", "수정된 로마가 이브에게 기타")),
-                    levellog.getId(), feedback1.getId(), roma.getId()))
+                    feedback1.getId(), roma.getId()))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContaining("이미 종료된 인터뷰입니다.");
         }
@@ -346,7 +346,7 @@ class FeedbackServiceTest extends ServiceTest {
             final Member eve = memberRepository.save(new Member("이브", 1111, "eve.img"));
             final Member roma = memberRepository.save(new Member("로마", 2222, "roma.img"));
 
-            final LocalDateTime startAt = LocalDateTime.now().plusDays(10);
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "트랙룸", startAt, "progile.img", 1));
             participantRepository.save(new Participant(team, eve, true));

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -311,7 +311,7 @@ class FeedbackServiceTest extends ServiceTest {
             assertThatThrownBy(() -> feedbackService.save(new FeedbackWriteDto(
                             new FeedbackContentDto("로마 스터디", "로마 말하기", "로마 기타")),
                     levellog.getId(), roma.getId()))
-                    .isInstanceOf(InvalidFeedbackException.class)
+                    .isInstanceOf(UnauthorizedException.class)
                     .hasMessageContaining("같은 팀에 속한 멤버만 피드백을 작성할 수 있습니다.");
         }
 

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -395,12 +395,12 @@ class TeamTest {
     }
 
     @Nested
-    @DisplayName("validateBeforeStartAt 메서드는")
-    class ValidateBeforeStartAt {
+    @DisplayName("validateAfterStartAt 메서드는")
+    class ValidateAfterStartAt {
 
         @Test
         @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이전이면 예외가 발생한다.")
-        void validate_beforeStartAt_thrownException() {
+        void validate_afterStartAt_thrownException() {
             // given
             final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -393,4 +393,42 @@ class TeamTest {
                     .hasMessageContaining("인터뷰가 시작되기 전에 종료할 수 없습니다.");
         }
     }
+
+    @Nested
+    @DisplayName("validateBeforeStartAt 메서드는")
+    class ValidateBeforeStartAt {
+
+        @Test
+        @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이전이면 예외가 발생한다.")
+        void validate_beforeStartAt_thrownException() {
+            // given
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
+            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
+
+            // when & then
+            assertThatThrownBy(() -> team.validateAfterStartAt(startAt.minusDays(1), "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다."))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("validateAlreadyClosed 메서드는")
+    class ValidateAlreadyClosed {
+
+        @Test
+        @DisplayName("팀 인터뷰가 이미 종료된 상태면 예외를 발생시킨다.")
+        void validate_alreadyClosed_thrownException() {
+            // given
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
+            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
+
+            team.close(startAt.plusDays(1));
+
+            // when & then
+            assertThatThrownBy(team::validateAlreadyClosed)
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("이미 종료된 인터뷰입니다.");
+        }
+    }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -413,12 +413,12 @@ class TeamTest {
     }
 
     @Nested
-    @DisplayName("validateAlreadyClosed 메서드는")
-    class ValidateAlreadyClosed {
+    @DisplayName("validateBeforeClose 메서드는")
+    class ValidateBeforeClose {
 
         @Test
         @DisplayName("팀 인터뷰가 이미 종료된 상태면 예외를 발생시킨다.")
-        void validate_alreadyClosed_thrownException() {
+        void validate_BeforeClose_thrownException() {
             // given
             final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
@@ -426,7 +426,7 @@ class TeamTest {
             team.close(startAt.plusDays(1));
 
             // when & then
-            assertThatThrownBy(team::validateAlreadyClosed)
+            assertThatThrownBy(team::validateBeforeClose)
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContaining("이미 종료된 인터뷰입니다.");
         }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -339,31 +339,6 @@ class FeedbackControllerTest extends ControllerTest {
     class FindAll {
 
         @Test
-        @DisplayName("존재하지 않는 멤버에 대한 피드백 목록 조회를 요청하면 예외가 발생한다.")
-        void findAll_notFoundMember_exceptionThrown() throws Exception {
-            // given
-            given(jwtTokenProvider.getPayload(token)).willReturn("1");
-            given(jwtTokenProvider.validateToken(token)).willReturn(true);
-
-            final Long levellogId = 1L;
-
-            given(feedbackService.findAll(levellogId, memberId))
-                    .willThrow(new MemberNotFoundException("멤버가 존재하지 않습니다."));
-
-            // when
-            final ResultActions perform = requestGet("/api/levellogs/" + levellogId + "/feedbacks", token);
-
-            // then
-            perform.andExpectAll(
-                    status().isNotFound(),
-                    jsonPath("message").value("멤버가 존재하지 않습니다.")
-            );
-
-            // docs
-            perform.andDo(document("feedback/find-all/exception/member"));
-        }
-
-        @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하면 예외가 발생한다.")
         void findAll_notFoundLevellog_exceptionThrown() throws Exception {
             // given

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -2,9 +2,7 @@ package com.woowacourse.levellog.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -367,66 +365,6 @@ class FeedbackControllerTest extends ControllerTest {
 
             // docs
             perform.andDo(document("feedback/update/exception/after-interview"));
-        }
-    }
-
-    @Nested
-    @DisplayName("delete 메서드는")
-    class delete {
-
-        @Test
-        @DisplayName("피드백에 관련이 없는 멤버가 삭제를 요청하면 예외가 발생한다.")
-        void delete_otherMember_exceptionThrown() throws Exception {
-            // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
-            given(jwtTokenProvider.getPayload(token)).willReturn("1");
-            given(jwtTokenProvider.validateToken(token)).willReturn(true);
-
-            final Long levellogId = 1L;
-            final Long feedbackId = 2L;
-            doThrow(new InvalidFeedbackException(
-                    " [feedbackId : " + feedbackId + ", memberId : " + memberId + "]", "자신이 남긴 피드백만 삭제할 수 있습니다."))
-                    .when(feedbackService)
-                    .deleteById(feedbackId, memberId);
-
-            // when
-            final ResultActions perform = mockMvc.perform(
-                            delete("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                    .andDo(print());
-
-            // then
-            perform.andExpect(status().isBadRequest());
-
-            // docs
-            perform.andDo(document("feedback/delete/exception/author"));
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 피드백 정보로 피드백 삭제를 요청하면 예외가 발생한다.")
-        void delete_notFoundFeedback_exceptionThrown() throws Exception {
-            // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
-            given(jwtTokenProvider.getPayload(token)).willReturn("1");
-            given(jwtTokenProvider.validateToken(token)).willReturn(true);
-
-            final Long levellogId = 1L;
-            final Long feedbackId = 2000000L;
-            doThrow(new FeedbackNotFoundException("존재하지 않는 피드백"))
-                    .when(feedbackService)
-                    .deleteById(feedbackId, memberId);
-
-            // when
-            final ResultActions perform = mockMvc.perform(
-                            delete("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                    .andDo(print());
-
-            // then
-            perform.andExpect(status().isNotFound());
-
-            // docs
-            perform.andDo(document("feedback/delete/exception/feedback"));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -186,7 +186,7 @@ class FeedbackControllerTest extends ControllerTest {
             doThrow(new InvalidFeedbackException(
                     " [feedbackId : " + feedbackId + ", memberId : " + memberId + "]", "자신이 남긴 피드백만 수정할 수 있습니다."))
                     .when(feedbackService)
-                    .update(request, feedbackId, memberId);
+                    .update(request, levellogId, feedbackId, memberId);
 
             // when
             final ResultActions perform = mockMvc.perform(
@@ -221,7 +221,7 @@ class FeedbackControllerTest extends ControllerTest {
 
             doThrow(new FeedbackNotFoundException("존재하지 않는 피드백"))
                     .when(feedbackService)
-                    .update(request, feedbackId, memberId);
+                    .update(request, levellogId, feedbackId, memberId);
 
             // when
             final ResultActions perform = mockMvc.perform(

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -28,12 +28,12 @@ import org.springframework.test.web.servlet.ResultActions;
 @DisplayName("FeedbackController의")
 class FeedbackControllerTest extends ControllerTest {
 
-    private final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
+    private static final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
     private final Long memberId = 1L;
 
     @Nested
     @DisplayName("save 메서드는")
-    class save {
+    class Save {
 
         @Test
         @DisplayName("레벨로그에 내가 작성한 피드백이 이미 존재하는 경우 새로운 피드백을 작성하면 예외를 던진다.")
@@ -50,14 +50,8 @@ class FeedbackControllerTest extends ControllerTest {
             given(feedbackService.save(request, levellogId, memberId))
                     .willThrow(new FeedbackAlreadyExistException("피드백이 이미 존재합니다."));
 
-            final String requestContent = objectMapper.writeValueAsString(request);
-
             // when
-            final ResultActions perform = mockMvc.perform(post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -82,14 +76,8 @@ class FeedbackControllerTest extends ControllerTest {
                     .willThrow(new InvalidFeedbackException(" [levellogId : " + levellogId + "]",
                             "자기 자신에게 피드백을 할 수 없습니다."));
 
-            final String requestContent = objectMapper.writeValueAsString(request);
-
             // when
-            final ResultActions perform = mockMvc.perform(post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -114,14 +102,8 @@ class FeedbackControllerTest extends ControllerTest {
                     .willThrow(new InvalidFeedbackException(
                             " [memberId :" + memberId + "]", "같은 팀에 속한 멤버만 피드백을 작성할 수 있습니다."));
 
-            final String requestContent = objectMapper.writeValueAsString(request);
-
             // when
-            final ResultActions perform = mockMvc.perform(post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -142,24 +124,18 @@ class FeedbackControllerTest extends ControllerTest {
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
             final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-            final String requestContent = objectMapper.writeValueAsString(request);
 
             given(feedbackService.save(request, levellogId, memberId))
                     .willThrow(new LevellogNotFoundException("존재하지 않는 레벨로그"));
 
             // when
-            final ResultActions performCreate = mockMvc.perform(
-                            post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
-            performCreate.andExpect(status().isNotFound());
+            perform.andExpect(status().isNotFound());
 
             // docs
-            performCreate.andDo(document("feedback/save/exception/levellog"));
+            perform.andDo(document("feedback/save/exception/levellog"));
         }
 
         @Test
@@ -177,14 +153,8 @@ class FeedbackControllerTest extends ControllerTest {
             given(feedbackService.save(request, levellogId, memberId))
                     .willThrow(new InterviewTimeException("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다."));
 
-            final String requestContent = objectMapper.writeValueAsString(request);
-
             // when
-            final ResultActions perform = mockMvc.perform(post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -208,14 +178,8 @@ class FeedbackControllerTest extends ControllerTest {
             given(feedbackService.save(request, levellogId, memberId))
                     .willThrow(new InterviewTimeException("이미 종료된 인터뷰입니다."));
 
-            final String requestContent = objectMapper.writeValueAsString(request);
-
             // when
-            final ResultActions perform = mockMvc.perform(post("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPost("/api/levellogs/" + levellogId + "/feedbacks", token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -227,7 +191,7 @@ class FeedbackControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("update 메서드는")
-    class update {
+    class Update {
 
         @Test
         @DisplayName("피드백에 관련이 없는 멤버가 피드백을 수정하면 예외가 발생한다.")
@@ -242,7 +206,6 @@ class FeedbackControllerTest extends ControllerTest {
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
             final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-            final String requestContent = objectMapper.writeValueAsString(request);
 
             willThrow(new InvalidFeedbackException(
                     " [feedbackId : " + feedbackId + ", memberId : " + memberId + "]", "자신이 남긴 피드백만 수정할 수 있습니다."))
@@ -250,12 +213,8 @@ class FeedbackControllerTest extends ControllerTest {
                     .update(request, levellogId, feedbackId, memberId);
 
             // when
-            final ResultActions perform = mockMvc.perform(
-                            put("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPut(
+                    "/api/levellogs/" + levellogId + "/feedbacks/" + feedbackId, token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -277,19 +236,14 @@ class FeedbackControllerTest extends ControllerTest {
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
             final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-            final String requestContent = objectMapper.writeValueAsString(request);
 
             willThrow(new FeedbackNotFoundException("존재하지 않는 피드백"))
                     .given(feedbackService)
                     .update(request, levellogId, feedbackId, memberId);
 
             // when
-            final ResultActions perform = mockMvc.perform(
-                            put("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPut(
+                    "/api/levellogs/" + levellogId + "/feedbacks/" + feedbackId, token, request);
 
             // then
             perform.andExpect(status().isNotFound());
@@ -302,7 +256,6 @@ class FeedbackControllerTest extends ControllerTest {
         @DisplayName("인터뷰 시작 전에 피드백을 수정하면 예외가 발생한다.")
         void update_beforeStartAt_exceptionThrown() throws Exception {
             // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
 
@@ -312,20 +265,14 @@ class FeedbackControllerTest extends ControllerTest {
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
             final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-            final String requestContent = objectMapper.writeValueAsString(request);
 
             willThrow(new InterviewTimeException("인터뷰가 시작되기 전에 피드백을 작성 또는 수정할 수 없습니다."))
                     .given(feedbackService)
                     .update(request, levellogId, feedbackId, memberId);
 
             // when
-            final ResultActions perform = mockMvc.perform(
-                            put("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(requestContent))
-                    .andDo(print());
-
+            final ResultActions perform = requestPut(
+                    "/api/levellogs/" + levellogId + "/feedbacks/" + feedbackId, token, request);
             // then
             perform.andExpect(status().isBadRequest());
 
@@ -346,19 +293,14 @@ class FeedbackControllerTest extends ControllerTest {
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
             final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
-            final String requestContent = objectMapper.writeValueAsString(request);
 
             willThrow(new InterviewTimeException("이미 종료된 인터뷰입니다."))
                     .given(feedbackService)
                     .update(request, levellogId, feedbackId, memberId);
 
             // when
-            final ResultActions perform = mockMvc.perform(
-                            put("/api/levellogs/{levellogId}/feedbacks/{feedbackId}", levellogId, feedbackId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(requestContent))
-                    .andDo(print());
+            final ResultActions perform = requestPut(
+                    "/api/levellogs/" + levellogId + "/feedbacks/" + feedbackId, token, request);
 
             // then
             perform.andExpect(status().isBadRequest());
@@ -370,26 +312,22 @@ class FeedbackControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("findAll 메서드는")
-    class findAll {
+    class FindAll {
 
         @Test
         @DisplayName("존재하지 않는 멤버에 대한 피드백 목록 조회를 요청하면 예외가 발생한다.")
         void findAll_notFoundMember_exceptionThrown() throws Exception {
             // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
 
             final Long levellogId = 1L;
 
-            given(feedbackService.findAll(1L, 1L))
+            given(feedbackService.findAll(levellogId, memberId))
                     .willThrow(new MemberNotFoundException("존재하지 않는 멤버"));
 
             // when
-            final ResultActions perform = mockMvc.perform(
-                            get("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                    .andDo(print());
+            final ResultActions perform = requestGet("/api/levellogs/" + levellogId + "/feedbacks", token);
 
             // then
             perform.andExpect(status().isNotFound());
@@ -402,20 +340,16 @@ class FeedbackControllerTest extends ControllerTest {
         @DisplayName("존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하면 예외가 발생한다.")
         void findAll_notFoundLevellog_exceptionThrown() throws Exception {
             // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
 
             final Long levellogId = 200000L;
 
-            given(feedbackService.findAll(levellogId, 1L))
+            given(feedbackService.findAll(levellogId, memberId))
                     .willThrow(new LevellogNotFoundException("존재하지 않는 레벨로그"));
 
             // when
-            final ResultActions performFindAll = mockMvc.perform(
-                            get("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                    .andDo(print());
+            final ResultActions performFindAll = requestGet("/api/levellogs/" + levellogId + "/feedbacks", token);
 
             // then
             performFindAll.andExpect(status().isNotFound());
@@ -428,18 +362,16 @@ class FeedbackControllerTest extends ControllerTest {
         @DisplayName("속하지 않은 팀의 피드백 조회를 요청하면 예외가 발생한다.")
         void findAll_notMyTeam_exception() throws Exception {
             // given
-            final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
-            final Long levellogId = 1L;
-
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
-            given(feedbackService.findAll(levellogId, 1L))
+
+            final Long levellogId = 1L;
+
+            given(feedbackService.findAll(levellogId, memberId))
                     .willThrow(new UnauthorizedException("권한이 없습니다."));
 
             // when
-            final ResultActions perform = mockMvc.perform(get("/api/levellogs/{levellogId}/feedbacks", levellogId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
-                    .andDo(print());
+            final ResultActions perform = requestGet("/api/levellogs/" + levellogId + "/feedbacks", token);
 
             // then
             perform.andExpect(status().isUnauthorized());


### PR DESCRIPTION
## 구현 기능
- 인터뷰 시작 도중에만 피드백을 작성, 수정할 수 있도록 검증 로직 추가
- 피드백 삭제 API 삭제

## 논의하고 싶은 내용
- Team 도메인 검증 로직
- 시간 의존 테스트 코드를 더 깔끔하게 작성하기 위한 TimeStandard 리팩토링

Close #238 