### PR TITLE
refactor: 픽스처를 활용해서 repository 테스트 개선

### DIFF
--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
@@ -3,44 +3,18 @@ package com.woowacourse.levellog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.feedback.domain.Feedback;
-import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.Participant;
-import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("FeedbackRepository의")
-class FeedbackRepositoryTest {
-
-    @Autowired
-    MemberRepository memberRepository;
-
-    @Autowired
-    LevellogRepository levellogRepository;
-
-    @Autowired
-    TeamRepository teamRepository;
-
-    @Autowired
-    ParticipantRepository participantRepository;
-
-    @Autowired
-    FeedbackRepository feedbackRepository;
+class FeedbackRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findAllByLevellog 메서드는 입력된 레벨로그에 등록된 모든 피드백을 조회한다.")
@@ -51,7 +25,7 @@ class FeedbackRepositoryTest {
         final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
         final Team team = teamRepository.save(
                 new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                1));
+                        1));
         participantRepository.save(new Participant(team, eve, true));
         participantRepository.save(new Participant(team, rick, false));
         participantRepository.save(new Participant(team, toMember, false));
@@ -79,7 +53,7 @@ class FeedbackRepositoryTest {
         final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
         final Team team = teamRepository.save(
                 new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                1));
+                        1));
         participantRepository.save(new Participant(team, eve, true));
         participantRepository.save(new Participant(team, rick, false));
         participantRepository.save(new Participant(team, toMember, false));
@@ -108,7 +82,7 @@ class FeedbackRepositoryTest {
         final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
         final Team team = teamRepository.save(
                 new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                1));
+                        1));
         participantRepository.save(new Participant(team, fromMember, true));
         participantRepository.save(new Participant(team, toMember, false));
         final Levellog levellog = levellogRepository.save(Levellog.of(toMember, team, "levellog"));

