### PR TITLE
feat: 팀의 상태 조회 기능

### DIFF
--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -147,7 +147,6 @@ include::{snippets}/team/find-by-id/exception/notfound/http-response.adoc[]
 |인터뷰가 종료된 상태이다.
 |===
 
-
 [[find-status-success]]
 === 팀 상태 조회 성공
 
@@ -155,6 +154,8 @@ operation::team/find-status[]
 
 [[find-status-exception]]
 === 팀 상태 조회 예외
+
+==== id에 해당하는 팀이 존재하지 않는 경우
 
 include::{snippets}/team/find-status/exception/team-not-found/http-response.adoc[]
 

--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -127,6 +127,37 @@ include::{snippets}/team/find/not-my-team/http-response.adoc[]
 
 include::{snippets}/team/find-by-id/exception/notfound/http-response.adoc[]
 
+[[find-status]]
+== 팀 상태 조회
+
+*STATUS 응답 종류*
+
+[cols="1,1"]
+|===
+|*응답*
+|*설명*
+
+|READY
+|인터뷰 시작 전 상태이다.
+
+|IN_PROGRESS
+|인터뷰 진행 중인 상태이다.
+
+|CLOSED
+|인터뷰가 종료된 상태이다.
+|===
+
+
+[[find-status-success]]
+=== 팀 상태 조회 성공
+
+operation::team/find-status[]
+
+[[find-status-exception]]
+=== 팀 상태 조회 예외
+
+include::{snippets}/team/find-status/exception/team-not-found/http-response.adoc[]
+
 [[find-my-role]]
 == 인터뷰 역할 조회
 
@@ -244,7 +275,7 @@ include::{snippets}/team/update/exception/participants/null/http-response.adoc[]
 
 include::{snippets}/team/update/exception/interviewer-number/not-positive/http-response.adoc[]
 
