### PR TITLE
feat: 레벨로그 상세 조회 시 body에 작성자의 정보도 제공하도록 수정한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -5,6 +5,7 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.levellog.dto.LevellogDto;
 import com.woowacourse.levellog.levellog.dto.LevellogWithIdDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.levellog.dto.LevellogsDto;
 import com.woowacourse.levellog.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
@@ -30,7 +31,7 @@ public class LevellogService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Long save(final LevellogDto request, final Long authorId, final Long teamId) {
+    public Long save(final LevellogWriteDto request, final Long authorId, final Long teamId) {
         final Team team = getTeam(teamId);
         final Member author = getMember(authorId);
         validateLevellogExistence(authorId, teamId);
@@ -59,7 +60,7 @@ public class LevellogService {
     }
 
     @Transactional
-    public void update(final LevellogDto request, final Long levellogId, final Long memberId) {
+    public void update(final LevellogWriteDto request, final Long levellogId, final Long memberId) {
         final Levellog levellog = getById(levellogId);
         final Member member = getMember(memberId);
 

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/dto/LevellogDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/dto/LevellogDto.java
@@ -1,9 +1,7 @@
 package com.woowacourse.levellog.levellog.dto;
 
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.team.domain.Team;
-import javax.validation.constraints.NotBlank;
+import com.woowacourse.levellog.member.dto.MemberDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -16,18 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LevellogDto {
 
-    @NotBlank
+    private MemberDto author;
     private String content;
 
-    public static LevellogDto from(final String content) {
-        return new LevellogDto(content);
-    }
-
     public static LevellogDto from(final Levellog levellog) {
-        return new LevellogDto(levellog.getContent());
-    }
-
-    public Levellog toLevellog(final Member author, final Team team) {
-        return Levellog.of(author, team, content);
+        return new LevellogDto(MemberDto.from(levellog.getAuthor()), levellog.getContent());
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/dto/LevellogWriteDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/dto/LevellogWriteDto.java
@@ -1,0 +1,29 @@
+package com.woowacourse.levellog.levellog.dto;
+
+import com.woowacourse.levellog.levellog.domain.Levellog;
+import com.woowacourse.levellog.member.domain.Member;
+import com.woowacourse.levellog.team.domain.Team;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LevellogWriteDto {
+
+    @NotBlank
+    private String content;
+
+    public static LevellogWriteDto from(final String content) {
+        return new LevellogWriteDto(content);
+    }
+
+    public Levellog toLevellog(final Member author, final Team team) {
+        return Levellog.of(author, team, content);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
@@ -45,8 +45,7 @@ public class LevellogController {
     public ResponseEntity<Void> update(@PathVariable final Long teamId,
                                        @PathVariable final Long levellogId,
                                        @Authentic final Long memberId,
-                                       @RequestBody @Valid final LevellogWriteDto request
-    ) {
+                                       @RequestBody @Valid final LevellogWriteDto request) {
         levellogService.update(request, levellogId, memberId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
@@ -4,6 +4,7 @@ import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.PublicAPI;
 import com.woowacourse.levellog.levellog.application.LevellogService;
 import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ public class LevellogController {
 
     @PostMapping
     public ResponseEntity<Void> save(@PathVariable final Long teamId,
-                                     @RequestBody @Valid final LevellogDto request,
+                                     @RequestBody @Valid final LevellogWriteDto request,
                                      @Authentic final Long authorId) {
         final Long id = levellogService.save(request, authorId, teamId);
         return ResponseEntity.created(URI.create("/api/teams/" + teamId + "/levellogs/" + id)).build();
@@ -44,7 +45,7 @@ public class LevellogController {
     public ResponseEntity<Void> update(@PathVariable final Long teamId,
                                        @PathVariable final Long levellogId,
                                        @Authentic final Long memberId,
-                                       @RequestBody @Valid final LevellogDto request
+                                       @RequestBody @Valid final LevellogWriteDto request
     ) {
         levellogService.update(request, levellogId, memberId);
         return ResponseEntity.noContent().build();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -9,7 +9,7 @@ import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackWriteDto;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.fixture.RestAssuredTemplate;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +40,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그");
         final String levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
                         levellogRequest)
                 .getLevellogId();
@@ -85,7 +85,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그");
         final String levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
                         levellogRequest)
                 .getLevellogId();
@@ -135,7 +135,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
 
         final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id).getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그");
         final String rick_levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
                         levellogRequest)
                 .getLevellogId();
@@ -200,7 +200,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final String teamId = requestCreateTeam("릭 and 로마", rickToken, roma_id)
                 .getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그");
         final String rick_levellogId = RestAssuredTemplate.post("/api/teams/" + teamId + "/levellogs", rickToken,
                         levellogRequest)
                 .getLevellogId();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
@@ -9,7 +9,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionDto;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
@@ -46,7 +46,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String pepperLevellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -89,7 +89,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String pepperLevellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -133,7 +133,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String pepperLevellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -181,7 +181,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String pepperLevellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -82,6 +82,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.OK.value())
+                .body("author.id", equalTo(loginResponse1.getMemberId().intValue()))
                 .body("content", equalTo("Spring과 React를 학습했습니다."));
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
@@ -36,7 +36,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
-        final LevellogDto request = LevellogDto.from("Spring과 React를 학습했습니다.");
+        final LevellogWriteDto request = LevellogWriteDto.from("Spring과 React를 학습했습니다.");
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -68,7 +68,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
-        final LevellogDto request = LevellogDto.from("Spring과 React를 학습했습니다.");
+        final LevellogWriteDto request = LevellogWriteDto.from("Spring과 React를 학습했습니다.");
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(), request)
                 .getLevellogId();
 
@@ -101,10 +101,10 @@ class LevellogAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(),
-                LevellogDto.from("Spring과 React를 학습했습니다.")).getLevellogId();
+                LevellogWriteDto.from("Spring과 React를 학습했습니다.")).getLevellogId();
 
         final String updateContent = "update content";
-        final LevellogDto request = LevellogDto.from(updateContent);
+        final LevellogWriteDto request = LevellogWriteDto.from(updateContent);
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -138,7 +138,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(),
-                LevellogDto.from("Spring과 React를 학습했습니다.")).getLevellogId();
+                LevellogWriteDto.from("Spring과 React를 학습했습니다.")).getLevellogId();
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -9,7 +9,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import com.woowacourse.levellog.feedback.dto.FeedbackContentDto;
 import com.woowacourse.levellog.feedback.dto.FeedbackWriteDto;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.member.dto.NicknameUpdateDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
@@ -111,7 +111,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final String team2Id = requestCreateTeam("릭,로마,페퍼", romaToken, rick_id, pepper_id).getTeamId();
 
         // 레벨로그 생성
-        final LevellogDto levellogRequest = LevellogDto.from("레벨로그1,2 내용");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("레벨로그1,2 내용");
         final String levellogId1 = post("/api/teams/" + team1Id + "/levellogs", rickToken,
                 levellogRequest)
                 .getLevellogId();
@@ -173,8 +173,8 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final String teamId2 = post("/api/teams", hostToken, teamCreateDto2).getTeamId();
 
         // 레벨로그 생성
-        final LevellogDto levellogRequest1 = LevellogDto.from("레벨로그1 내용");
-        final LevellogDto levellogRequest2 = LevellogDto.from("레벨로그2 내용");
+        final LevellogWriteDto levellogRequest1 = LevellogWriteDto.from("레벨로그1 내용");
+        final LevellogWriteDto levellogRequest2 = LevellogWriteDto.from("레벨로그2 내용");
 
         post("/api/teams/" + teamId1 + "/levellogs", romaToken, levellogRequest1).getLevellogId();
         post("/api/teams/" + teamId2 + "/levellogs", romaToken, levellogRequest2).getLevellogId();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
@@ -43,7 +43,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -84,7 +84,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -131,7 +131,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 
@@ -173,7 +173,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
-        final LevellogDto levellogRequest = LevellogDto.from("페퍼의 레벨로그");
+        final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", pepperToken,
                 levellogRequest).getLevellogId();
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.levellog.common.exception.InvalidFieldException;
 import com.woowacourse.levellog.common.exception.UnauthorizedException;
@@ -141,7 +142,10 @@ class LevellogServiceTest extends ServiceTest {
             final LevellogDto response = levellogService.findById(levellog.getId());
 
             // then
-            assertThat(response.getContent()).isEqualTo(content);
+            assertAll(
+                    () -> assertThat(response.getAuthor().getId()).isEqualTo(member.getId()),
+                    () -> assertThat(response.getContent()).isEqualTo(content)
+            );
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -7,6 +7,7 @@ import com.woowacourse.levellog.common.exception.InvalidFieldException;
 import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.levellog.dto.LevellogsDto;
 import com.woowacourse.levellog.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
@@ -38,7 +39,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("레벨로그를 저장한다.")
         void success() {
             // given
-            final LevellogDto request = LevellogDto.from("Spring을 학습하였습니다.");
+            final LevellogWriteDto request = LevellogWriteDto.from("Spring을 학습하였습니다.");
             final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
@@ -55,7 +56,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("레벨로그의 팀이 존재하지 않는 경우 예외를 던진다.")
         void save_teamNotFound_exception() {
             // given
-            final LevellogDto request = LevellogDto.from("스프링에 대해 학습하였습니다.");
+            final LevellogWriteDto request = LevellogWriteDto.from("스프링에 대해 학습하였습니다.");
             final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
             final Long teamId = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
@@ -71,7 +72,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("레벨로그의 작성자가 존재하지 않는 경우 예외를 던진다.")
         void save_memberNotFound_exception() {
             // given
-            final LevellogDto request = LevellogDto.from("스프링에 대해 학습하였습니다.");
+            final LevellogWriteDto request = LevellogWriteDto.from("스프링에 대해 학습하였습니다.");
             final Long teamId = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
             final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
@@ -87,7 +88,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("팀에서 이미 레벨로그를 작성한 경우 새로운 레벨로그를 작성하면 예외를 던진다.")
         void save_alreadyExist_exception() {
             // given
-            final LevellogDto request = LevellogDto.from("굳굳");
+            final LevellogWriteDto request = LevellogWriteDto.from("굳굳");
             final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
@@ -110,7 +111,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("레벨로그 내용이 공백이나 null일 경우 예외를 던진다.")
         void save_contentBlank_exception(final String invalidContent) {
             // given
-            final LevellogDto request = LevellogDto.from(invalidContent);
+            final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
             final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
             final Long teamId = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
@@ -172,7 +173,7 @@ class LevellogServiceTest extends ServiceTest {
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
             final Levellog levellog = levellogRepository.save(Levellog.of(member, team, "original content"));
-            final LevellogDto request = LevellogDto.from("update content");
+            final LevellogWriteDto request = LevellogWriteDto.from("update content");
 
             // when
             levellogService.update(request, levellog.getId(), member.getId());
@@ -186,7 +187,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("id에 해당하는 레벨로그가 존재하지 않는 경우 예외를 던진다.")
         void update_notFound_exception() {
             // given
-            final LevellogDto request = LevellogDto.from("update content");
+            final LevellogWriteDto request = LevellogWriteDto.from("update content");
             final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
@@ -208,7 +209,7 @@ class LevellogServiceTest extends ServiceTest {
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(member, team, "Spring을 학습하였습니다.")).getId();
-            final LevellogDto request = LevellogDto.from("JPA를 학습하였습니다.");
+            final LevellogWriteDto request = LevellogWriteDto.from("JPA를 학습하였습니다.");
             final Long memberId = member.getId();
             memberRepository.deleteById(memberId);
 
@@ -227,7 +228,7 @@ class LevellogServiceTest extends ServiceTest {
             final Team team = teamRepository.save(
                     new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
-            final LevellogDto request = LevellogDto.from("update content");
+            final LevellogWriteDto request = LevellogWriteDto.from("update content");
 
             // when & then
             assertThatThrownBy(() -> levellogService.update(request, levellogId, memberId))
@@ -240,7 +241,7 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("수정한 레벨로그의 내용이 공백이나 null일 경우 예외를 던진다.")
         void update_contentBlank_Exception(final String invalidContent) {
             // given
-            final LevellogDto request = LevellogDto.from(invalidContent);
+            final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
             final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
             final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.levellog.common.exception.UnauthorizedException;
-import com.woowacourse.levellog.levellog.dto.LevellogDto;
+import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
 import com.woowacourse.levellog.levellog.exception.LevellogAlreadyExistException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ class LevellogControllerTest extends ControllerTest {
         @DisplayName("팀에서 이미 레벨로그를 작성한 경우 새로운 레벨로그를 작성하면 예외를 던진다.")
         void save_alreadyExists_exception() throws Exception {
             // given
-            final LevellogDto request = LevellogDto.from("content");
+            final LevellogWriteDto request = LevellogWriteDto.from("content");
             final String requestContent = objectMapper.writeValueAsString(request);
             final Long authorId = 1L;
             final Long teamId = 1L;
@@ -61,7 +61,7 @@ class LevellogControllerTest extends ControllerTest {
         void save_nameNullOrEmpty_Exception() throws Exception {
             // given
             final Long teamId = 1L;
-            final LevellogDto request = LevellogDto.from(" ");
+            final LevellogWriteDto request = LevellogWriteDto.from(" ");
             final String requestContent = objectMapper.writeValueAsString(request);
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
@@ -127,7 +127,7 @@ class LevellogControllerTest extends ControllerTest {
             // given
             final Long teamId = 1L;
             final Long levellogId = 2L;
-            final LevellogDto request = LevellogDto.from(" ");
+            final LevellogWriteDto request = LevellogWriteDto.from(" ");
             final String requestContent = objectMapper.writeValueAsString(request);
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
@@ -151,7 +151,7 @@ class LevellogControllerTest extends ControllerTest {
             final Long teamId = 1L;
             final Long levellogId = 2L;
             final Long authorId = 1L;
-            final LevellogDto request = LevellogDto.from("update content");
+            final LevellogWriteDto request = LevellogWriteDto.from("update content");
             final String requestContent = objectMapper.writeValueAsString(request);
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");


### PR DESCRIPTION
## 구현 기능
- 피드백 작성 페이지에서 레벨로그 조회는 가능하지만 작성자에 대한 정보가 없어 타이틀의 메세지를 정해주기 어렵다.
- 따라서 레벨로그 상세 조회 시 레벨로그의 작성자를 포함하여 응답하도록 수정했다. 

## 수정된 내용
- Levellog save(), update() 시 사용하는 DTO 수정 : LevellogDto -> LevellogWriteDto
- 기존의 LevellogDto의 필드 : String content -> MemberDto author, String content

Close #249 