--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
@@ -18,15 +18,15 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByLevellog 메서드는 입력된 레벨로그에 등록된 모든 피드백을 조회한다.")
     void findAllByLevellog() {
         // given
-        final Member eve = getMember("eve");
-        final Member rick = getMember("rick");
-        final Member toMember = getMember("toMember");
+        final Member eve = saveMember("eve");
+        final Member rick = saveMember("rick");
+        final Member toMember = saveMember("toMember");
 
-        final Team team = getTeam(eve, rick, toMember);
-        final Levellog levellog = getLevellog(toMember, team);
+        final Team team = saveTeam(eve, rick, toMember);
+        final Levellog levellog = saveLevellog(toMember, team);
 
-        final Feedback savedFeedback1 = getFeedback(eve, toMember, levellog);
-        final Feedback savedFeedback2 = getFeedback(rick, toMember, levellog);
+        final Feedback savedFeedback1 = saveFeedback(eve, toMember, levellog);
+        final Feedback savedFeedback2 = saveFeedback(rick, toMember, levellog);
 
         // when
         final List<Feedback> feedbacks = feedbackRepository.findAllByLevellog(levellog);
@@ -40,15 +40,15 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByToOrderByUpdatedAtDesc 메서드는 입력된 멤버가 받은 피드백을 수정일 기준 내림차순으로 조회한다.")
     void findAllByToOrderByUpdatedAtDesc() {
         // given
-        final Member eve = getMember("eve");
-        final Member rick = getMember("rick");
-        final Member toMember = getMember("toMember");
+        final Member eve = saveMember("eve");
+        final Member rick = saveMember("rick");
+        final Member toMember = saveMember("toMember");
 
-        final Team team = getTeam(eve, rick, toMember);
-        final Levellog levellog = getLevellog(toMember, team);
+        final Team team = saveTeam(eve, rick, toMember);
+        final Levellog levellog = saveLevellog(toMember, team);
 
-        final Feedback savedFeedback1 = getFeedback(eve, toMember, levellog);
-        final Feedback savedFeedback2 = getFeedback(rick, toMember, levellog);
+        final Feedback savedFeedback1 = saveFeedback(eve, toMember, levellog);
+        final Feedback savedFeedback2 = saveFeedback(rick, toMember, levellog);
 
         savedFeedback2.updateFeedback("update", "update", "update");
 
@@ -64,13 +64,13 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("existsByLevellogIdAndFromId 메서드는 입력 받은 레벨로그 Id와 작성자 Id로 작성된 피드백의 존재 여부를 반환한다.")
     void existsByLevellogIdAndFromId() {
         // given
-        final Member eve = getMember("eve");
-        final Member rick = getMember("rick");
+        final Member eve = saveMember("eve");
+        final Member rick = saveMember("rick");
 
-        final Team team = getTeam(eve, rick);
-        final Levellog levellog = getLevellog(rick, team);
+        final Team team = saveTeam(eve, rick);
+        final Levellog levellog = saveLevellog(rick, team);
 
-        getFeedback(eve, rick, levellog);
+        saveFeedback(eve, rick, levellog);
 
         // when
         final boolean isExist1 = feedbackRepository.existsByLevellogIdAndFromId(levellog.getId(), eve.getId());

--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackRepositoryTest.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.woowacourse.levellog.feedback.domain.Feedback;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,21 +18,15 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByLevellog 메서드는 입력된 레벨로그에 등록된 모든 피드백을 조회한다.")
     void findAllByLevellog() {
         // given
-        final Member eve = memberRepository.save(new Member("eve", 111, "profile.img"));
-        final Member rick = memberRepository.save(new Member("rick", 222, "profile.img"));
-        final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                        1));
-        participantRepository.save(new Participant(team, eve, true));
-        participantRepository.save(new Participant(team, rick, false));
-        participantRepository.save(new Participant(team, toMember, false));
-        final Levellog levellog = levellogRepository.save(Levellog.of(toMember, team, "levellog"));
+        final Member eve = getMember("eve");
+        final Member rick = getMember("rick");
+        final Member toMember = getMember("toMember");
 
-        final Feedback savedFeedback1 = feedbackRepository.save(
-                new Feedback(eve, toMember, levellog, "study", "speak", "etc"));
-        final Feedback savedFeedback2 = feedbackRepository.save(
-                new Feedback(rick, toMember, levellog, "study", "speak", "etc"));
+        final Team team = getTeam(eve, rick, toMember);
+        final Levellog levellog = getLevellog(toMember, team);
+
+        final Feedback savedFeedback1 = getFeedback(eve, toMember, levellog);
+        final Feedback savedFeedback2 = getFeedback(rick, toMember, levellog);
 
         // when
         final List<Feedback> feedbacks = feedbackRepository.findAllByLevellog(levellog);
@@ -48,21 +40,15 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByToOrderByUpdatedAtDesc 메서드는 입력된 멤버가 받은 피드백을 수정일 기준 내림차순으로 조회한다.")
     void findAllByToOrderByUpdatedAtDesc() {
         // given
-        final Member eve = memberRepository.save(new Member("eve", 111, "profile.img"));
-        final Member rick = memberRepository.save(new Member("rick", 222, "profile.img"));
-        final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                        1));
-        participantRepository.save(new Participant(team, eve, true));
-        participantRepository.save(new Participant(team, rick, false));
-        participantRepository.save(new Participant(team, toMember, false));
-        final Levellog levellog = levellogRepository.save(Levellog.of(toMember, team, "levellog"));
+        final Member eve = getMember("eve");
+        final Member rick = getMember("rick");
+        final Member toMember = getMember("toMember");
 
-        final Feedback savedFeedback1 = feedbackRepository.save(
-                new Feedback(eve, toMember, levellog, "study", "speak", "etc"));
-        final Feedback savedFeedback2 = feedbackRepository.save(
-                new Feedback(rick, toMember, levellog, "study", "speak", "etc"));
+        final Team team = getTeam(eve, rick, toMember);
+        final Levellog levellog = getLevellog(toMember, team);
+
+        final Feedback savedFeedback1 = getFeedback(eve, toMember, levellog);
+        final Feedback savedFeedback2 = getFeedback(rick, toMember, levellog);
 
         savedFeedback2.updateFeedback("update", "update", "update");
 
@@ -78,23 +64,20 @@ class FeedbackRepositoryTest extends RepositoryTest {
     @DisplayName("existsByLevellogIdAndFromId 메서드는 입력 받은 레벨로그 Id와 작성자 Id로 작성된 피드백의 존재 여부를 반환한다.")
     void existsByLevellogIdAndFromId() {
         // given
-        final Member fromMember = memberRepository.save(new Member("fromMember", 111, "profile.img"));
-        final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img",
-                        1));
-        participantRepository.save(new Participant(team, fromMember, true));
-        participantRepository.save(new Participant(team, toMember, false));
-        final Levellog levellog = levellogRepository.save(Levellog.of(toMember, team, "levellog"));
+        final Member eve = getMember("eve");
+        final Member rick = getMember("rick");
 
-        feedbackRepository.save(new Feedback(fromMember, toMember, levellog, "study", "speak", "etc"));
+        final Team team = getTeam(eve, rick);
+        final Levellog levellog = getLevellog(rick, team);
+
+        getFeedback(eve, rick, levellog);
 
         // when
-        final boolean isExist1 = feedbackRepository.existsByLevellogIdAndFromId(levellog.getId(), fromMember.getId());
+        final boolean isExist1 = feedbackRepository.existsByLevellogIdAndFromId(levellog.getId(), eve.getId());
         final boolean isExist2 = feedbackRepository.existsByLevellogIdAndFromId(levellog.getId() + 1,
-                fromMember.getId());
+                eve.getId());
         final boolean isExist3 = feedbackRepository.existsByLevellogIdAndFromId(levellog.getId(),
-                fromMember.getId() + 1);
+                eve.getId() + 1);
 
         // then
         assertAll(() -> {

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
@@ -5,9 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,18 +17,14 @@ class InterviewQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByLevellogAndAuthor 메서드는 levellog와 author 멤버가 모두 일치하는 인터뷰 질문 목록를 반환한다.")
     void findAllByLevellogAndAuthor() {
         // given
-        final Member eve = memberRepository.save(new Member("eve", 111, "profile.img"));
-        final Member toMember = memberRepository.save(new Member("toMember", 333, "profile.img"));
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "작은 강의실", LocalDateTime.now().plusDays(3), "team.img", 1));
-        participantRepository.save(new Participant(team, eve, true));
-        participantRepository.save(new Participant(team, toMember, false));
-        final Levellog levellog = levellogRepository.save(Levellog.of(toMember, team, "levellog"));
+        final Member eve = getMember("eve");
+        final Member toMember = getMember("toMember");
 
-        final InterviewQuestion savedInterviewQuestion1 = interviewQuestionRepository.save(
-                InterviewQuestion.of(eve, levellog, "스프링을 왜 사용하였나요?"));
-        final InterviewQuestion savedInterviewQuestion2 = interviewQuestionRepository.save(
-                InterviewQuestion.of(eve, levellog, "AOP란?"));
+        final Team team = getTeam(eve, toMember);
+        final Levellog levellog = getLevellog(toMember, team);
+
+        final InterviewQuestion savedInterviewQuestion1 = getInterviewQuestion("스프링을 왜 사용하였나요?", levellog, eve);
+        final InterviewQuestion savedInterviewQuestion2 = getInterviewQuestion("AOP란?", levellog, eve);
 
         // when
         final List<InterviewQuestion> interviewQuestions = interviewQuestionRepository.findAllByLevellogAndAuthor(

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
@@ -2,44 +2,18 @@ package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
-import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionRepository;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.Participant;
-import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
-@DisplayName("InterviewQuestionRepository 클래스의")
-class InterviewQuestionRepositoryTest {
-
-    @Autowired
-    private InterviewQuestionRepository interviewQuestionRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private TeamRepository teamRepository;
-
-    @Autowired
-    private ParticipantRepository participantRepository;
-
-    @Autowired
-    private LevellogRepository levellogRepository;
+@DisplayName("InterviewQuestionRepository의")
+class InterviewQuestionRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findAllByLevellogAndAuthor 메서드는 levellog와 author 멤버가 모두 일치하는 인터뷰 질문 목록를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionRepositoryTest.java
@@ -17,14 +17,14 @@ class InterviewQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByLevellogAndAuthor 메서드는 levellog와 author 멤버가 모두 일치하는 인터뷰 질문 목록를 반환한다.")
     void findAllByLevellogAndAuthor() {
         // given
-        final Member eve = getMember("eve");
-        final Member toMember = getMember("toMember");
+        final Member eve = saveMember("eve");
+        final Member toMember = saveMember("toMember");
 
-        final Team team = getTeam(eve, toMember);
-        final Levellog levellog = getLevellog(toMember, team);
+        final Team team = saveTeam(eve, toMember);
+        final Levellog levellog = saveLevellog(toMember, team);
 
-        final InterviewQuestion savedInterviewQuestion1 = getInterviewQuestion("스프링을 왜 사용하였나요?", levellog, eve);
-        final InterviewQuestion savedInterviewQuestion2 = getInterviewQuestion("AOP란?", levellog, eve);
+        final InterviewQuestion savedInterviewQuestion1 = saveInterviewQuestion("스프링을 왜 사용하였나요?", levellog, eve);
+        final InterviewQuestion savedInterviewQuestion2 = saveInterviewQuestion("AOP란?", levellog, eve);
 
         // when
         final List<InterviewQuestion> interviewQuestions = interviewQuestionRepository.findAllByLevellogAndAuthor(

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -22,10 +21,9 @@ class LevellogRepositoryTest extends RepositoryTest {
     @DisplayName("findByAuthorIdAndTeamId 메서드는 memberId와 teamId이 모두 일치하는 레벨로그를 반환한다.")
     void findByAuthorIdAndTeamId() {
         // given
-        final Member author = memberRepository.save(new Member("pepper", 1111, "pepper.png"));
-        final Team team = teamRepository.save(
-                new Team("선릉 브라운조", "무중력 광장", LocalDateTime.now().plusDays(1), "campus.png", 1));
-        final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."));
+        final Member author = getMember("pepper");
+        final Team team = getTeam(author);
+        final Levellog levellog = getLevellog(author, team);
 
         final Long authorId = author.getId();
         final Long teamId = team.getId();
@@ -37,6 +35,30 @@ class LevellogRepositoryTest extends RepositoryTest {
         assertThat(actual).hasValue(levellog);
     }
 
+    @Test
+    @DisplayName("findAllByAuthor 메서드는 주어진 author가 작성한 레벨로그를 모두 반환한다.")
+    void findAllByAuthor() {
+        // given
+        final Member author = getMember("pepper");
+        final Member anotherAuthor = getMember("roma");
+
+        final Team team = getTeam(author);
+        final Team team2 = getTeam(anotherAuthor, author);
+
+        final Levellog authorLevellog1 = getLevellog(author, team);
+        final Levellog authorLevellog2 = getLevellog(author, team2);
+        getLevellog(anotherAuthor, team);
+
+        // when
+        final List<Levellog> levellogs = levellogRepository.findAllByAuthor(author);
+
+        // then
+        assertAll(
+                () -> assertThat(levellogs).hasSize(2),
+                () -> assertThat(levellogs).contains(authorLevellog1, authorLevellog2)
+        );
+    }
+
     @Nested
     @DisplayName("existsByAuthorIdAndTeamId 메서드는")
     class ExistsByAuthorIdAndTeamIdTest {
@@ -45,10 +67,9 @@ class LevellogRepositoryTest extends RepositoryTest {
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하는 경우 true를 반환한다.")
         void exists() {
             // given
-            final Member author = memberRepository.save(new Member("pepper", 1111, "pepper.png"));
-            final Team team = teamRepository.save(
-                    new Team("선릉 브라운조", "무중력 광장", LocalDateTime.now().plusDays(1), "campus.png", 1));
-            levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."));
+            final Member author = getMember("pepper");
+            final Team team = getTeam(author);
+            getLevellog(author, team);
 
             final Long authorId = author.getId();
             final Long teamId = team.getId();
@@ -64,10 +85,9 @@ class LevellogRepositoryTest extends RepositoryTest {
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하지 않는 경우 false를 반환한다.")
         void notExists() {
             // given
-            final Member author = memberRepository.save(new Member("pepper", 1111, "pepper.png"));
-            final Team team = teamRepository.save(
-                    new Team("선릉 브라운조", "무중력 광장", LocalDateTime.now().plusDays(1), "campus.png", 1));
-            levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."));
+            final Member author = getMember("pepper");
+            final Team team = getTeam(author);
+            getLevellog(author, team);
 
             final Long anotherAuthorId = author.getId() + 1;
             final Long teamId = team.getId();
@@ -78,30 +98,5 @@ class LevellogRepositoryTest extends RepositoryTest {
             // then
             assertFalse(actual);
         }
-    }
-
-    @Test
-    @DisplayName("findAllByAuthor 메서드는 주어진 author가 작성한 레벨로그를 모두 반환한다.")
-    void findAllByAuthor() {
-        // given
-        final Member author = memberRepository.save(new Member("pepper", 1111, "pepper.png"));
-        final Member anotherAuthor = memberRepository.save(new Member("roma", 12345, "roma.png"));
-        final Team team = teamRepository.save(
-                new Team("선릉 브라운조", "무중력 광장", LocalDateTime.now().plusDays(1), "campus.png", 1));
-        final Team team2 = teamRepository.save(
-                new Team("선릉 네오조", "수성 회의실", LocalDateTime.now().plusDays(1), "campus2.png", 1));
-
-        final Levellog authorLevellog1 = levellogRepository.save(Levellog.of(author, team, "Spring을 학습하였습니다."));
-        final Levellog authorLevellog2 = levellogRepository.save(Levellog.of(author, team2, "JPA를 학습하였습니다."));
-        final Levellog anotherLevelog = levellogRepository.save(Levellog.of(anotherAuthor, team, "리액트를 학습하였습니다."));
-
-        // when
-        final List<Levellog> levellogs = levellogRepository.findAllByAuthor(author);
-
-        // then
-        assertAll(
-                () -> assertThat(levellogs).hasSize(2),
-                () -> assertThat(levellogs).contains(authorLevellog1, authorLevellog2)
-        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
@@ -5,36 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("LevellogRepository의")
-class LevellogRepositoryTest {
-
-    @Autowired
-    private LevellogRepository levellogRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private TeamRepository teamRepository;
+class LevellogRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findByAuthorIdAndTeamId 메서드는 memberId와 teamId이 모두 일치하는 레벨로그를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
@@ -21,9 +21,9 @@ class LevellogRepositoryTest extends RepositoryTest {
     @DisplayName("findByAuthorIdAndTeamId 메서드는 memberId와 teamId이 모두 일치하는 레벨로그를 반환한다.")
     void findByAuthorIdAndTeamId() {
         // given
-        final Member author = getMember("pepper");
-        final Team team = getTeam(author);
-        final Levellog levellog = getLevellog(author, team);
+        final Member author = saveMember("pepper");
+        final Team team = saveTeam(author);
+        final Levellog levellog = saveLevellog(author, team);
 
         final Long authorId = author.getId();
         final Long teamId = team.getId();
@@ -39,15 +39,15 @@ class LevellogRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByAuthor 메서드는 주어진 author가 작성한 레벨로그를 모두 반환한다.")
     void findAllByAuthor() {
         // given
-        final Member author = getMember("pepper");
-        final Member anotherAuthor = getMember("roma");
+        final Member author = saveMember("pepper");
+        final Member anotherAuthor = saveMember("roma");
 
-        final Team team = getTeam(author);
-        final Team team2 = getTeam(anotherAuthor, author);
+        final Team team = saveTeam(author);
+        final Team team2 = saveTeam(anotherAuthor, author);
 
-        final Levellog authorLevellog1 = getLevellog(author, team);
-        final Levellog authorLevellog2 = getLevellog(author, team2);
-        getLevellog(anotherAuthor, team);
+        final Levellog authorLevellog1 = saveLevellog(author, team);
+        final Levellog authorLevellog2 = saveLevellog(author, team2);
+        saveLevellog(anotherAuthor, team);
 
         // when
         final List<Levellog> levellogs = levellogRepository.findAllByAuthor(author);
@@ -67,9 +67,9 @@ class LevellogRepositoryTest extends RepositoryTest {
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하는 경우 true를 반환한다.")
         void exists() {
             // given
-            final Member author = getMember("pepper");
-            final Team team = getTeam(author);
-            getLevellog(author, team);
+            final Member author = saveMember("pepper");
+            final Team team = saveTeam(author);
+            saveLevellog(author, team);
 
             final Long authorId = author.getId();
             final Long teamId = team.getId();
@@ -85,9 +85,9 @@ class LevellogRepositoryTest extends RepositoryTest {
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하지 않는 경우 false를 반환한다.")
         void notExists() {
             // given
-            final Member author = getMember("pepper");
-            final Team team = getTeam(author);
-            getLevellog(author, team);
+            final Member author = saveMember("pepper");
+            final Team team = saveTeam(author);
+            saveLevellog(author, team);
 
             final Long anotherAuthorId = author.getId() + 1;
             final Long teamId = team.getId();

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
@@ -15,10 +15,11 @@ class MemberRepositoryTest extends RepositoryTest {
     @DisplayName("findByGithubId 메서드는 특정 GithubId가 포함된 멤버 객체를 반환한다.")
     void findByGithubId() {
         // given
-        final Member member = memberRepository.save(new Member("nickname", 10, "123"));
+        final Member member = getMember("릭");
+        final Integer githubId = member.getGithubId();
 
         // when
-        final Optional<Member> actual = memberRepository.findByGithubId(10);
+        final Optional<Member> actual = memberRepository.findByGithubId(githubId);
 
         // then
         assertThat(actual).hasValue(member);
@@ -28,13 +29,14 @@ class MemberRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByNicknameContains 메서드는 입력한 문자열이 포함된 nickname을 가진 멤버를 모두 조회한다.")
     void findAllByNicknameContains() {
         // given
-        final Member roma = memberRepository.save(new Member("roma", 10, "roma.img"));
-        final Member pepper = memberRepository.save(new Member("pepper", 20, "pepper.img"));
-        final Member alien = memberRepository.save(new Member("alien", 30, "alien.img"));
-        final Member rick = memberRepository.save(new Member("rick", 40, "rick.img"));
-        final Member eve = memberRepository.save(new Member("eve", 50, "eve.img"));
-        final Member kyul = memberRepository.save(new Member("kyul", 60, "kyul.img"));
-        final Member harry = memberRepository.save(new Member("harry", 70, "harry.img"));
+        getMember("roma");
+        getMember("pepper");
+        getMember("rick");
+        getMember("eve");
+        getMember("kyul");
+        getMember("harry");
+
+        final Member alien = getMember("alien");
 
         // when
         final List<Member> actual = memberRepository.findAllByNicknameContains("ali");

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
@@ -2,24 +2,14 @@ package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("MemberRepository의")
-class MemberRepositoryTest {
-
-    @Autowired
-    MemberRepository memberRepository;
+class MemberRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findByGithubId 메서드는 특정 GithubId가 포함된 멤버 객체를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberRepositoryTest.java
@@ -15,7 +15,7 @@ class MemberRepositoryTest extends RepositoryTest {
     @DisplayName("findByGithubId 메서드는 특정 GithubId가 포함된 멤버 객체를 반환한다.")
     void findByGithubId() {
         // given
-        final Member member = getMember("릭");
+        final Member member = saveMember("릭");
         final Integer githubId = member.getGithubId();
 
         // when
@@ -29,14 +29,14 @@ class MemberRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByNicknameContains 메서드는 입력한 문자열이 포함된 nickname을 가진 멤버를 모두 조회한다.")
     void findAllByNicknameContains() {
         // given
-        getMember("roma");
-        getMember("pepper");
-        getMember("rick");
-        getMember("eve");
-        getMember("kyul");
-        getMember("harry");
+        saveMember("roma");
+        saveMember("pepper");
+        saveMember("rick");
+        saveMember("eve");
+        saveMember("kyul");
+        saveMember("harry");
 
-        final Member alien = getMember("alien");
+        final Member alien = saveMember("alien");
 
         // when
         final List<Member> actual = memberRepository.findAllByNicknameContains("ali");

--- a/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
@@ -3,34 +3,16 @@ package com.woowacourse.levellog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.Participant;
-import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("ParticipantRepository의")
-public class ParticipantRepositoryTest {
-
-    @Autowired
-    ParticipantRepository participantRepository;
-
-    @Autowired
-    TeamRepository teamRepository;
-
-    @Autowired
-    MemberRepository memberRepository;
+class ParticipantRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findByTeam은 team이 일치하는 모든 participant를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
@@ -19,10 +19,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("findByTeam은 team이 일치하는 모든 participant를 반환한다.")
     void findByTeam() {
         // given
-        final Member alien = getMember("알린");
-        final Member roma = getMember("로마");
+        final Member alien = saveMember("알린");
+        final Member roma = saveMember("로마");
 
-        final Team team = getTeam(alien, roma);
+        final Team team = saveTeam(alien, roma);
 
         // when
         final List<Participant> participants = participantRepository.findByTeam(team);
@@ -39,10 +39,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("deleteByTeam는 team이 일치하는 모든 participant를 제거한다.")
     void deleteByTeam() {
         // given
-        final Member alien = getMember("알린");
-        final Member roma = getMember("로마");
+        final Member alien = saveMember("알린");
+        final Member roma = saveMember("로마");
 
-        final Team team = getTeam(alien, roma);
+        final Team team = saveTeam(alien, roma);
 
         // when
         participantRepository.deleteByTeam(team);
@@ -55,10 +55,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("existsByMemberAndTeam는 멤버와 팀이 일치 여부를 반환한다.")
     void existsByMemberAndTeam() {
         // given
-        final Member alien = getMember("알린");
-        final Member roma = getMember("로마");
+        final Member alien = saveMember("알린");
+        final Member roma = saveMember("로마");
 
-        final Team team = getTeam(alien);
+        final Team team = saveTeam(alien);
 
         // when
         final boolean existsAlien = participantRepository.existsByMemberAndTeam(alien, team);
@@ -75,11 +75,11 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByMember 메서드는 해당 멤버가 포함된 모든 participant 반환한다.")
     void findAllByMember() {
         // given
-        final Member alien = getMember("알린");
-        final Member roma = getMember("로마");
+        final Member alien = saveMember("알린");
+        final Member roma = saveMember("로마");
 
-        final Team team1 = getTeam(alien, roma);
-        final Team team2 = getTeam(roma);
+        final Team team1 = saveTeam(alien, roma);
+        final Team team2 = saveTeam(roma);
 
         // when
         final List<Participant> participants = participantRepository.findAllByMember(roma);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantRepositoryTest.java
@@ -3,11 +3,12 @@ package com.woowacourse.levellog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.levellog.common.domain.BaseEntity;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,17 +19,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("findByTeam은 team이 일치하는 모든 participant를 반환한다.")
     void findByTeam() {
         // given
-        final Team team = teamRepository.save(new Team(
-                "네오와 함께하는 레벨 인터뷰",
-                "선릉 트랙룸",
-                LocalDateTime.now().plusDays(3),
-                "profile.img", 1));
+        final Member alien = getMember("알린");
+        final Member roma = getMember("로마");
 
-        final Member alien = memberRepository.save(new Member("알린", 12345678, "alien.img"));
-        final Member roma = memberRepository.save(new Member("로마", 56781234, "roma.img"));
-
-        participantRepository.save(new Participant(team, alien, true));
-        participantRepository.save(new Participant(team, roma, false));
+        final Team team = getTeam(alien, roma);
 
         // when
         final List<Participant> participants = participantRepository.findByTeam(team);
@@ -45,17 +39,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("deleteByTeam는 team이 일치하는 모든 participant를 제거한다.")
     void deleteByTeam() {
         // given
-        final Team team = teamRepository.save(new Team(
-                "네오와 함께하는 레벨 인터뷰",
-                "선릉 트랙룸",
-                LocalDateTime.now().plusDays(3),
-                "profile.img", 1));
+        final Member alien = getMember("알린");
+        final Member roma = getMember("로마");
 
-        final Member alien = memberRepository.save(new Member("알린", 12345678, "alien.img"));
-        final Member roma = memberRepository.save(new Member("로마", 56781234, "roma.img"));
-
-        participantRepository.save(new Participant(team, alien, true));
-        participantRepository.save(new Participant(team, roma, false));
+        final Team team = getTeam(alien, roma);
 
         // when
         participantRepository.deleteByTeam(team);
@@ -68,16 +55,10 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("existsByMemberAndTeam는 멤버와 팀이 일치 여부를 반환한다.")
     void existsByMemberAndTeam() {
         // given
-        final Team team = teamRepository.save(new Team(
-                "네오와 함께하는 레벨 인터뷰",
-                "선릉 트랙룸",
-                LocalDateTime.now().plusDays(3),
-                "profile.img", 1));
+        final Member alien = getMember("알린");
+        final Member roma = getMember("로마");
 
-        final Member alien = memberRepository.save(new Member("알린", 12345678, "alien.img"));
-        final Member roma = memberRepository.save(new Member("로마", 56781234, "roma.img"));
-
-        participantRepository.save(new Participant(team, alien, true));
+        final Team team = getTeam(alien);
 
         // when
         final boolean existsAlien = participantRepository.existsByMemberAndTeam(alien, team);
@@ -94,26 +75,28 @@ class ParticipantRepositoryTest extends RepositoryTest {
     @DisplayName("findAllByMember 메서드는 해당 멤버가 포함된 모든 participant 반환한다.")
     void findAllByMember() {
         // given
-        final Team team = teamRepository.save(
-                new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", LocalDateTime.now().plusDays(3), "profile.img", 1));
-        final Team team2 = teamRepository.save(
-                new Team("브라운 잠실", "잠실 트랙룸", LocalDateTime.now().plusDays(3), "profile.img", 1));
+        final Member alien = getMember("알린");
+        final Member roma = getMember("로마");
 
-        final Member alien = memberRepository.save(new Member("알린", 12345678, "alien.img"));
-        final Member roma = memberRepository.save(new Member("로마", 56781234, "roma.img"));
-
-        final Participant romaParticipant1 = participantRepository.save(new Participant(team, roma, false));
-        final Participant romaParticipant2 = participantRepository.save(new Participant(team2, roma, true));
-
-        participantRepository.save(new Participant(team, alien, true)); // roma 비포함 participant
+        final Team team1 = getTeam(alien, roma);
+        final Team team2 = getTeam(roma);
 
         // when
         final List<Participant> participants = participantRepository.findAllByMember(roma);
 
+        final List<Long> actualTeamIds = toTeamIds(participants);
+
         // then
         assertAll(
                 () -> assertThat(participants).hasSize(2),
-                () -> assertThat(participants).contains(romaParticipant1, romaParticipant2)
+                () -> assertThat(actualTeamIds).contains(team1.getId(), team2.getId())
         );
+    }
+
+    private List<Long> toTeamIds(final List<Participant> participants) {
+        return participants.stream()
+                .map(Participant::getTeam)
+                .map(BaseEntity::getId)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -4,40 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.prequestion.domain.PreQuestion;
-import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
 import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("PreQuestionRepository의")
-class PreQuestionRepositoryTest {
-
-    @Autowired
-    PreQuestionRepository preQuestionRepository;
-
-    @Autowired
-    MemberRepository memberRepository;
-
-    @Autowired
-    TeamRepository teamRepository;
-
-    @Autowired
-    LevellogRepository levellogRepository;
+class PreQuestionRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findByIdAndAuthor 메서드는 preQuestionId와 From 멤버가 같은 사전 질문을 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -20,12 +20,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByIdAndAuthor 메서드는 preQuestionId와 From 멤버가 같은 사전 질문을 반환한다.")
     void findByIdAndAuthor() {
         // given
-        final Member author = getMember("알린");
-        final Member questioner = getMember("로마");
-        final Team team = getTeam(author, questioner);
-        final Levellog levellog = getLevellog(author, team);
+        final Member author = saveMember("알린");
+        final Member questioner = saveMember("로마");
+        final Team team = saveTeam(author, questioner);
+        final Levellog levellog = saveLevellog(author, team);
 
-        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
+        final PreQuestion preQuestion = savePreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByIdAndAuthor(preQuestion.getId(), questioner);
@@ -38,12 +38,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByLevellogAndAuthor 메서드는 Levellog와 Author가 같은 사전 질문을 반환한다.")
     void findByLevellogAndAuthor() {
         // given
-        final Member levellogAuthor = getMember("알린");
-        final Member questioner = getMember("로마");
-        final Team team = getTeam(levellogAuthor, questioner);
-        final Levellog levellog = getLevellog(levellogAuthor, team);
+        final Member levellogAuthor = saveMember("알린");
+        final Member questioner = saveMember("로마");
+        final Team team = saveTeam(levellogAuthor, questioner);
+        final Levellog levellog = saveLevellog(levellogAuthor, team);
 
-        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
+        final PreQuestion preQuestion = savePreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthor(levellog, questioner);
@@ -56,12 +56,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByLevellogAndAuthorId 메서드는 Levellog와 AuthorId가 같은 사전 질문을 반환한다.")
     void findByLevellogAndAuthorId() {
         // given
-        final Member levellogAuthor = getMember("알린");
-        final Member questioner = getMember("로마");
-        final Team team = getTeam(levellogAuthor, questioner);
-        final Levellog levellog = getLevellog(levellogAuthor, team);
+        final Member levellogAuthor = saveMember("알린");
+        final Member questioner = saveMember("로마");
+        final Team team = saveTeam(levellogAuthor, questioner);
+        final Levellog levellog = saveLevellog(levellogAuthor, team);
 
-        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
+        final PreQuestion preQuestion = savePreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthorId(levellog, questioner.getId());
@@ -78,12 +78,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하는 경우 true를 반환한다.")
         void exists() {
             // given
-            final Member levellogAuthor = getMember("알린");
-            final Member questioner = getMember("로마");
-            final Team team = getTeam(levellogAuthor, questioner);
-            final Levellog levellog = getLevellog(levellogAuthor, team);
+            final Member levellogAuthor = saveMember("알린");
+            final Member questioner = saveMember("로마");
+            final Team team = saveTeam(levellogAuthor, questioner);
+            final Levellog levellog = saveLevellog(levellogAuthor, team);
 
-            getPreQuestion(levellog, questioner);
+            savePreQuestion(levellog, questioner);
 
             // when
             final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);
@@ -96,10 +96,10 @@ class PreQuestionRepositoryTest extends RepositoryTest {
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하지 않는 경우 false를 반환한다.")
         void notExists() {
             // given
-            final Member levellogAuthor = getMember("알린");
-            final Member questioner = getMember("로마");
-            final Team team = getTeam(levellogAuthor, questioner);
-            final Levellog levellog = getLevellog(levellogAuthor, team);
+            final Member levellogAuthor = saveMember("알린");
+            final Member questioner = saveMember("로마");
+            final Team team = saveTeam(levellogAuthor, questioner);
+            final Levellog levellog = saveLevellog(levellogAuthor, team);
 
             // when
             final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -8,7 +8,6 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,13 +20,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByIdAndAuthor 메서드는 preQuestionId와 From 멤버가 같은 사전 질문을 반환한다.")
     void findByIdAndAuthor() {
         // given
-        final Member author = memberRepository.save(new Member("알린", 12345678, "알린.img"));
-        final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
-        final Levellog levellog = levellogRepository.save(Levellog.of(author, team, "알린의 레벨로그"));
+        final Member author = getMember("알린");
+        final Member questioner = getMember("로마");
+        final Team team = getTeam(author, questioner);
+        final Levellog levellog = getLevellog(author, team);
 
-        final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
-        final String content = "로마가 쓴 사전 질문입니다.";
-        final PreQuestion preQuestion = preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByIdAndAuthor(preQuestion.getId(), questioner);
@@ -40,13 +38,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByLevellogAndAuthor 메서드는 Levellog와 Author가 같은 사전 질문을 반환한다.")
     void findByLevellogAndAuthor() {
         // given
-        final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
-        final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
-        final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+        final Member levellogAuthor = getMember("알린");
+        final Member questioner = getMember("로마");
+        final Team team = getTeam(levellogAuthor, questioner);
+        final Levellog levellog = getLevellog(levellogAuthor, team);
 
-        final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
-        final String content = "로마가 쓴 사전 질문입니다.";
-        final PreQuestion preQuestion = preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthor(levellog, questioner);
@@ -59,13 +56,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
     @DisplayName("findByLevellogAndAuthorId 메서드는 Levellog와 AuthorId가 같은 사전 질문을 반환한다.")
     void findByLevellogAndAuthorId() {
         // given
-        final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
-        final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
-        final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+        final Member levellogAuthor = getMember("알린");
+        final Member questioner = getMember("로마");
+        final Team team = getTeam(levellogAuthor, questioner);
+        final Levellog levellog = getLevellog(levellogAuthor, team);
 
-        final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
-        final String content = "로마가 쓴 사전 질문입니다.";
-        final PreQuestion preQuestion = preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+        final PreQuestion preQuestion = getPreQuestion(levellog, questioner);
 
         // when
         final Optional<PreQuestion> actual = preQuestionRepository.findByLevellogAndAuthorId(levellog, questioner.getId());
@@ -82,13 +78,12 @@ class PreQuestionRepositoryTest extends RepositoryTest {
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하는 경우 true를 반환한다.")
         void exists() {
             // given
-            final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
-            final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
+            final Member levellogAuthor = getMember("알린");
+            final Member questioner = getMember("로마");
+            final Team team = getTeam(levellogAuthor, questioner);
+            final Levellog levellog = getLevellog(levellogAuthor, team);
 
-            final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
-            final String content = "로마가 쓴 사전 질문입니다.";
-            preQuestionRepository.save(new PreQuestion(levellog, questioner, content));
+            getPreQuestion(levellog, questioner);
 
             // when
             final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);
@@ -101,10 +96,10 @@ class PreQuestionRepositoryTest extends RepositoryTest {
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하지 않는 경우 false를 반환한다.")
         void notExists() {
             // given
-            final Member levellogAuthor = memberRepository.save(new Member("알린", 12345678, "알린.img"));
-            final Team team = teamRepository.save(new Team("선릉 네오조", "목성방", LocalDateTime.now().plusDays(3), "네오조.img", 1));
-            final Levellog levellog = levellogRepository.save(Levellog.of(levellogAuthor, team, "알린의 레벨로그"));
-            final Member questioner = memberRepository.save(new Member("로마", 56781234, "로마.img"));
+            final Member levellogAuthor = getMember("알린");
+            final Member questioner = getMember("로마");
+            final Team team = getTeam(levellogAuthor, questioner);
+            final Levellog levellog = getLevellog(levellogAuthor, team);
 
             // when
             final boolean actual = preQuestionRepository.existsByLevellogAndAuthor(levellog, questioner);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -2,12 +2,22 @@ package com.woowacourse.levellog.domain;
 
 import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
+import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionRepository;
+import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionDto;
+import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
+import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
+import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
+import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -36,4 +46,38 @@ abstract class RepositoryTest {
 
     @Autowired
     protected TeamRepository teamRepository;
+
+    protected Member getMember(final String nickname) {
+        final Member member = new Member(nickname, ((int) System.nanoTime()), nickname + ".org");
+        return memberRepository.save(member);
+    }
+
+    protected Team getTeam(final Member host, final Member... members) {
+        return getTeam(3, host, members);
+    }
+
+    protected Team getTeam(final long days,  final Member host, final Member... members) {
+        final Team team = teamRepository.save(
+                new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(days), "jamsil.img", 1));
+
+        participantRepository.save(new Participant(team, host, true));
+
+        final List<Participant> participants = Arrays.stream(members)
+                .map(it -> new Participant(team, it, false))
+                .collect(Collectors.toList());
+        participantRepository.saveAll(participants);
+
+        return team;
+    }
+
+    protected Levellog getLevellog(final Member author, final Team team) {
+        final Levellog levellog = Levellog.of(author, team, "levellog content");
+        return levellogRepository.save(levellog);
+    }
+
+    protected InterviewQuestion getInterviewQuestion(final String content, final Levellog levellog, final Member author) {
+        final InterviewQuestionDto request = InterviewQuestionDto.from(content);
+        final InterviewQuestion interviewQuestion = request.toInterviewQuestion(author, levellog);
+        return interviewQuestionRepository.save(interviewQuestion);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -10,6 +10,7 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.domain.MemberRepository;
+import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
 import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
@@ -87,5 +88,11 @@ abstract class RepositoryTest {
         final Feedback feedback = new Feedback(from, to, levellog, "study from " + from.getNickname(),
                 "speak from " + from.getNickname(), "etc from " + from.getNickname());
         return feedbackRepository.save(feedback);
+    }
+
+    protected PreQuestion getPreQuestion(final Levellog levellog, final Member author) {
+        final PreQuestion preQuestion = new PreQuestion(levellog, author,
+                author.getNickname() + "이 " + levellog.getId() + "에 작성한 사전질문");
+        return preQuestionRepository.save(preQuestion);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.levellog.domain;
 import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.feedback.domain.Feedback;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
+import com.woowacourse.levellog.fixture.TimeFixture;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionRepository;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionDto;
@@ -16,7 +17,6 @@ import com.woowacourse.levellog.team.domain.Participant;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamRepository;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,12 +55,7 @@ abstract class RepositoryTest {
     }
 
     protected Team getTeam(final Member host, final Member... members) {
-        return getTeam(3, host, members);
-    }
-
-    protected Team getTeam(final long days, final Member host, final Member... members) {
-        final Team team = teamRepository.save(
-                new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(days), "jamsil.img", 1));
+        final Team team = teamRepository.save(new Team("잠실 네오조", "트랙룸", TimeFixture.TEAM_START_TIME, "jamsil.img", 1));
 
         participantRepository.save(new Participant(team, host, true));
 

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -49,12 +49,12 @@ abstract class RepositoryTest {
     @Autowired
     protected TeamRepository teamRepository;
 
-    protected Member getMember(final String nickname) {
+    protected Member saveMember(final String nickname) {
         final Member member = new Member(nickname, ((int) System.nanoTime()), nickname + ".org");
         return memberRepository.save(member);
     }
 
-    protected Team getTeam(final Member host, final Member... members) {
+    protected Team saveTeam(final Member host, final Member... members) {
         final Team team = teamRepository.save(new Team("잠실 네오조", "트랙룸", TimeFixture.TEAM_START_TIME, "jamsil.img", 1));
 
         participantRepository.save(new Participant(team, host, true));
@@ -67,25 +67,25 @@ abstract class RepositoryTest {
         return team;
     }
 
-    protected Levellog getLevellog(final Member author, final Team team) {
+    protected Levellog saveLevellog(final Member author, final Team team) {
         final Levellog levellog = Levellog.of(author, team, "levellog content");
         return levellogRepository.save(levellog);
     }
 
-    protected InterviewQuestion getInterviewQuestion(final String content, final Levellog levellog,
-                                                     final Member author) {
+    protected InterviewQuestion saveInterviewQuestion(final String content, final Levellog levellog,
+                                                      final Member author) {
         final InterviewQuestionDto request = InterviewQuestionDto.from(content);
         final InterviewQuestion interviewQuestion = request.toInterviewQuestion(author, levellog);
         return interviewQuestionRepository.save(interviewQuestion);
     }
 
-    protected Feedback getFeedback(final Member from, final Member to, final Levellog levellog) {
+    protected Feedback saveFeedback(final Member from, final Member to, final Levellog levellog) {
         final Feedback feedback = new Feedback(from, to, levellog, "study from " + from.getNickname(),
                 "speak from " + from.getNickname(), "etc from " + from.getNickname());
         return feedbackRepository.save(feedback);
     }
 
-    protected PreQuestion getPreQuestion(final Levellog levellog, final Member author) {
+    protected PreQuestion savePreQuestion(final Levellog levellog, final Member author) {
         final PreQuestion preQuestion = new PreQuestion(levellog, author,
                 author.getNickname() + "이 " + levellog.getId() + "에 작성한 사전질문");
         return preQuestionRepository.save(preQuestion);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.levellog.domain;
 
 import com.woowacourse.levellog.common.config.JpaConfig;
+import com.woowacourse.levellog.feedback.domain.Feedback;
 import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionRepository;
@@ -56,7 +57,7 @@ abstract class RepositoryTest {
         return getTeam(3, host, members);
     }
 
-    protected Team getTeam(final long days,  final Member host, final Member... members) {
+    protected Team getTeam(final long days, final Member host, final Member... members) {
         final Team team = teamRepository.save(
                 new Team("잠실 네오조", "트랙룸", LocalDateTime.now().plusDays(days), "jamsil.img", 1));
 
@@ -75,9 +76,16 @@ abstract class RepositoryTest {
         return levellogRepository.save(levellog);
     }
 
-    protected InterviewQuestion getInterviewQuestion(final String content, final Levellog levellog, final Member author) {
+    protected InterviewQuestion getInterviewQuestion(final String content, final Levellog levellog,
+                                                     final Member author) {
         final InterviewQuestionDto request = InterviewQuestionDto.from(content);
         final InterviewQuestion interviewQuestion = request.toInterviewQuestion(author, levellog);
         return interviewQuestionRepository.save(interviewQuestion);
+    }
+
+    protected Feedback getFeedback(final Member from, final Member to, final Levellog levellog) {
+        final Feedback feedback = new Feedback(from, to, levellog, "study from " + from.getNickname(),
+                "speak from " + from.getNickname(), "etc from " + from.getNickname());
+        return feedbackRepository.save(feedback);
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -1,0 +1,39 @@
+package com.woowacourse.levellog.domain;
+
+import com.woowacourse.levellog.common.config.JpaConfig;
+import com.woowacourse.levellog.feedback.domain.FeedbackRepository;
+import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionRepository;
+import com.woowacourse.levellog.levellog.domain.LevellogRepository;
+import com.woowacourse.levellog.member.domain.MemberRepository;
+import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
+import com.woowacourse.levellog.team.domain.ParticipantRepository;
+import com.woowacourse.levellog.team.domain.TeamRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+abstract class RepositoryTest {
+
+    @Autowired
+    protected FeedbackRepository feedbackRepository;
+
+    @Autowired
+    protected InterviewQuestionRepository interviewQuestionRepository;
+
+    @Autowired
+    protected LevellogRepository levellogRepository;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected ParticipantRepository participantRepository;
+
+    @Autowired
+    protected PreQuestionRepository preQuestionRepository;
+
+    @Autowired
+    protected TeamRepository teamRepository;
+}


### PR DESCRIPTION
## 구현 기능
- `XXXRepositoryTest`가 `RepositoryTest`를 상속 받도록 변경
- 객체 생성 & DB에 저장하는 코드 메서드 추출
- given 블록에서 객체 생성 & DB에 적재하는 코드 수정