-[[update-exception-interviewer-number-not-positive]]
+[[update-exception-interviewer-number-more-than-participant]]
 ==== 수정 시 인터뷰어 수가 참가자 수 보다 많거나 같은 경우
 
 include::{snippets}/team/update/exception/interviewer-number/more-than-participant/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -89,7 +89,10 @@ public class TeamService {
     }
 
     public TeamStatusDto findStatus(final Long teamId) {
-        return null;
+        final Team team = getTeam(teamId);
+        final TeamStatus status = team.status(timeStandard.now());
+
+        return new TeamStatusDto(status);
     }
 
     public InterviewRoleDto findMyRole(final Long teamId, final Long targetMemberId, final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -20,6 +20,7 @@ import com.woowacourse.levellog.team.dto.ParticipantDto;
 import com.woowacourse.levellog.team.dto.TeamAndRoleDto;
 import com.woowacourse.levellog.team.dto.TeamAndRolesDto;
 import com.woowacourse.levellog.team.dto.TeamDto;
+import com.woowacourse.levellog.team.dto.TeamStatusDto;
 import com.woowacourse.levellog.team.dto.TeamWriteDto;
 import com.woowacourse.levellog.team.dto.TeamsDto;
 import com.woowacourse.levellog.team.exception.DuplicateParticipantsException;
@@ -85,6 +86,10 @@ public class TeamService {
         final List<Team> teams = getTeamsByMemberId(memberId);
 
         return new TeamsDto(getTeamResponses(teams, memberId));
+    }
+
+    public TeamStatusDto findStatus(final Long teamId) {
+        return null;
     }
 
     public InterviewRoleDto findMyRole(final Long teamId, final Long targetMemberId, final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/InterviewRoleDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/InterviewRoleDto.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 public class InterviewRoleDto {
 
     private InterviewRole myRole;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/ParticipantDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/ParticipantDto.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 public class ParticipantDto {
 
     private Long memberId;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRoleDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRoleDto.java
@@ -9,13 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 public class TeamAndRoleDto {
 
     private Long id;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRolesDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamAndRolesDto.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-@ToString
 public class TeamAndRolesDto {
 
     private List<TeamAndRoleDto> teams;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDto.java
@@ -9,13 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 public class TeamDto {
 
     private Long id;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamStatusDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamStatusDto.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-@ToString
 public class TeamStatusDto {
 
     private TeamStatus status;

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamStatusDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamStatusDto.java
@@ -1,0 +1,19 @@
+package com.woowacourse.levellog.team.dto;
+
+import com.woowacourse.levellog.team.domain.TeamStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@ToString
+public class TeamStatusDto {
+
+    private TeamStatus status;
+}

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamsDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamsDto.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-@ToString
 public class TeamsDto {
 
     private List<TeamDto> teams;

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -6,6 +6,7 @@ import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.dto.InterviewRoleDto;
 import com.woowacourse.levellog.team.dto.TeamAndRoleDto;
 import com.woowacourse.levellog.team.dto.TeamAndRolesDto;
+import com.woowacourse.levellog.team.dto.TeamStatusDto;
 import com.woowacourse.levellog.team.dto.TeamWriteDto;
 import java.net.URI;
 import javax.validation.Valid;
@@ -46,6 +47,13 @@ public class TeamController {
     public ResponseEntity<TeamAndRoleDto> findById(@PathVariable final Long teamId,
                                                    @Authentic final Long memberId) {
         final TeamAndRoleDto response = teamService.findByTeamIdAndMemberId(teamId, memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{teamId}/status")
+    @PublicAPI
+    public ResponseEntity<TeamStatusDto> findStatus(@PathVariable final Long teamId) {
+        final TeamStatusDto response = teamService.findStatus(teamId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -214,7 +214,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.OK.value())
-                .body("status", equalTo(TeamStatus.IN_PROGRESS));
+                .body("status", equalTo(String.valueOf(TeamStatus.IN_PROGRESS)));
     }
 
     /*

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -214,7 +214,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.OK.value())
-                .body("status", equalTo(String.valueOf(TeamStatus.IN_PROGRESS)));
+                .body("status", equalTo(TeamStatus.IN_PROGRESS.name()));
     }
 
     /*

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -25,6 +25,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 @DisplayName("Team의")
 class TeamTest {
 
+    private Team saveTeam() {
+        return saveTeam(2);
+    }
+
+    private Team saveTeam(final int interviewerNumber) {
+        return new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", interviewerNumber);
+    }
+
     @Nested
     @DisplayName("생성자 메서드는")
     class Constructor {
@@ -169,11 +177,11 @@ class TeamTest {
         @DisplayName("팀 이름, 장소, 시작 시간을 수정한다.")
         void update() {
             // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
+            final Team team = saveTeam();
             final Team updatedTeam = new Team("브라운과 카페 투어", "잠실 어드레스룸", TEAM_START_TIME, "profile.img", 2);
 
             // when
-            team.update(updatedTeam, LocalDateTime.now());
+            team.update(updatedTeam, BEFORE_START_TIME);
 
             // then
             assertAll(
@@ -184,107 +192,15 @@ class TeamTest {
             );
         }
 
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {" "})
-        @DisplayName("팀 이름이 null 또는 공백이 들어오면 예외를 던진다.")
-        void titleNullOrBlank_Exception(final String updateTitle) {
-            // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(
-                    () -> team.update(new Team(updateTitle, "잠실 어드레스룸", TEAM_START_TIME, "profile.img", 2),
-                            LocalDateTime.now()))
-                    .isInstanceOf(InvalidFieldException.class)
-                    .hasMessageContaining("팀 이름이 null 또는 공백입니다.");
-        }
-
-        @Test
-        @DisplayName("팀 이름이 255자를 초과할 경우 예외를 던진다.")
-        void titleInvalidLength_Exception() {
-            // given
-            final String updateTitle = "a".repeat(256);
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(
-                    () -> team.update(new Team(updateTitle, "잠실 어드레스룸", TEAM_START_TIME, "profile.img", 2),
-                            LocalDateTime.now()))
-                    .isInstanceOf(InvalidFieldException.class)
-                    .hasMessageContaining("잘못된 팀 이름을 입력했습니다.");
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {" "})
-        @DisplayName("팀 장소가 null 또는 공백이 들어오면 예외를 던진다.")
-        void placeNullOrBlank_Exception(final String updatePlace) {
-            // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(() -> team.update(new Team("네오와 함께하는 레벨 인터뷰", updatePlace, TEAM_START_TIME, "profile.img", 1), LocalDateTime.now()))
-                    .isInstanceOf(InvalidFieldException.class)
-                    .hasMessageContaining("장소가 null 또는 공백입니다.");
-        }
-
-        @Test
-        @DisplayName("팀 장소가 255자를 초과할 경우 예외를 던진다.")
-        void placeInvalidLength_Exception() {
-            // given
-            final String updatePlace = "a".repeat(256);
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(
-                    () -> team.update(new Team("브라운과 카페 투어", updatePlace, AFTER_START_TIME, "profile.img", 2),
-                            LocalDateTime.now()))
-                    .isInstanceOf(InvalidFieldException.class)
-                    .hasMessageContaining("잘못된 장소를 입력했습니다.");
-        }
-
-        @ParameterizedTest
-        @NullSource
-        @DisplayName("인터뷰 시작 시간이 null이 들어오면 예외를 던진다.")
-        void startAtNull_Exception(final LocalDateTime updateStartAt) {
-            // given
-            final LocalDateTime presentTime = LocalDateTime.now();
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(
-                    () -> team.update(new Team("브라운과 카페 투어", "잠실 어드레스룸", updateStartAt, "profile.img", 2), presentTime))
-                    .isInstanceOf(InterviewTimeException.class)
-                    .hasMessageContaining("시작 시간이 없습니다.");
-        }
-
-        @Test
-        @DisplayName("인터뷰 시작 시간이 과거인 경우 예외를 던진다.")
-        void startAtInvalidDateTime_Exception() {
-            // given
-            final LocalDateTime presentTime = LocalDateTime.now();
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
-
-            // when & then
-            assertThatThrownBy(
-                    () -> team.update(new Team("브라운과 카페 투어", "잠실 어드레스룸", presentTime.minusDays(10), "profile.img", 2),
-                            presentTime))
-                    .isInstanceOf(InterviewTimeException.class)
-                    .hasMessageContaining("인터뷰 시작 시간은 현재 시간 이후여야 합니다.");
-        }
-
         @Test
         @DisplayName("인터뷰 시작 이후인 경우 예외를 던진다.")
         void updateAfterStartAt_Exception() {
             // given
-            final LocalDateTime now = LocalDateTime.now();
-            final LocalDateTime presentTime = now.plusDays(2);
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", now.plusDays(1), "profile.img", 1);
-            final Team updatedTeam = new Team("브라운과 카페 투어", "잠실 어드레스룸", now.plusDays(3), "profile.img", 2);
+            final Team team = saveTeam();
+            final Team updatedTeam = new Team("브라운과 카페 투어", "잠실 어드레스룸", TEAM_START_TIME, "profile.img", 2);
 
             // when & then
-            assertThatThrownBy(() -> team.update(updatedTeam, presentTime))
+            assertThatThrownBy(() -> team.update(updatedTeam, AFTER_START_TIME))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContaining("인터뷰가 시작된 이후에는 수정할 수 없습니다.");
         }
@@ -299,8 +215,7 @@ class TeamTest {
         @DisplayName("isValidParticipantNumber 메서드는 인터뷰어 수를 참고해서 참가자 수가 유효한지 계산한다.")
         void throwException(final int interviewerNumber, final int participantNumber) {
             // given
-            final Team team = new Team("레벨로그팀", "우리집", TEAM_START_TIME, "profile.url",
-                    interviewerNumber);
+            final Team team = saveTeam(interviewerNumber);
 
             // when & then
             assertThatThrownBy(() -> team.validParticipantNumber(participantNumber))
@@ -312,8 +227,7 @@ class TeamTest {
         @DisplayName("isValidParticipantNumber 메서드는 인터뷰어 수를 참고해서 참가자 수가 유효한지 계산한다.")
         void notThrownException(final int interviewerNumber, final int participantNumber) {
             // given
-            final Team team = new Team("레벨로그팀", "우리집", TEAM_START_TIME, "profile.url",
-                    interviewerNumber);
+            final Team team = saveTeam(interviewerNumber);
 
             // when & then
             assertThatCode(() -> team.validParticipantNumber(participantNumber))
@@ -329,7 +243,7 @@ class TeamTest {
         @DisplayName("팀 인터뷰를 종료 상태로 바꾼다.")
         void close_success() {
             // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
+            final Team team = saveTeam();
 
             // when
             team.close(AFTER_START_TIME);
@@ -342,7 +256,7 @@ class TeamTest {
         @DisplayName("이미 종료된 인터뷰를 종료하려는 경우 예외가 발생한다.")
         void close_alreadyClosed_exceptionThrown() {
             // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
+            final Team team = saveTeam();
 
             team.close(AFTER_START_TIME);
 
@@ -356,7 +270,7 @@ class TeamTest {
         @DisplayName("인터뷰 시작 시간 전 종료를 요청할 경우 예외가 발생한다.")
         void close_beforeStart_exceptionThrown() {
             // given
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
+            final Team team = saveTeam();
 
             // when & then
             assertThatThrownBy(() -> team.close(BEFORE_START_TIME))
@@ -373,11 +287,10 @@ class TeamTest {
         @DisplayName("팀을 deleted 상태로 만든다.")
         void delete_success() {
             // given
-            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
+            final Team team = saveTeam();
 
             // when
-            team.delete(startAt.minusDays(1));
+            team.delete(BEFORE_START_TIME);
 
             // then
             assertThat(team.isDeleted()).isTrue();
@@ -387,113 +300,109 @@ class TeamTest {
         @DisplayName("인터뷰 시작 이후 삭제를 요청할 경우 예외가 발생한다.")
         void delete_afterStart_exceptionThrown() {
             // given
-            final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
-            final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
+            final Team team = saveTeam();
 
             // when & then
-            final LocalDateTime deletedTime = startAt.plusDays(1);
-            assertThatThrownBy(() -> team.delete(deletedTime))
+            assertThatThrownBy(() -> team.delete(AFTER_START_TIME))
                     .isInstanceOf(InterviewTimeException.class)
                     .hasMessageContaining("인터뷰가 시작된 이후에는 삭제할 수 없습니다.");
         }
 
-        @Nested
-        @DisplayName("validateInProgress 메서드는")
-        class ValidateInProgress {
+    }
 
-            final String message = "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.";
+    @Nested
+    @DisplayName("validateInProgress 메서드는")
+    class ValidateInProgress {
 
-            @Test
-            @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이전이면 예외가 발생한다.")
-            void validate_afterStartAt_thrownException() {
-                // given
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
+        final String message = "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.";
 
-                // when & then
-                assertThatThrownBy(() -> team.validateInProgress(BEFORE_START_TIME, message))
-                        .isInstanceOf(InterviewTimeException.class)
-                        .hasMessageContaining(message);
-            }
+        @Test
+        @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이전이면 예외가 발생한다.")
+        void validate_afterStartAt_thrownException() {
+            // given
+            final Team team = saveTeam();
 
-            @Test
-            @DisplayName("팀 인터뷰가 이미 종료된 상태면 예외를 발생시킨다.")
-            void validate_BeforeClose_thrownException() {
-                // given
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
-
-                team.close(AFTER_START_TIME);
-
-                // when & then
-                assertThatThrownBy(() -> team.validateInProgress(AFTER_START_TIME.plusDays(1), message))
-                        .isInstanceOf(InterviewTimeException.class)
-                        .hasMessageContaining("이미 종료된 인터뷰입니다.");
-            }
+            // when & then
+            assertThatThrownBy(() -> team.validateInProgress(BEFORE_START_TIME, message))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining(message);
         }
 
-        @Nested
-        @DisplayName("status 메서드는")
-        class Status {
+        @Test
+        @DisplayName("팀 인터뷰가 이미 종료된 상태면 예외를 발생시킨다.")
+        void validate_BeforeClose_thrownException() {
+            // given
+            final Team team = saveTeam();
 
-            @Test
-            @DisplayName("현재 시간이 인터뷰 시작 시간보다 이전인 경우 READY를 반환한다.")
-            void readyStatus_success() {
-                // given
-                final LocalDateTime presentTime = LocalDateTime.now();
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(3), "profileUrl", 2);
+            team.close(AFTER_START_TIME);
 
-                // when
-                final TeamStatus actual = team.status(presentTime);
+            // when & then
+            assertThatThrownBy(() -> team.validateInProgress(AFTER_START_TIME.plusDays(1), message))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("이미 종료된 인터뷰입니다.");
+        }
+    }
 
-                // then
-                assertThat(actual).isEqualTo(TeamStatus.READY);
-            }
+    @Nested
+    @DisplayName("validateBeforeStartAt 메서드는")
+    class ValidateBeforeStartAt {
 
-            @Test
-            @DisplayName("인터뷰 시작시간이 현재 시간보다 이후이면서 종료되지 않은 경우 IN_PROGRESS를 반환한다.")
-            void inProgressStatus_success() {
-                // given
-                final LocalDateTime presentTime = LocalDateTime.now();
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(1), "profileUrl", 2);
+        @Test
+        @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이후면 예외가 발생한다.")
+        void validate_beforeStartAt_thrownException() {
+            // given
+            final Team team = saveTeam();
 
-                // when
-                final TeamStatus actual = team.status(presentTime.plusDays(2));
+            // when & then
+            assertThatThrownBy(
+                    () -> team.validateReady(AFTER_START_TIME, "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다."))
+                    .isInstanceOf(InterviewTimeException.class)
+                    .hasMessageContaining("피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.");
+        }
+    }
 
-                // then
-                assertThat(actual).isEqualTo(TeamStatus.IN_PROGRESS);
-            }
+    @Nested
+    @DisplayName("status 메서드는")
+    class Status {
 
-            @Test
-            @DisplayName("인터뷰가 종료된 경우 CLOSED를 반환한다.")
-            void closedStatus_success() {
-                // given
-                final LocalDateTime presentTime = LocalDateTime.now();
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(1), "profileUrl", 2);
-                team.close(presentTime.plusDays(2));
+        @Test
+        @DisplayName("현재 시간이 인터뷰 시작 시간보다 이전인 경우 READY를 반환한다.")
+        void readyStatus_success() {
+            // given
+            final Team team = saveTeam();
 
-                // when
-                final TeamStatus actual = team.status(presentTime.plusDays(3));
+            // when
+            final TeamStatus actual = team.status(BEFORE_START_TIME);
 
-                // then
-                assertThat(actual).isEqualTo(TeamStatus.CLOSED);
-            }
+            // then
+            assertThat(actual).isEqualTo(TeamStatus.READY);
         }
 
-        @Nested
-        @DisplayName("validateBeforeStartAt 메서드는")
-        class ValidateBeforeStartAt {
+        @Test
+        @DisplayName("인터뷰 시작시간이 현재 시간보다 이후이면서 종료되지 않은 경우 IN_PROGRESS를 반환한다.")
+        void inProgressStatus_success() {
+            // given
+            final Team team = saveTeam();
 
-            @Test
-            @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이후면 예외가 발생한다.")
-            void validate_beforeStartAt_thrownException() {
-                // given
-                final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
+            // when
+            final TeamStatus actual = team.status(AFTER_START_TIME);
 
-                // when & then
-                assertThatThrownBy(
-                        () -> team.validateReady(AFTER_START_TIME, "피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다."))
-                        .isInstanceOf(InterviewTimeException.class)
-                        .hasMessageContaining("피드백은 인터뷰가 진행되는 도중에만 작성할 수 있습니다.");
-            }
+            // then
+            assertThat(actual).isEqualTo(TeamStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("인터뷰가 종료된 경우 CLOSED를 반환한다.")
+        void closedStatus_success() {
+            // given
+            final Team team = saveTeam();
+            team.close(AFTER_START_TIME);
+
+            // when
+            final TeamStatus actual = team.status(AFTER_START_TIME);
+
+            // then
+            assertThat(actual).isEqualTo(TeamStatus.CLOSED);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -701,6 +701,37 @@ class TeamControllerTest extends ControllerTest {
     }
 
     @Nested
+    @DisplayName("findStatus 메서드는")
+    class FindStatus {
+
+        @Test
+        @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
+        void findStatus_teamNotFound_Exception() throws Exception {
+            // given
+            final String message = "팀이 존재하지 않습니다.";
+            final long teamId = 10000000L;
+            willThrow(new TeamNotFoundException(message + " 입력한 팀 id : [10000000]", message))
+                    .given(teamService)
+                    .findStatus(teamId);
+
+            // when
+            final ResultActions perform = mockMvc.perform(get("/api/teams/" + teamId + "/status")
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.ALL))
+                    .andDo(print());
+
+            // then
+            perform.andExpectAll(
+                    status().isNotFound(),
+                    jsonPath("message").value(message)
+            );
+
+            // docs
+            perform.andDo(document("team/find-status/exception/team-not-found"));
+        }
+    }
+
+    @Nested
     @DisplayName("findMyRole 메서드는")
     class FindMyRole {
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -715,10 +715,7 @@ class TeamControllerTest extends ControllerTest {
                     .findStatus(teamId);
 
             // when
-            final ResultActions perform = mockMvc.perform(get("/api/teams/" + teamId + "/status")
-                            .contentType(MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.ALL))
-                    .andDo(print());
+            final ResultActions perform = requestGet("/api/teams/" + teamId + "/status", TOKEN);
 
             // then
             perform.andExpectAll(

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -715,7 +715,7 @@ class TeamControllerTest extends ControllerTest {
                     .findStatus(teamId);
 
             // when
-            final ResultActions perform = requestGet("/api/teams/" + teamId + "/status", TOKEN);
+            final ResultActions perform = requestFindStatus(teamId);
 
             // then
             perform.andExpectAll(
@@ -725,6 +725,10 @@ class TeamControllerTest extends ControllerTest {
 
             // docs
             perform.andDo(document("team/find-status/exception/team-not-found"));
+        }
+
+        private ResultActions requestFindStatus(final Long teamId) throws Exception {
+            return requestGet("/api/teams/" + teamId + "/status");
         }
     }
 


### PR DESCRIPTION
## 구현 기능
- 팀의 상태를 조회하는 API
- TeamTest 리팩터링
  - update 메서드 테스트 코드 삭제 (사실상 update가 아닌 생성자 validation로직 테스트임)
  - 다른 메서드 테스트 클래스에 들어가있는 내부 클래스..

## 공유하고 싶은 내용
- 코멘트 확인 바람.


Close #264 
