### PR TITLE
feat: 레벨로그 생성, 수정 시 바뀐 정책 적용

### DIFF
--- a/backend/src/docs/asciidoc/levellog.adoc
+++ b/backend/src/docs/asciidoc/levellog.adoc
@@ -20,10 +20,13 @@ operation::levellog/save[]
 === 레벨로그 작성 실패
 
 ==== 이미 작성한 레벨로그가 존재하는 경우
-operation::levellog/save/exception-already-exists[]
+include::{snippets}/levellog/save/exception-already-exists/http-response.adoc[]
 
 ==== 레벨로그 내용이 공백인 경우
-operation::levellog/save/exception-contents[]
+include::{snippets}/levellog/save/exception-contents/http-response.adoc[]
+
+==== 인터뷰가 진행중이거나 끝난 팀에 레벨로그 작성을 하려는 경우
+include::{snippets}/levellog/save/exception-after-start/http-response.adoc[]
 
 [[find]]
 == 레벨로그 상세 조회
@@ -37,7 +40,7 @@ operation::levellog/find[]
 === 레벨로그 조회 실패
 
 ==== 레벨로그가 존재하지 않는 경우
-operation::levellog/find/exception-exist[]
+include::{snippets}/levellog/find/exception-exist/http-response.adoc[]
 
 [[update]]
 == 레벨로그 수정
@@ -51,10 +54,10 @@ operation::levellog/update[]
 === 레벨로그 수정 실패
 
 ==== 작성자가 아닌 멤버가 수정하려는 경우
-operation::levellog/update/exception-author[]
+include::{snippets}/levellog/update/exception-author/http-response.adoc[]
 
 ==== 레벨로그 내용이 공백인 경우
-operation::levellog/update/exception-contents[]
+include::{snippets}/levellog/update/exception-contents/http-response.adoc[]
 
 [[delete]]
 == 레벨로그 삭제
@@ -68,4 +71,4 @@ operation::levellog/delete[]
 === 레벨로그 삭제 실패
 
 ==== 작성자가 아닌 멤버가 삭제하려는 경우
-operation::levellog/delete/exception-author[]
+include::{snippets}/levellog/delete/exception-author/http-response.adoc[]

--- a/backend/src/docs/asciidoc/levellog.adoc
+++ b/backend/src/docs/asciidoc/levellog.adoc
@@ -61,17 +61,3 @@ include::{snippets}/levellog/update/exception-contents/http-response.adoc[]
 
 ==== 인터뷰가 진행중이거나 끝난 팀에 레벨로그 수정을 하려는 경우
 include::{snippets}/levellog/update/exception-after-start/http-response.adoc[]
-
-[[delete]]
-== 레벨로그 삭제
-
-[[delete-success]]
-=== 레벨로그 삭제 성공
-
-operation::levellog/delete[]
-
-[[delete-exception]]
-=== 레벨로그 삭제 실패
-
-==== 작성자가 아닌 멤버가 삭제하려는 경우
-include::{snippets}/levellog/delete/exception-author/http-response.adoc[]

--- a/backend/src/docs/asciidoc/levellog.adoc
+++ b/backend/src/docs/asciidoc/levellog.adoc
@@ -59,6 +59,9 @@ include::{snippets}/levellog/update/exception-author/http-response.adoc[]
 ==== 레벨로그 내용이 공백인 경우
 include::{snippets}/levellog/update/exception-contents/http-response.adoc[]
 
