### PR TITLE
refactor: 인수테스트에서 사용중인 `@DirtiesContext` 제거

### DIFF
--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.levellog.authentication.dto.GithubCodeDto;
 import com.woowacourse.levellog.authentication.dto.GithubProfileDto;
+import com.woowacourse.levellog.config.DatabaseCleaner;
 import com.woowacourse.levellog.config.TestConfig;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
@@ -21,6 +22,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,12 +31,9 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Import(TestConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 @ActiveProfiles("test")
@@ -44,6 +43,9 @@ abstract class AcceptanceTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected DatabaseCleaner databaseCleaner;
 
     @LocalServerPort
     private int port;
@@ -57,6 +59,11 @@ abstract class AcceptanceTest {
     public void setUp(final RestDocumentationContextProvider contextProvider) {
         setRestAssuredPort();
         setRestDocsSpec(contextProvider);
+    }
+
+    @AfterEach
+    public void claenDatabase() {
+        databaseCleaner.clean();
     }
 
     private void setRestAssuredPort() {

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -50,19 +50,14 @@ abstract class AcceptanceTest {
     @LocalServerPort
     private int port;
 
-    /*
-     * 기본 생성 snippet은 http-request.adoc, http-response.adoc입니다.
-     * Request host는 https://api.levellog.app입니다.
-     * 응답 헤더 중 Transfer-Encoding, Date, Keep-Alive, Connection은 제외됩니다.
-     */
     @BeforeEach
-    public void setUp(final RestDocumentationContextProvider contextProvider) {
+    public void tearDown(final RestDocumentationContextProvider contextProvider) {
         setRestAssuredPort();
         setRestDocsSpec(contextProvider);
     }
 
     @AfterEach
-    public void claenDatabase() {
+    public void cleanDatabase() {
         databaseCleaner.clean();
     }
 
@@ -70,6 +65,11 @@ abstract class AcceptanceTest {
         RestAssured.port = port;
     }
 
+    /*
+     * 기본 생성 snippet은 http-request.adoc, http-response.adoc입니다.
+     * Request host는 https://api.levellog.app입니다.
+     * 응답 헤더 중 Transfer-Encoding, Date, Keep-Alive, Connection은 제외됩니다.
+     */
     private void setRestDocsSpec(final RestDocumentationContextProvider contextProvider) {
         specification = new RequestSpecBuilder()
                 .addFilter(
@@ -109,13 +109,14 @@ abstract class AcceptanceTest {
     protected RestAssuredResponse login(final String nickname) {
         try {
             final GithubProfileDto response = new GithubProfileDto(String.valueOf(
-                    ((int) System.currentTimeMillis())), nickname,
-                    nickname + ".com");
+                    ((int) System.nanoTime())), nickname, nickname + ".com");
             final String code = objectMapper.writeValueAsString(response);
+
             return post("/api/auth/login", new GithubCodeDto(code));
         } catch (final JsonProcessingException e) {
             e.printStackTrace();
         }
+
         return null;
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -55,7 +55,15 @@ abstract class AcceptanceTest {
      */
     @BeforeEach
     public void setUp(final RestDocumentationContextProvider contextProvider) {
+        setRestAssuredPort();
+        setRestDocsSpec(contextProvider);
+    }
+
+    private void setRestAssuredPort() {
         RestAssured.port = port;
+    }
+
+    private void setRestDocsSpec(final RestDocumentationContextProvider contextProvider) {
         specification = new RequestSpecBuilder()
                 .addFilter(
                         documentationConfiguration(contextProvider)

--- a/backend/src/test/java/com/woowacourse/levellog/config/DatabaseCleaner.java
+++ b/backend/src/test/java/com/woowacourse/levellog/config/DatabaseCleaner.java
@@ -1,18 +1,20 @@
 package com.woowacourse.levellog.config;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Table;
-import javax.persistence.metamodel.EntityType;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class DatabaseCleaner implements InitializingBean {
+
+    private static final String CONSTRAINT_OFF_SQL = "SET REFERENTIAL_INTEGRITY FALSE";
+    private static final String CONSTRAINT_ON_SQL = "SET REFERENTIAL_INTEGRITY TRUE";
+    private static final String TRUNCATE_TABLE_SQL = "TRUNCATE TABLE ";
+    private static final String SHOW_TABLES_SQL = "SHOW TABLES";
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -25,46 +27,22 @@ public class DatabaseCleaner implements InitializingBean {
     }
 
     private List<String> findTableNamesByEntities() {
-        final List<String> tableNames = new ArrayList<>();
+        final List<Object[]> tables = (List<Object[]>) entityManager.createNativeQuery(SHOW_TABLES_SQL)
+                .getResultList();
 
-        final Set<EntityType<?>> entities = entityManager.getMetamodel()
-                .getEntities();
-
-        for (final EntityType<?> entity : entities) {
-            final Table t = entity.getJavaType()
-                    .getAnnotation(Table.class);
-
-            if (haveNoCustomTableName(t)) {
-                tableNames.add(toSnakeCase(entity.getName()));
-            } else {
-                tableNames.add(t.name());
-            }
-        }
-        return tableNames;
-    }
-
-    private boolean haveNoCustomTableName(final Table t) {
-        return t == null || t.name().isBlank();
-    }
-
-    private String toSnakeCase(final String text) {
-        final String regex = "([a-z])([A-Z]+)";
-        final String replacement = "$1_$2";
-
-        return text.replaceAll(regex, replacement)
-                .toLowerCase();
+        return tables.stream()
+                .map(it -> it[0].toString())
+                .collect(Collectors.toList());
     }
 
     @Transactional
     public void clean() {
         entityManager.flush();
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery(CONSTRAINT_OFF_SQL).executeUpdate();
 
         for (final String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1")
-                    .executeUpdate();
+            entityManager.createNativeQuery(TRUNCATE_TABLE_SQL + tableName).executeUpdate();
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery(CONSTRAINT_ON_SQL).executeUpdate();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/config/DatabaseCleaner.java
+++ b/backend/src/test/java/com/woowacourse/levellog/config/DatabaseCleaner.java
@@ -1,0 +1,70 @@
+package com.woowacourse.levellog.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import javax.persistence.metamodel.EntityType;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        this.tableNames = findTableNamesByEntities();
+    }
+
+    private List<String> findTableNamesByEntities() {
+        final List<String> tableNames = new ArrayList<>();
+
+        final Set<EntityType<?>> entities = entityManager.getMetamodel()
+                .getEntities();
+
+        for (final EntityType<?> entity : entities) {
+            final Table t = entity.getJavaType()
+                    .getAnnotation(Table.class);
+
+            if (haveNoCustomTableName(t)) {
+                tableNames.add(toSnakeCase(entity.getName()));
+            } else {
+                tableNames.add(t.name());
+            }
+        }
+        return tableNames;
+    }
+
+    private boolean haveNoCustomTableName(final Table t) {
+        return t == null || t.name().isBlank();
+    }
+
+    private String toSnakeCase(final String text) {
+        final String regex = "([a-z])([A-Z]+)";
+        final String replacement = "$1_$2";
+
+        return text.replaceAll(regex, replacement)
+                .toLowerCase();
+    }
+
+    @Transactional
+    public void clean() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (final String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1")
+                    .executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 테스트 코드 성능을 향상시키기 위해 DirtiesContext를 제거했습니다.
  - 제거 결과 테스트 코드 전체 걸리는 시간이 절반으로 줄었습니다👍

## 논의하고 싶은 내용
- 테이블 이름을 가져오는 로직이 두 가지 방법으로 해보았습니다. 어떤 방식이 나은지는 모르겠습니다.
  - 테이블 이름을 가져오는 로직을 show tables 하는 방식 ( 지원플랫폼에서 하는 방식. 타입 관련 이슈때문에 좀 지저분함 ㅋ)
  - Entity를 가져와서 `@Table`을 확인 -> Table 어노테이션에서 설정한 이름이 따로 없으면 엔티티 이름을 스네이크 케이스로 변경해서 이름 가져오는 방식 ( snake case로 변경하는 작업이 열받음 ) -> **커밋 내역 안에 해당 두 방법이 있음 **
    - [엔티티를 이용해 가져오는 방식](https://github.com/woowacourse-teams/2022-levellog/commit/c38a02d4748f8cdc12f57b0e82e367385a56e2c7) 
    - [Table 조회해오는 방식](https://github.com/woowacourse-teams/2022-levellog/commit/5447534b621adbf5bed40fcd74cffc3646142aa8)

## 공유하고 싶은 내용
- `DirtiesContext`는 데이터 초기화 뿐만 아니라 빈을 초기화. 즉 컨텍스트를 다시 띄웁니다. 따라서 비용이 많이 듭니다.
  - 우리가 필요한건 데이터 초기화입니다. 상태를 가진 빈을 이용한 테스트를 진행하지 않기 때문에 데이터 초기화만을 위한 다른 방법을 찾아야 합니다.
  - 방법으로는 세 가지가 있습니다. `@Sql` 이용하는 방식, Repository로 DeletAll 해주는 방식, 그리고 현재 사용중인 데이터 초기화 빈을 정의해서 제거하는 방식이 있습니다.
  - `@Sql` 방식은 엔티티가 수정되어 테이블이 변경, 추가 될 때마다 ddl 문을 수정해주어야 한다는 단점이 있습니다.
  - Repository로 DeleteAll 하는 방식은 각각의 연관관계에 제약조건이 걸려있기 때문에 순서를 고려해야한다는 점이 불편합니다.
  - 마지막으로 데이터 초기화 빈을 설정하는 방법은 테이블의 변경, 추가에도 유연하고 내부적으로 NativeQuery를 사용하기 때문에 제약조건도 무시할 수 있다는 장점이 있습니다. ( 설정이 번거롭긴 합니다. )
- 슬랙에서 공유했듯이 DirtiesContext를 제거해주기만 해도 테스트 성능 개선이 엄청나게 됩니다. 그만큼 컨텍스트를 띄우는 비용이 비싸다는 뜻이겠지요 😋

오늘의 한줄 

> 테스트의 성능 개선의 핵심은 **Context**를 덜 띄우는 것이다.


Close #152