+==== 인터뷰가 진행중이거나 끝난 팀에 레벨로그 수정을 하려는 경우
+include::{snippets}/levellog/update/exception-after-start/http-response.adoc[]
+
 [[delete]]
 == 레벨로그 삭제
 

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -64,7 +64,7 @@ public class LevellogService {
     public void update(final LevellogWriteDto request, final Long levellogId, final Long memberId) {
         final Levellog levellog = getById(levellogId);
         final Member member = getMember(memberId);
-        levellog.getTeam().validateBeforeStartAt(timeStandard.now(), "인터뷰 시작 전에만 레벨로그 작성이 가능합니다.");
+        levellog.getTeam().validateBeforeStartAt(timeStandard.now(), "인터뷰 시작 전에만 레벨로그 수정이 가능합니다.");
 
         levellog.updateContent(member, request.getContent());
     }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -36,9 +36,9 @@ public class LevellogService {
         final Team team = getTeam(teamId);
         final Member author = getMember(authorId);
         validateLevellogExistence(authorId, teamId);
+        team.validateBeforeStartAt(timeStandard.now(), "인터뷰 시작 전에만 레벨로그 작성이 가능합니다.");
 
         final Levellog savedLevellog = levellogRepository.save(request.toLevellog(author, team));
-        savedLevellog.validateTeamStartTime(timeStandard.now());
 
         return savedLevellog.getId();
     }
@@ -64,8 +64,9 @@ public class LevellogService {
     public void update(final LevellogWriteDto request, final Long levellogId, final Long memberId) {
         final Levellog levellog = getById(levellogId);
         final Member member = getMember(memberId);
+        levellog.getTeam().validateBeforeStartAt(timeStandard.now(), "인터뷰 시작 전에만 레벨로그 작성이 가능합니다.");
 
-        levellog.updateContent(member, request.getContent(), timeStandard.now());
+        levellog.updateContent(member, request.getContent());
     }
 
     private Levellog getById(final Long levellogId) {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -14,7 +14,6 @@ import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamRepository;
-import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
 import com.woowacourse.levellog.team.support.TimeStandard;
 import java.util.List;
@@ -38,13 +37,9 @@ public class LevellogService {
         final Team team = getTeam(teamId);
         final Member author = getMember(authorId);
         validateLevellogExistence(authorId, teamId);
-        // TODO TEAM 도메인에 해당 로직 삽입 예정 ( 다른 팀원들 어떻게 하는지 보고 해결하자 )
-        if (team.isAfterStartTime(timeStandard.now())) {
-            throw new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", "[teamId : " + teamId + "]");
-        }
 
-        final Levellog levellog = request.toLevellog(author, team);
-        final Levellog savedLevellog = levellogRepository.save(levellog);
+        final Levellog savedLevellog = levellogRepository.save(request.toLevellog(author, team));
+        savedLevellog.validateTeamStartTime(timeStandard.now());
 
         return savedLevellog.getId();
     }
@@ -71,7 +66,7 @@ public class LevellogService {
         final Levellog levellog = getById(levellogId);
         final Member member = getMember(memberId);
 
-        levellog.updateContent(member, request.getContent());
+        levellog.updateContent(member, request.getContent(), timeStandard.now());
     }
 
     @Transactional

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -1,6 +1,5 @@
 package com.woowacourse.levellog.levellog.application;
 
-import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.levellog.dto.LevellogDto;
@@ -69,15 +68,6 @@ public class LevellogService {
         levellog.updateContent(member, request.getContent(), timeStandard.now());
     }
 
-    @Transactional
-    public void deleteById(final Long levellogId, final Long memberId) {
-        final Levellog levellog = getById(levellogId);
-        final Member member = getMember(memberId);
-        validateAuthor(member, levellog);
-
-        levellogRepository.deleteById(levellogId);
-    }
-
     private Levellog getById(final Long levellogId) {
         return levellogRepository.findById(levellogId)
                 .orElseThrow(() -> new LevellogNotFoundException("레벨로그가 존재하지 않습니다. levellogId : " + levellogId));
@@ -97,14 +87,6 @@ public class LevellogService {
         final boolean isExists = levellogRepository.existsByAuthorIdAndTeamId(authorId, teamId);
         if (isExists) {
             throw new LevellogAlreadyExistException("레벨로그를 이미 작성하였습니다. authorId : " + authorId + " teamId : " + teamId);
-        }
-    }
-
-    private void validateAuthor(final Member member, final Levellog levellog) {
-        final boolean isNotAuthor = !levellog.isAuthor(member);
-        if (isNotAuthor) {
-            throw new UnauthorizedException("레벨로그를 삭제할 권한이 없습니다. memberId : " + member.getId()
-                    + " levellogId: " + levellog.getId());
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -14,7 +14,9 @@ import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamRepository;
+import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
+import com.woowacourse.levellog.team.support.TimeStandard;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +31,17 @@ public class LevellogService {
     private final LevellogRepository levellogRepository;
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final TimeStandard timeStandard;
 
     @Transactional
     public Long save(final LevellogWriteDto request, final Long authorId, final Long teamId) {
         final Team team = getTeam(teamId);
         final Member author = getMember(authorId);
         validateLevellogExistence(authorId, teamId);
+        // TODO TEAM 도메인에 해당 로직 삽입 예정 ( 다른 팀원들 어떻게 하는지 보고 해결하자 )
+        if (team.isAfterStartTime(timeStandard.now())) {
+            throw new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", "[teamId : " + teamId + "]");
+        }
 
         final Levellog levellog = request.toLevellog(author, team);
         final Levellog savedLevellog = levellogRepository.save(levellog);

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
@@ -7,8 +7,6 @@ import com.woowacourse.levellog.feedback.exception.InvalidFeedbackException;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.prequestion.exception.InvalidPreQuestionException;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.exception.InterviewTimeException;
-import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -60,17 +58,10 @@ public class Levellog extends BaseEntity {
         }
     }
 
-    public void updateContent(final Member member, final String content, final LocalDateTime presentTime) {
+    public void updateContent(final Member member, final String content) {
         validateAuthor(member, "레벨로그를 수정할 권한이 없습니다. memberId : " + member.getId() + " levellogId : " + getId());
         validateContent(content);
-        validateTeamStartTime(presentTime);
         this.content = content;
-    }
-
-    public void validateTeamStartTime(final LocalDateTime presentTime) {
-        if (team.isAfterStartTime(presentTime)) {
-            throw new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", "[teamId : " + team.getId() + "]");
-        }
     }
 
     public boolean isAuthor(final Member member) {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
@@ -7,6 +7,8 @@ import com.woowacourse.levellog.feedback.exception.InvalidFeedbackException;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.prequestion.exception.InvalidPreQuestionException;
 import com.woowacourse.levellog.team.domain.Team;
+import com.woowacourse.levellog.team.exception.InterviewTimeException;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -58,10 +60,17 @@ public class Levellog extends BaseEntity {
         }
     }
 
-    public void updateContent(final Member member, final String content) {
+    public void updateContent(final Member member, final String content, final LocalDateTime presentTime) {
         validateAuthor(member, "레벨로그를 수정할 권한이 없습니다. memberId : " + member.getId() + " levellogId : " + getId());
         validateContent(content);
+        validateTeamStartTime(presentTime);
         this.content = content;
+    }
+
+    public void validateTeamStartTime(final LocalDateTime presentTime) {
+        if (team.isAfterStartTime(presentTime)) {
+            throw new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", "[teamId : " + team.getId() + "]");
+        }
     }
 
     public boolean isAuthor(final Member member) {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/presentation/LevellogController.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,14 +46,6 @@ public class LevellogController {
                                        @Authentic final Long memberId,
                                        @RequestBody @Valid final LevellogWriteDto request) {
         levellogService.update(request, levellogId, memberId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @DeleteMapping("/{levellogId}")
-    public ResponseEntity<Void> delete(@PathVariable final Long teamId,
-                                       @PathVariable final Long levellogId,
-                                       @Authentic final Long memberId) {
-        levellogService.deleteById(levellogId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
@@ -124,16 +124,14 @@ public class Team extends BaseEntity {
         isClosed = true;
     }
 
-    public boolean isAfterStartTime(final LocalDateTime presentTime) {
-        return presentTime.isAfter(startAt);
-    }
-
-    public boolean isBeforeStartTime(final LocalDateTime presentTime) {
-        return presentTime.isBefore(startAt);
-    }
-
     public void validateAfterStartAt(final LocalDateTime presentTime, final String message) {
         if (isBeforeStartTime(presentTime)) {
+            throw new InterviewTimeException(message, "[teamId : " + this.getId() + "]");
+        }
+    }
+
+    public void validateBeforeStartAt(final LocalDateTime presentTime, final String message) {
+        if (isAfterStartTime(presentTime)) {
             throw new InterviewTimeException(message, "[teamId : " + this.getId() + "]");
         }
     }
@@ -142,5 +140,13 @@ public class Team extends BaseEntity {
         if (isClosed) {
             throw new InterviewTimeException("이미 종료된 인터뷰입니다.", "[teamId : " + this.getId() + "]");
         }
+    }
+
+    private boolean isAfterStartTime(final LocalDateTime presentTime) {
+        return presentTime.isAfter(startAt);
+    }
+
+    private boolean isBeforeStartTime(final LocalDateTime presentTime) {
+        return presentTime.isBefore(startAt);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
@@ -124,9 +124,17 @@ public class Team extends BaseEntity {
         isClosed = true;
     }
 
+    public boolean isAfterStartTime(final LocalDateTime presentTime) {
+        return presentTime.isAfter(startAt);
+    }
+
+    public boolean isBeforeStartTime(final LocalDateTime presentTime) {
+        return presentTime.isBefore(startAt);
+    }
+
     public void validateAfterStartAt(final LocalDateTime presentTime, final String message) {
-        if (presentTime.isBefore(startAt)) {
-            throw new InterviewTimeException(message, "[teamId : " + this.getId() + ", startAt : " + startAt + "]");
+        if (isBeforeStartTime(presentTime)) {
+            throw new InterviewTimeException(message, "[teamId : " + this.getId() + "]");
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -99,7 +99,7 @@ abstract class AcceptanceTest {
     protected RestAssuredResponse requestCreateTeam(final String title, final String token,
                                                     final Long... participantIds) {
         final ParticipantIdsDto participantIdsDto = new ParticipantIdsDto(List.of(participantIds));
-        final TeamCreateDto request = new TeamCreateDto(title, title + "place", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto request = new TeamCreateDto(title, title + "place", 1, LocalDateTime.now().plusDays(7),
                 participantIdsDto);
 
         return post("/api/teams", token, request);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
 import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
 import com.woowacourse.levellog.config.DatabaseCleaner;
+import com.woowacourse.levellog.config.FakeTimeStandard;
 import com.woowacourse.levellog.config.TestConfig;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
@@ -20,7 +22,6 @@ import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,17 +48,22 @@ abstract class AcceptanceTest {
     @Autowired
     protected DatabaseCleaner databaseCleaner;
 
+    @Autowired
+    protected FakeTimeStandard timeStandard;
+
     @LocalServerPort
     private int port;
 
     @BeforeEach
-    public void tearDown(final RestDocumentationContextProvider contextProvider) {
+    public void setUp(final RestDocumentationContextProvider contextProvider) {
         setRestAssuredPort();
         setRestDocsSpec(contextProvider);
+
+        timeStandard.setBeforeStarted();
     }
 
     @AfterEach
-    public void cleanDatabase() {
+    public void tearDown() {
         databaseCleaner.clean();
     }
 
@@ -99,7 +105,7 @@ abstract class AcceptanceTest {
     protected RestAssuredResponse requestCreateTeam(final String title, final String token,
                                                     final Long... participantIds) {
         final ParticipantIdsDto participantIdsDto = new ParticipantIdsDto(List.of(participantIds));
-        final TeamCreateDto request = new TeamCreateDto(title, title + "place", 1, LocalDateTime.now().plusDays(7),
+        final TeamCreateDto request = new TeamCreateDto(title, title + "place", 1, TEAM_START_TIME,
                 participantIdsDto);
 
         return post("/api/teams", token, request);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -49,6 +49,8 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
                 "윙크하지 마세요.");
         final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
 
+        timeStandard.setInProgress();
+
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
@@ -93,6 +95,8 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
                 "아이 컨텍이 좋습니다.",
                 "윙크하지 마세요.");
         final FeedbackWriteDto request = new FeedbackWriteDto(feedbackContentDto);
+
+        timeStandard.setInProgress();
 
         RestAssuredTemplate.post("/api/levellogs/" + levellogId + "/feedbacks", romaToken, request);
 
@@ -142,6 +146,8 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         final FeedbackContentDto givenFeedbackContentDto = new FeedbackContentDto(
                 "Spring에 대한 학습을 충분히 하였습니다.", "아이 컨텍이 좋습니다.", "윙크하지 마세요.");
         final FeedbackWriteDto givenRequest = new FeedbackWriteDto(givenFeedbackContentDto);
+
+        timeStandard.setInProgress();
 
         final RestAssuredResponse saveResponse = RestAssuredTemplate.post(
                 "/api/levellogs/" + rick_levellogId + "/feedbacks",

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.get;
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -14,7 +15,6 @@ import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
         final Long romaId = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
@@ -85,7 +85,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
         final Long romaId = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
@@ -129,7 +129,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
         final Long romaId = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 
@@ -177,7 +177,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
         final Long romaId = romaLoginResponse.getMemberId();
         final String romaToken = romaLoginResponse.getToken();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("롬펲 인터뷰", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -123,39 +123,6 @@ class LevellogAcceptanceTest extends AcceptanceTest {
                 .body("content", equalTo(updateContent));
     }
 
-    /*
-     * Scenario: 레벨로그 삭제
-     *   given: 레벨로그가 등록되어있다.
-     *   when: 레벨로그를 삭제한다.
-     *   then: 204 No Content 상태 코드를 응답 받는다.
-     */
-    @Test
-    @DisplayName("레벨로그 삭제")
-    void deleteLevellog() {
-        // given
-        final RestAssuredResponse loginResponse1 = login("페퍼");
-        final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
-                new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
-        final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
-        final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(),
-                LevellogWriteDto.from("Spring과 React를 학습했습니다.")).getLevellogId();
-
-        // when
-        final ValidatableResponse response = RestAssured.given(specification).log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginResponse1.getToken())
-                .filter(document("levellog/delete"))
-                .when()
-                .delete("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
-                .then().log().all();
-
-        // then
-        response.statusCode(HttpStatus.NO_CONTENT.value());
-        requestFindLevellog(Long.parseLong(teamId), Long.parseLong(levellogId))
-                .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", equalTo("레벨로그가 존재하지 않습니다."));
-    }
-
     private ValidatableResponse requestFindLevellog(final Long teamId, final Long levellogId) {
         return RestAssured.given().log().all()
                 .accept(MediaType.ALL_VALUE)

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/LevellogAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
@@ -11,7 +12,6 @@ import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         // given
         final RestAssuredResponse loginResponse1 = login("페퍼");
         final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final LevellogWriteDto request = LevellogWriteDto.from("Spring과 React를 학습했습니다.");
@@ -65,7 +65,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         // given
         final RestAssuredResponse loginResponse1 = login("페퍼");
         final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final LevellogWriteDto request = LevellogWriteDto.from("Spring과 React를 학습했습니다.");
@@ -98,7 +98,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         // given
         final RestAssuredResponse loginResponse1 = login("페퍼");
         final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(),
@@ -135,7 +135,7 @@ class LevellogAcceptanceTest extends AcceptanceTest {
         // given
         final RestAssuredResponse loginResponse1 = login("페퍼");
         final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String teamId = post("/api/teams", loginResponse1.getToken(), teamRequest).getTeamId();
         final String levellogId = post("/api/teams/" + teamId + "/levellogs", loginResponse1.getToken(),

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -15,7 +16,6 @@ import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.hamcrest.Matchers;
@@ -120,6 +120,8 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
                 .getLevellogId();
 
         // 피드백 작성
+        timeStandard.setInProgress();
+
         final FeedbackContentDto feedbackContentDto1 = new FeedbackContentDto("로마 study 리뷰", "로마 speak 리뷰",
                 "로마 etc 리뷰");
         final FeedbackContentDto feedbackContentDto2 = new FeedbackContentDto("페퍼 study 리뷰", "페퍼 speak 리뷰",
@@ -164,9 +166,9 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final String hostToken = hostLoginResponse.getToken();
 
         // 팀 생성
-        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
-        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId)));
 
         final String teamId1 = post("/api/teams", hostToken, teamCreateDto1).getTeamId();
@@ -214,9 +216,9 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final Long alienId = login("알린").getMemberId();
 
         // 팀 생성
-        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId, pepperId)));
-        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(romaId, alienId)));
 
         post("/api/teams", hostToken, teamCreateDto1);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.get;
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
@@ -13,7 +14,6 @@ import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final String eveToken = eveResponse.getToken();
         final Long eveMemberId = eveResponse.getMemberId();
 
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
         final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
@@ -81,7 +81,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final String eveToken = eveResponse.getToken();
         final Long eveMemberId = eveResponse.getMemberId();
 
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
         final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
@@ -128,7 +128,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final String eveToken = eveResponse.getToken();
         final Long eveMemberId = eveResponse.getMemberId();
 
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
         final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");
@@ -170,7 +170,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final String eveToken = eveResponse.getToken();
         final Long eveMemberId = eveResponse.getMemberId();
 
-        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamRequest = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveMemberId)));
         final String teamId = post("/api/teams", pepperToken, teamRequest).getTeamId();
         final LevellogWriteDto levellogRequest = LevellogWriteDto.from("페퍼의 레벨로그");

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.acceptance;
 
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.get;
 import static com.woowacourse.levellog.fixture.RestAssuredTemplate.post;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -13,7 +14,6 @@ import com.woowacourse.levellog.team.dto.TeamCreateDto;
 import com.woowacourse.levellog.team.dto.TeamUpdateDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
 
         final List<Long> participantIds = List.of(eveId, rickId);
 
-        final TeamCreateDto request = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto request = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(participantIds));
 
         // when
@@ -73,9 +73,9 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final RestAssuredResponse eve = login("이브");
         final RestAssuredResponse rick = login("릭");
 
-        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto1 = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eve.getMemberId())));
-        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto2 = new TeamCreateDto("잠실 브리조", "톱오브스윙방", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(rick.getMemberId())));
 
         post("/api/teams", pepper.getToken(), teamCreateDto1);
@@ -117,7 +117,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final Long romaId = login("로마").getMemberId();
 
         final ParticipantIdsDto participants = new ParticipantIdsDto(List.of(eveId, rickId, romaId));
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, TEAM_START_TIME,
                 participants);
 
         final String id = post("/api/teams", pepper.getToken(), teamCreateDto).getTeamId();
@@ -160,7 +160,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final Long romaId = login("로마").getMemberId();
 
         final ParticipantIdsDto participants = new ParticipantIdsDto(List.of(eveId, rickId, romaId));
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, TEAM_START_TIME,
                 participants);
 
         final String id = post("/api/teams", pepper.getToken(), teamCreateDto).getTeamId();
@@ -200,7 +200,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final Long romaId = login("로마").getMemberId();
 
         final ParticipantIdsDto participants = new ParticipantIdsDto(List.of(eveId, rickId, romaId));
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, TEAM_START_TIME,
                 participants);
 
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
@@ -237,7 +237,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final Long romaId = login("로마").getMemberId();
 
         final ParticipantIdsDto participants = new ParticipantIdsDto(List.of(eveId, rickId, romaId));
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 2, TEAM_START_TIME,
                 participants);
 
         final String teamId = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
@@ -266,12 +266,15 @@ class TeamAcceptanceTest extends AcceptanceTest {
     @DisplayName("레벨 인터뷰 종료하기")
     void closeInterview() {
         // given
+
         final RestAssuredResponse loginResponse1 = login("페퍼");
         final RestAssuredResponse loginResponse2 = login("이브");
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
-                new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
 
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
+                new ParticipantIdsDto(List.of(loginResponse2.getMemberId())));
         final String id = post("/api/teams", loginResponse1.getToken(), teamCreateDto).getTeamId();
+
+        timeStandard.setInProgress();
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -302,10 +305,10 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final String pepperToken = login("페퍼").getToken();
         final Long eveId = login("이브").getMemberId();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveId)));
         final String id = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
-        final TeamUpdateDto request = new TeamUpdateDto("선릉 브리조", "수성방", LocalDateTime.now().plusDays(3));
+        final TeamUpdateDto request = new TeamUpdateDto("선릉 브리조", "수성방", TEAM_START_TIME);
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -334,7 +337,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final String pepperToken = login("페퍼").getToken();
         final Long eveId = login("이브").getMemberId();
 
-        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, LocalDateTime.now().plusDays(3),
+        final TeamCreateDto teamCreateDto = new TeamCreateDto("잠실 제이슨조", "트랙룸", 1, TEAM_START_TIME,
                 new ParticipantIdsDto(List.of(eveId)));
         final String id = post("/api/teams", pepperToken, teamCreateDto).getTeamId();
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.application;
 
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -17,7 +18,6 @@ import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,9 +28,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("LevellogService의")
 class LevellogServiceTest extends ServiceTest {
-
-    private static final LocalDateTime TOMORROW = LocalDateTime.now().plusDays(1);
-    private static final LocalDateTime AFTER_FAKE_NOW = LocalDateTime.now().plusDays(6);
 
     @Nested
     @DisplayName("save 메서드는")
@@ -43,7 +40,7 @@ class LevellogServiceTest extends ServiceTest {
             final LevellogWriteDto request = LevellogWriteDto.from("Spring을 학습하였습니다.");
             final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
                     .getId();
-            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", AFTER_FAKE_NOW, "profileUrl", 1))
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1))
                     .getId();
 
             // when
@@ -75,7 +72,7 @@ class LevellogServiceTest extends ServiceTest {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("스프링에 대해 학습하였습니다.");
             final Long authorId = 1000L;
-            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1))
                     .getId();
 
             // when & then
@@ -91,7 +88,7 @@ class LevellogServiceTest extends ServiceTest {
             final LevellogWriteDto request = LevellogWriteDto.from("굳굳");
             final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
                     .getId();
-            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1))
                     .getId();
 
             levellogService.save(request, authorId, teamId);
@@ -111,7 +108,7 @@ class LevellogServiceTest extends ServiceTest {
             final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
             final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
                     .getId();
-            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1))
                     .getId();
 
             //  when & then
@@ -127,8 +124,10 @@ class LevellogServiceTest extends ServiceTest {
             final LevellogWriteDto request = LevellogWriteDto.from("Spring을 학습하였습니다.");
             final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
                     .getId();
-            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1))
                     .getId();
+
+            timeStandard.setInProgress();
 
             // when & then
             assertThatThrownBy(() -> levellogService.save(request, authorId, teamId))
@@ -146,7 +145,7 @@ class LevellogServiceTest extends ServiceTest {
         void success() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
             final String content = "content";
             final Levellog levellog = levellogRepository.save(Levellog.of(author, team, content));
 
@@ -179,7 +178,7 @@ class LevellogServiceTest extends ServiceTest {
         void success() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
 
             final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
             final LevellogWriteDto request = LevellogWriteDto.from("update content");
@@ -212,7 +211,7 @@ class LevellogServiceTest extends ServiceTest {
         void update_memberNotFound_exception() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."))
                     .getId();
 
@@ -230,7 +229,7 @@ class LevellogServiceTest extends ServiceTest {
         void update_unauthorized_Exception() {
             // given
             final Member author = memberRepository.save(new Member("알린", 2222, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
                     .getId();
 
@@ -252,7 +251,7 @@ class LevellogServiceTest extends ServiceTest {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
 
             final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
                     .getId();
@@ -274,7 +273,7 @@ class LevellogServiceTest extends ServiceTest {
         void success() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
             final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
 
             // when
@@ -304,7 +303,7 @@ class LevellogServiceTest extends ServiceTest {
         void deleteById_memberNotFound_exception() {
             // given
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
 
             final Long levellogId = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."))
                     .getId();
@@ -323,7 +322,7 @@ class LevellogServiceTest extends ServiceTest {
         void deleteById_unauthorized_Exception() {
             // given
             final Member author = memberRepository.save(new Member("알린", 2222, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
             final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
                     .getId();
 
@@ -346,8 +345,8 @@ class LevellogServiceTest extends ServiceTest {
             // given
             final Member author = memberRepository.save(new Member("페퍼", 1111, "pepper.img"));
 
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
-            final Team team2 = teamRepository.save(new Team("선릉 제이슨조", "선릉 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
+            final Team team2 = teamRepository.save(new Team("선릉 제이슨조", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 1));
 
             levellogRepository.save(Levellog.of(author, team, "content1"));
             levellogRepository.save(Levellog.of(author, team2, "content2"));

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -267,87 +267,18 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("인터뷰 시작 후에 요청한 경우 예외를 반환한다.")
         void update_afterStart_exception() {
             // given
-            final LevellogDto request = LevellogDto.from("update content");
+            final LevellogWriteDto request = LevellogWriteDto.from("update content");
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", BEFORE_FAKE_NOW_TIME, "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
 
             final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
+
+            timeStandard.setInProgress();
 
             // when & then
             assertThatThrownBy(() -> levellogService.update(request, levellog.getId(), author.getId()))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
-        }
-    }
-
-    @Nested
-    @DisplayName("deleteById 메서드는")
-    class DeleteById {
-
-        @Test
-        @DisplayName("id에 해당하는 레벨로그를 삭제한다.")
-        void success() {
-            // given
-            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
-
-            // when
-            levellogService.deleteById(levellog.getId(), author.getId());
-
-            // then
-            final Optional<Levellog> actual = levellogRepository.findById(levellog.getId());
-            assertThat(actual).isEmpty();
-        }
-
-        @Test
-        @DisplayName("id에 해당하는 레벨로그가 존재하지 않는 경우 예외를 던진다.")
-        void deleteById_notFound_exception() {
-            // given
-            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
-                    .getId();
-            final Long levellogId = 1000L;
-
-            // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, authorId))
-                    .isInstanceOf(LevellogNotFoundException.class)
-                    .hasMessageContainingAll("레벨로그가 존재하지 않습니다.", String.valueOf(levellogId));
-        }
-
-        @Test
-        @DisplayName("memberId에 해당하는 작성자가 존재하지 않는 경우 예외를 던진다.")
-        void deleteById_memberNotFound_exception() {
-            // given
-            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
-
-            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."))
-                    .getId();
-            final Long authorId = author.getId();
-
-            memberRepository.deleteById(authorId);
-
-            // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, authorId))
-                    .isInstanceOf(MemberNotFoundException.class)
-                    .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(authorId));
-        }
-
-        @Test
-        @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
-        void deleteById_unauthorized_Exception() {
-            // given
-            final Member author = memberRepository.save(new Member("알린", 2222, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TEAM_START_TIME, "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
-                    .getId();
-
-            final Long otherMemberId = memberRepository.save(new Member("페퍼", 1111, "pepper.img"))
-                    .getId();
-
-            // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, otherMemberId))
-                    .isInstanceOf(UnauthorizedException.class);
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -28,28 +28,27 @@ import org.junit.jupiter.params.provider.ValueSource;
 @DisplayName("LevellogService의")
 class LevellogServiceTest extends ServiceTest {
 
-    private LocalDateTime setTeamStartAt() {
-        return LocalDateTime.now().plusDays(1);
-    }
+    private static final LocalDateTime TOMORROW = LocalDateTime.now().plusDays(1);
 
     @Nested
     @DisplayName("save 메서드는")
-    class SaveTest {
+    class Save {
 
         @Test
         @DisplayName("레벨로그를 저장한다.")
         void success() {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("Spring을 학습하였습니다.");
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+                    .getId();
 
             // when
-            final Long id = levellogService.save(request, member.getId(), team.getId());
+            final Long savedLevellogId = levellogService.save(request, authorId, teamId);
 
             // then
-            final Optional<Levellog> levellog = levellogRepository.findById(id);
+            final Optional<Levellog> levellog = levellogRepository.findById(savedLevellogId);
             assertThat(levellog).isPresent();
         }
 
@@ -58,13 +57,12 @@ class LevellogServiceTest extends ServiceTest {
         void save_teamNotFound_exception() {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("스프링에 대해 학습하였습니다.");
-            final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
-            final Long teamId = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
-            teamRepository.deleteById(teamId);
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long teamId = 1000L;
 
             // when & then
-            assertThatThrownBy(() -> levellogService.save(request, memberId, teamId))
+            assertThatThrownBy(() -> levellogService.save(request, authorId, teamId))
                     .isInstanceOf(TeamNotFoundException.class)
                     .hasMessageContainingAll("팀이 존재하지 않습니다.", String.valueOf(teamId));
         }
@@ -74,15 +72,14 @@ class LevellogServiceTest extends ServiceTest {
         void save_memberNotFound_exception() {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("스프링에 대해 학습하였습니다.");
-            final Long teamId = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
-            final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
-            memberRepository.deleteById(memberId);
+            final Long authorId = 1000L;
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+                    .getId();
 
             // when & then
-            assertThatThrownBy(() -> levellogService.save(request, memberId, teamId))
+            assertThatThrownBy(() -> levellogService.save(request, authorId, teamId))
                     .isInstanceOf(MemberNotFoundException.class)
-                    .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(memberId));
+                    .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(authorId));
         }
 
         @Test
@@ -90,20 +87,17 @@ class LevellogServiceTest extends ServiceTest {
         void save_alreadyExist_exception() {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("굳굳");
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
-            final Long memberId = member.getId();
-            final Long teamId = team.getId();
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+                    .getId();
 
-            levellogRepository.save(Levellog.of(member, team, "굳굳굳"));
+            levellogService.save(request, authorId, teamId);
 
             // when & then
-            assertThatThrownBy(() -> levellogService.save(request, memberId, teamId))
+            assertThatThrownBy(() -> levellogService.save(request, authorId, teamId))
                     .isInstanceOf(LevellogAlreadyExistException.class)
-                    .hasMessageContainingAll("레벨로그를 이미 작성하였습니다.", "teamId",
-                            String.valueOf(memberId),
-                            String.valueOf(teamId));
+                    .hasMessageContainingAll("레벨로그를 이미 작성하였습니다.", String.valueOf(authorId), String.valueOf(teamId));
         }
 
         @ParameterizedTest
@@ -113,12 +107,13 @@ class LevellogServiceTest extends ServiceTest {
         void save_contentBlank_exception(final String invalidContent) {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
-            final Long memberId = memberRepository.save(new Member("알린", 1111, "alien.img")).getId();
-            final Long teamId = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1)).getId();
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long teamId = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1))
+                    .getId();
 
             //  when & then
-            assertThatThrownBy(() -> levellogService.save(request, memberId, teamId))
+            assertThatThrownBy(() -> levellogService.save(request, authorId, teamId))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessage("레벨로그 내용은 공백이나 null일 수 없습니다.");
         }
@@ -126,24 +121,23 @@ class LevellogServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("findById 메서드는")
-    class FindByIdTest {
+    class FindById {
 
         @Test
         @DisplayName("id에 해당하는 레벨로그를 조회한다.")
         void success() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
             final String content = "content";
-            final Levellog levellog = levellogRepository.save(Levellog.of(member, team, content));
+            final Levellog levellog = levellogRepository.save(Levellog.of(author, team, content));
 
             // when
             final LevellogDto response = levellogService.findById(levellog.getId());
 
             // then
             assertAll(
-                    () -> assertThat(response.getAuthor().getId()).isEqualTo(member.getId()),
+                    () -> assertThat(response.getAuthor().getId()).isEqualTo(author.getId()),
                     () -> assertThat(response.getContent()).isEqualTo(content)
             );
         }
@@ -151,36 +145,29 @@ class LevellogServiceTest extends ServiceTest {
         @Test
         @DisplayName("id에 해당하는 레벨로그가 존재하지 않는 경우 예외를 던진다.")
         void findById_notFound_exception() {
-            // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
-            levellogRepository.deleteById(levellogId);
-
             // when & then
-            assertThatThrownBy(() -> levellogService.findById(levellogId))
+            assertThatThrownBy(() -> levellogService.findById(1000L))
                     .isInstanceOf(LevellogNotFoundException.class)
-                    .hasMessageContainingAll("레벨로그가 존재하지 않습니다.", String.valueOf(levellogId));
+                    .hasMessageContainingAll("레벨로그가 존재하지 않습니다.", String.valueOf(1000L));
         }
     }
 
     @Nested
     @DisplayName("update 메서드는")
-    class UpdateTest {
+    class Update {
 
         @Test
         @DisplayName("id에 해당하는 레벨로그를 변경한다.")
         void success() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(member, team, "original content"));
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+
+            final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
             final LevellogWriteDto request = LevellogWriteDto.from("update content");
 
             // when
-            levellogService.update(request, levellog.getId(), member.getId());
+            levellogService.update(request, levellog.getId(), author.getId());
 
             // then
             final Levellog actual = levellogRepository.findById(levellog.getId()).orElseThrow();
@@ -192,30 +179,27 @@ class LevellogServiceTest extends ServiceTest {
         void update_notFound_exception() {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("update content");
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
-            final Long memberId = member.getId();
-            levellogRepository.deleteById(levellogId);
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long levellogId = 1000L;
 
             // when & then
-            assertThatThrownBy(() -> levellogService.update(request, levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.update(request, levellogId, authorId))
                     .isInstanceOf(LevellogNotFoundException.class)
                     .hasMessageContainingAll("레벨로그가 존재하지 않습니다.", String.valueOf(levellogId));
         }
 
         @Test
-        @DisplayName("memberId에 해당하는 작성자가 존재하지 않는 경우 예외를 던진다.")
+        @DisplayName("memberId에 해당하는 멤버가 존재하지 않는 경우 예외를 던진다.")
         void update_memberNotFound_exception() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "Spring을 학습하였습니다.")).getId();
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."))
+                    .getId();
+
             final LevellogWriteDto request = LevellogWriteDto.from("JPA를 학습하였습니다.");
-            final Long memberId = member.getId();
-            memberRepository.deleteById(memberId);
+            final Long memberId = 1000L;
 
             // when & then
             assertThatThrownBy(() -> levellogService.update(request, levellogId, memberId))
@@ -227,15 +211,18 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
         void update_unauthorized_Exception() {
             // given
-            final Long memberId = memberRepository.save(new Member("페퍼", 1111, "pepper.img")).getId();
-            final Member member = memberRepository.save(new Member("알린", 2222, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
+            final Member author = memberRepository.save(new Member("알린", 2222, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
+                    .getId();
+
             final LevellogWriteDto request = LevellogWriteDto.from("update content");
 
+            final Long otherMemberId = memberRepository.save(new Member("페퍼", 1111, "pepper.img"))
+                    .getId();
+
             // when & then
-            assertThatThrownBy(() -> levellogService.update(request, levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.update(request, levellogId, otherMemberId))
                     .isInstanceOf(UnauthorizedException.class);
         }
 
@@ -246,13 +233,15 @@ class LevellogServiceTest extends ServiceTest {
         void update_contentBlank_Exception(final String invalidContent) {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt(), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
-            final Long memberId = member.getId();
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+
+            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
+                    .getId();
+            final Long authorId = author.getId();
 
             //  when & then
-            assertThatThrownBy(() -> levellogService.update(request, levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.update(request, levellogId, authorId))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessage("레벨로그 내용은 공백이나 null일 수 없습니다.");
         }
@@ -260,19 +249,18 @@ class LevellogServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("deleteById 메서드는")
-    class DeleteByIdTest {
+    class DeleteById {
 
         @Test
         @DisplayName("id에 해당하는 레벨로그를 삭제한다.")
         void success() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(member, team, "original content"));
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
 
             // when
-            levellogService.deleteById(levellog.getId(), member.getId());
+            levellogService.deleteById(levellog.getId(), author.getId());
 
             // then
             final Optional<Levellog> actual = levellogRepository.findById(levellog.getId());
@@ -283,15 +271,12 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("id에 해당하는 레벨로그가 존재하지 않는 경우 예외를 던진다.")
         void deleteById_notFound_exception() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
-            final Long memberId = member.getId();
-            levellogRepository.deleteById(levellogId);
+            final Long authorId = memberRepository.save(new Member("알린", 1111, "alien.img"))
+                    .getId();
+            final Long levellogId = 1000L;
 
             // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.deleteById(levellogId, authorId))
                     .isInstanceOf(LevellogNotFoundException.class)
                     .hasMessageContainingAll("레벨로그가 존재하지 않습니다.", String.valueOf(levellogId));
         }
@@ -300,31 +285,35 @@ class LevellogServiceTest extends ServiceTest {
         @DisplayName("memberId에 해당하는 작성자가 존재하지 않는 경우 예외를 던진다.")
         void deleteById_memberNotFound_exception() {
             // given
-            final Member member = memberRepository.save(new Member("알린", 1111, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "Spring을 학습하였습니다.")).getId();
-            final Long memberId = member.getId();
-            memberRepository.deleteById(memberId);
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+
+            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."))
+                    .getId();
+            final Long authorId = author.getId();
+
+            memberRepository.deleteById(authorId);
 
             // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.deleteById(levellogId, authorId))
                     .isInstanceOf(MemberNotFoundException.class)
-                    .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(memberId));
+                    .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(authorId));
         }
 
         @Test
         @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
         void deleteById_unauthorized_Exception() {
             // given
-            final Long memberId = memberRepository.save(new Member("페퍼", 1111, "pepper.img")).getId();
-            final Member member = memberRepository.save(new Member("알린", 2222, "alien.img"));
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Long levellogId = levellogRepository.save(Levellog.of(member, team, "original content")).getId();
+            final Member author = memberRepository.save(new Member("알린", 2222, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Long levellogId = levellogRepository.save(Levellog.of(author, team, "original content"))
+                    .getId();
+
+            final Long otherMemberId = memberRepository.save(new Member("페퍼", 1111, "pepper.img"))
+                    .getId();
 
             // when & then
-            assertThatThrownBy(() -> levellogService.deleteById(levellogId, memberId))
+            assertThatThrownBy(() -> levellogService.deleteById(levellogId, otherMemberId))
                     .isInstanceOf(UnauthorizedException.class);
         }
     }
@@ -339,10 +328,8 @@ class LevellogServiceTest extends ServiceTest {
             // given
             final Member author = memberRepository.save(new Member("페퍼", 1111, "pepper.img"));
 
-            final Team team = teamRepository.save(
-                    new Team("잠실 네오조", "잠실 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
-            final Team team2 = teamRepository.save(
-                    new Team("선릉 제이슨조", "선릉 트랙룸", setTeamStartAt().plusDays(3), "profileUrl", 1));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", TOMORROW, "profileUrl", 1));
+            final Team team2 = teamRepository.save(new Team("선릉 제이슨조", "선릉 트랙룸", TOMORROW, "profileUrl", 1));
 
             levellogRepository.save(Levellog.of(author, team, "content1"));
             levellogRepository.save(Levellog.of(author, team2, "content2"));

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -247,7 +247,7 @@ class LevellogServiceTest extends ServiceTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("수정한 레벨로그의 내용이 공백이나 null일 경우 예외를 던진다.")
-        void update_contentBlank_Exception(final String invalidContent) {
+        void update_contentBlank_exception(final String invalidContent) {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from(invalidContent);
             final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
@@ -261,6 +261,22 @@ class LevellogServiceTest extends ServiceTest {
             assertThatThrownBy(() -> levellogService.update(request, levellogId, authorId))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessage("레벨로그 내용은 공백이나 null일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("인터뷰 시작 후에 요청한 경우 예외를 반환한다.")
+        void update_afterStart_exception() {
+            // given
+            final LevellogDto request = LevellogDto.from("update content");
+            final Member author = memberRepository.save(new Member("알린", 1111, "alien.img"));
+            final Team team = teamRepository.save(new Team("잠실 네오조", "잠실 트랙룸", BEFORE_FAKE_NOW_TIME, "profileUrl", 1));
+
+            final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "original content"));
+
+            // when & then
+            assertThatThrownBy(() -> levellogService.update(request, levellog.getId(), author.getId()))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
         }
     }
 
@@ -367,5 +383,4 @@ class LevellogServiceTest extends ServiceTest {
                     .hasMessageContainingAll("멤버가 존재하지 않음", String.valueOf(1_000_000L));
         }
     }
-
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -278,7 +278,7 @@ class LevellogServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> levellogService.update(request, levellog.getId(), author.getId()))
                     .isInstanceOf(InterviewTimeException.class)
-                    .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
+                    .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 수정이 가능합니다.", String.valueOf(team.getId()));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/ServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.levellog.application;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.application.OAuthService;
 import com.woowacourse.levellog.authentication.support.JwtTokenProvider;
+import com.woowacourse.levellog.config.FakeTimeStandard;
 import com.woowacourse.levellog.config.TestConfig;
 import com.woowacourse.levellog.feedback.application.FeedbackService;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
@@ -11,13 +12,14 @@ import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionReposi
 import com.woowacourse.levellog.levellog.application.LevellogService;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.application.MemberService;
-import com.woowacourse.levellog.member.domain.NicknameMappingRepository;
 import com.woowacourse.levellog.member.domain.MemberRepository;
+import com.woowacourse.levellog.member.domain.NicknameMappingRepository;
 import com.woowacourse.levellog.prequestion.application.PreQuestionService;
 import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
 import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -35,6 +37,9 @@ abstract class ServiceTest {
 
     @Autowired
     protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected FakeTimeStandard timeStandard;
 
     @Autowired
     protected MemberService memberService;
@@ -80,4 +85,9 @@ abstract class ServiceTest {
 
     @Autowired
     protected PreQuestionRepository preQuestionRepository;
+
+    @BeforeEach
+    void setUp() {
+        timeStandard.setBeforeStarted();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/config/FakeTimeStandard.java
+++ b/backend/src/test/java/com/woowacourse/levellog/config/FakeTimeStandard.java
@@ -1,14 +1,25 @@
 package com.woowacourse.levellog.config;
 
+import static com.woowacourse.levellog.fixture.TimeFixture.AFTER_START_TIME;
+import static com.woowacourse.levellog.fixture.TimeFixture.BEFORE_START_TIME;
+
 import com.woowacourse.levellog.team.support.TimeStandard;
 import java.time.LocalDateTime;
 
 public class FakeTimeStandard implements TimeStandard {
 
-    public static final int PLUS_DAYS = 5;
+    private LocalDateTime now = BEFORE_START_TIME;
 
     @Override
     public LocalDateTime now() {
-        return LocalDateTime.now().plusDays(PLUS_DAYS);
+        return now;
+    }
+
+    public void setBeforeStarted() {
+        now = BEFORE_START_TIME;
+    }
+
+    public void setInProgress() {
+        now = AFTER_START_TIME;
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
@@ -1,5 +1,8 @@
 package com.woowacourse.levellog.domain;
 
+import static com.woowacourse.levellog.fixture.TimeFixture.AFTER_START_TIME;
+import static com.woowacourse.levellog.fixture.TimeFixture.BEFORE_START_TIME;
+import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -10,7 +13,6 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.exception.InterviewTimeException;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,8 +23,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 @DisplayName("LevellogTest 의")
 class LevellogTest {
 
-    private static final LocalDateTime TOMORROW = LocalDateTime.now().plusDays(3);
-
     @Nested
     @DisplayName("생성자는")
     class ConstructorTest {
@@ -32,7 +32,7 @@ class LevellogTest {
         void success() {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
             final String content = "Spring을 학습하였습니다";
 
             // when & then
@@ -46,7 +46,7 @@ class LevellogTest {
         void newLevellog_contentBlank_exception(final String invalidContent) {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
 
             //  when & then
             assertThatThrownBy(() -> Levellog.of(author, team, invalidContent))
@@ -64,12 +64,12 @@ class LevellogTest {
         void success() {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
             final Levellog levellog = Levellog.of(author, team, "content");
             final String updatedContent = "updated content";
 
             // when
-            levellog.updateContent(author, updatedContent, LocalDateTime.now());
+            levellog.updateContent(author, updatedContent, BEFORE_START_TIME);
 
             // then
             assertThat(levellog.getContent()).isEqualTo(updatedContent);
@@ -81,11 +81,11 @@ class LevellogTest {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
             final Member member = new Member("알린", 2222, "alien.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
             final Levellog levellog = Levellog.of(author, team, "content");
 
             //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(member, "update content", LocalDateTime.now()))
+            assertThatThrownBy(() -> levellog.updateContent(member, "update content", BEFORE_START_TIME))
                     .isInstanceOf(UnauthorizedException.class)
                     .hasMessageContainingAll("레벨로그를 수정할 권한이 없습니다.", String.valueOf(member.getId()),
                             String.valueOf(levellog.getId()));
@@ -99,11 +99,11 @@ class LevellogTest {
         void updateContent_contentBlank_exception(final String invalidContent) {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
             final Levellog levellog = Levellog.of(author, team, "content");
 
             //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(author, invalidContent, LocalDateTime.now()))
+            assertThatThrownBy(() -> levellog.updateContent(author, invalidContent, BEFORE_START_TIME))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessage("레벨로그 내용은 공백이나 null일 수 없습니다.");
         }
@@ -113,11 +113,11 @@ class LevellogTest {
         void updateContent_afterStartTime_exception() {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
             final Levellog levellog = Levellog.of(author, team, "content");
 
             //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(author, "new content", TOMORROW.plusHours(1)))
+            assertThatThrownBy(() -> levellog.updateContent(author, "new content", AFTER_START_TIME))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
         }
@@ -128,11 +128,11 @@ class LevellogTest {
     void validateTeamStartTime() {
         // given
         final Member author = new Member("페퍼", 1111, "pepper.png");
-        final Team team = new Team("잠실 제이슨조,", "트랙룸", TOMORROW, "jamsil_trackroom.png", 1);
+        final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
         final Levellog levellog = Levellog.of(author, team, "content");
 
         // when & then
-        assertThatThrownBy(() -> levellog.validateTeamStartTime(TOMORROW.plusHours(3)))
+        assertThatThrownBy(() -> levellog.validateTeamStartTime(AFTER_START_TIME))
                 .isInstanceOf(InterviewTimeException.class)
                 .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
     }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
@@ -1,7 +1,5 @@
 package com.woowacourse.levellog.domain;
 
-import static com.woowacourse.levellog.fixture.TimeFixture.AFTER_START_TIME;
-import static com.woowacourse.levellog.fixture.TimeFixture.BEFORE_START_TIME;
 import static com.woowacourse.levellog.fixture.TimeFixture.TEAM_START_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,7 +10,6 @@ import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,7 +66,7 @@ class LevellogTest {
             final String updatedContent = "updated content";
 
             // when
-            levellog.updateContent(author, updatedContent, BEFORE_START_TIME);
+            levellog.updateContent(author, updatedContent);
 
             // then
             assertThat(levellog.getContent()).isEqualTo(updatedContent);
@@ -85,7 +82,7 @@ class LevellogTest {
             final Levellog levellog = Levellog.of(author, team, "content");
 
             //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(member, "update content", BEFORE_START_TIME))
+            assertThatThrownBy(() -> levellog.updateContent(member, "update content"))
                     .isInstanceOf(UnauthorizedException.class)
                     .hasMessageContainingAll("레벨로그를 수정할 권한이 없습니다.", String.valueOf(member.getId()),
                             String.valueOf(levellog.getId()));
@@ -103,37 +100,9 @@ class LevellogTest {
             final Levellog levellog = Levellog.of(author, team, "content");
 
             //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(author, invalidContent, BEFORE_START_TIME))
+            assertThatThrownBy(() -> levellog.updateContent(author, invalidContent))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessage("레벨로그 내용은 공백이나 null일 수 없습니다.");
         }
-
-        @Test
-        @DisplayName("인터뷰가 시작된 이후에는 예외를 던진다.")
-        void updateContent_afterStartTime_exception() {
-            // given
-            final Member author = new Member("페퍼", 1111, "pepper.png");
-            final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
-            final Levellog levellog = Levellog.of(author, team, "content");
-
-            //  when & then
-            assertThatThrownBy(() -> levellog.updateContent(author, "new content", AFTER_START_TIME))
-                    .isInstanceOf(InterviewTimeException.class)
-                    .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
-        }
-    }
-
-    @Test
-    @DisplayName("validateTeamStartTime 메서드는 주어진 시간에 팀의 상태가 인터뷰 시작 전이 아닌 경우 예외를 던진다.")
-    void validateTeamStartTime() {
-        // given
-        final Member author = new Member("페퍼", 1111, "pepper.png");
-        final Team team = new Team("잠실 제이슨조,", "트랙룸", TEAM_START_TIME, "jamsil_trackroom.png", 1);
-        final Levellog levellog = Levellog.of(author, team, "content");
-
-        // when & then
-        assertThatThrownBy(() -> levellog.validateTeamStartTime(AFTER_START_TIME))
-                .isInstanceOf(InterviewTimeException.class)
-                .hasMessageContainingAll("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.", String.valueOf(team.getId()));
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -413,6 +413,24 @@ class TeamTest {
     }
 
     @Nested
+    @DisplayName("validateBeforeStartAt 메서드는")
+    class ValidateBeforeStartAt {
+
+        @Test
+        @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이후면 예외가 발생한다.")
+        void validate_beforeStartAt_thrownException() {
+            // given
+            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
+            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
+
+            // when & then
+            assertThatThrownBy(() -> team.validateBeforeStartAt(startAt.plusDays(1), "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다."))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.");
+        }
+    }
+
+    @Nested
     @DisplayName("validateBeforeClose 메서드는")
     class ValidateBeforeClose {
 

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/TimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/TimeFixture.java
@@ -1,0 +1,10 @@
+package com.woowacourse.levellog.fixture;
+
+import java.time.LocalDateTime;
+
+public class TimeFixture {
+
+    public static final LocalDateTime BEFORE_START_TIME = LocalDateTime.now().plusDays(5);
+    public static final LocalDateTime TEAM_START_TIME = LocalDateTime.now().plusDays(6);
+    public static final LocalDateTime AFTER_START_TIME = LocalDateTime.now().plusDays(7);
+}

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
@@ -1,7 +1,7 @@
 package com.woowacourse.levellog.presentation;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -66,8 +66,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new InvalidFieldException("인터뷰 질문은 255자 이하여야합니다."))
-                    .when(interviewQuestionService)
+            willThrow(new InvalidFieldException("인터뷰 질문은 255자 이하여야합니다."))
+                    .given(interviewQuestionService)
                     .save(request, 1L, 1L);
 
             // when
@@ -95,8 +95,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .save(request, invalidLevellogId, 1L);
 
             // when
@@ -126,8 +126,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn(String.valueOf(invalidMemberId));
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new MemberNotFoundException("멤버가 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new MemberNotFoundException("멤버가 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .save(request, levellogId, invalidMemberId);
 
             // when
@@ -158,8 +158,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
             final long invalidLevellogId = 20000000L;
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .findAllByLevellogAndAuthor(invalidLevellogId, 1L);
 
             // when
@@ -184,8 +184,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
             final long levellogId = 1L;
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn(String.valueOf(invalidMemberId));
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new MemberNotFoundException("멤버가 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new MemberNotFoundException("멤버가 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .findAllByLevellogAndAuthor(levellogId, invalidMemberId);
 
             // when
@@ -241,8 +241,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new InvalidFieldException("인터뷰 질문은 255자 이하여야합니다."))
-                    .when(interviewQuestionService)
+            willThrow(new InvalidFieldException("인터뷰 질문은 255자 이하여야합니다."))
+                    .given(interviewQuestionService)
                     .update(request, 1L, 1L);
 
             // when
@@ -271,8 +271,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new InterviewQuestionNotFoundException("인터뷰 질문이 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new InterviewQuestionNotFoundException("인터뷰 질문이 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .update(request, invalidInterviewQuestionId, 1L);
 
             // when
@@ -301,8 +301,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new UnauthorizedException("권한이 없습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new UnauthorizedException("권한이 없습니다."))
+                    .given(interviewQuestionService)
                     .update(request, 1L, 1L);
 
             // when
@@ -334,8 +334,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new InterviewQuestionNotFoundException("인터뷰 질문이 존재하지 않습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new InterviewQuestionNotFoundException("인터뷰 질문이 존재하지 않습니다."))
+                    .given(interviewQuestionService)
                     .deleteById(invalidInterviewQuestionId, 1L);
 
             // when
@@ -359,8 +359,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
             // given
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new UnauthorizedException("권한이 없습니다."))
-                    .when(interviewQuestionService)
+            willThrow(new UnauthorizedException("권한이 없습니다."))
+                    .given(interviewQuestionService)
                     .deleteById(1L, 1L);
 
             // when

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -71,7 +71,7 @@ class LevellogControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("팀의 인터뷰가 시작된 이후에 요청하는 경우 예외를 던진다.")
+        @DisplayName("팀의 인터뷰가 시작된 이후에 레벨로그를 저장하는 경우 예외를 던진다.")
         void save_afterStart_exception() throws Exception {
             // given
             final LevellogWriteDto request = LevellogWriteDto.from("content");
@@ -180,7 +180,7 @@ class LevellogControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("팀의 인터뷰가 시작된 이후에 요청하는 경우 예외를 던진다.")
+        @DisplayName("팀의 인터뷰가 시작된 이후에 레벨로그를 수정하는 경우 예외를 던진다.")
         void update_afterStart_exception() throws Exception {
             // given
             final Long teamId = 1L;

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.levellog.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -43,7 +42,7 @@ class LevellogControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new LevellogAlreadyExistException("팀에 레벨로그를 이미 작성했습니다.")).when(levellogService)
+            willThrow(new LevellogAlreadyExistException("팀에 레벨로그를 이미 작성했습니다.")).given(levellogService)
                     .save(request, authorId, teamId);
 
             // when
@@ -90,7 +89,8 @@ class LevellogControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.")).when(levellogService)
+            willThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다."))
+                    .given(levellogService)
                     .save(request, authorId, teamId);
 
             // when
@@ -124,7 +124,8 @@ class LevellogControllerTest extends ControllerTest {
             final Long teamId = 1L;
             final Long levellogId = 1000L;
 
-            doThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다.")).when(levellogService)
+            willThrow(new LevellogNotFoundException("레벨로그가 존재하지 않습니다."))
+                    .given(levellogService)
                     .findById(levellogId);
 
             // when
@@ -181,7 +182,8 @@ class LevellogControllerTest extends ControllerTest {
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new UnauthorizedException("권한이 없습니다.")).when(levellogService)
+            willThrow(new UnauthorizedException("권한이 없습니다."))
+                    .given(levellogService)
                     .update(request, levellogId, authorId);
 
             // when
@@ -208,7 +210,8 @@ class LevellogControllerTest extends ControllerTest {
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
 
-            willThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다.")).given(levellogService)
+            willThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다."))
+                    .given(levellogService)
                     .update(request, levellogId, authorId);
 
             // when

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -203,7 +202,7 @@ class LevellogControllerTest extends ControllerTest {
             final Long teamId = 1L;
             final Long levellogId = 2L;
             final Long authorId = 1L;
-            final LevellogDto request = LevellogDto.from("new content");
+            final LevellogWriteDto request = LevellogWriteDto.from("new content");
             final String requestContent = objectMapper.writeValueAsString(request);
 
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
@@ -232,38 +231,6 @@ class LevellogControllerTest extends ControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(requestContent))
                     .andDo(print());
-        }
-    }
-
-    @Nested
-    @DisplayName("delete 메서드는")
-    class DeleteTest {
-
-        @Test
-        @DisplayName("본인이 작성하지 않은 레벨로그를 삭제하려는 경우 예외를 던진다.")
-        void delete_nameNullOrEmpty_Exception() throws Exception {
-            // given
-            final Long teamId = 1L;
-            final Long memberId = 1L;
-            final Long levellogId = 2L;
-
-            given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
-            given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
-            doThrow(new UnauthorizedException("권한이 없습니다.")).when(levellogService)
-                    .deleteById(levellogId, memberId);
-
-            // when
-            final ResultActions perform = mockMvc.perform(
-                            delete("/api/teams/{teamId}/levellogs/{levellogId}", teamId, levellogId)
-                                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
-                    .andDo(print());
-
-            // then
-            perform.andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("message").value("권한이 없습니다."));
-
-            // docs
-            perform.andDo(document("levellog/delete/exception-author"));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -191,7 +191,7 @@ class LevellogControllerTest extends ControllerTest {
             given(jwtTokenProvider.getPayload(ACCESS_TOKEN)).willReturn("1");
             given(jwtTokenProvider.validateToken(ACCESS_TOKEN)).willReturn(true);
 
-            willThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 작성이 가능합니다."))
+            willThrow(new InterviewTimeException("인터뷰 시작 전에만 레벨로그 수정이 가능합니다."))
                     .given(levellogService)
                     .update(request, levellogId, authorId);
 
@@ -200,7 +200,7 @@ class LevellogControllerTest extends ControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("message").value("인터뷰 시작 전에만 레벨로그 작성이 가능합니다."));
+                    .andExpect(jsonPath("message").value("인터뷰 시작 전에만 레벨로그 수정이 가능합니다."));
 
             // docs
             perform.andDo(document("levellog/update/exception-after-start"));

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -3,7 +3,7 @@ package com.woowacourse.levellog.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -36,8 +36,8 @@ class MyInfoControllerTest extends ControllerTest {
             given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
             given(jwtTokenProvider.validateToken(any())).willReturn(true);
 
-            doThrow(new InvalidFieldException("닉네임은 50자 이하여야합니다."))
-                    .when(memberService)
+            willThrow(new InvalidFieldException("닉네임은 50자 이하여야합니다."))
+                    .given(memberService)
                     .updateNickname(any(), any());
             final String invalidNickname = "a".repeat(51);
 


### PR DESCRIPTION
## 구현 기능
- 레벨로그 생성 시 인터뷰 시작 전에만 레벨로그 생성 가능
- 레벨로그 수정 시 인터뷰 시작 전에만 레벨로그 수정 가능
- 레벨로그 삭제 기능 제거 ( 🚨 프론트에게 알려야함 )

## 논의하고 싶은 내용
- TimeStandard에 대한 논의

## 공유하고 싶은 내용
- TimeStandard를 조금 손봤습니다.
  - 기존에 시간 의존적인 테스트는 팀을 만드는 시간을 꼭 유의해서 작성해야합니다. ( 이제 거의 모든 통합테스트가 시간에 민감해짐 )
  - TimeFixture를 만들어서 내부에 `AFTER_FAKE_NOW_TIME`, `BEFORE_FAKE_NOW_TIME` 를 만들었습니다.
  - `AFTER_FAKE_NOW_TIME` : 현재 시간의 5일 + 1시간
  - `BEFORE_FAKE_NOW_TIME` : 현재 시간의 5일 + 1시간
    - 왜 애매하게 1시간으로 함? -> 추후 스케쥴링이 적용되면 인터뷰 시작 하고 하루까지만 유효할 것 같아서
🚨 사용 : 통합테스트의 팀 생성할 때는 위 두 픽스쳐를 활용해서 StartAt을 넣어준다.


Close #237
