### PR TITLE
chore: Jacoco 라이브러리 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,8 +57,6 @@ ext {
 test {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
-
-	finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -99,8 +97,6 @@ jacocoTestReport {
 				})
 		)
 	}
-
-	finalizedBy 'jacocoTestCoverageVerification'
 }
 
 jacocoTestCoverageVerification {
@@ -124,4 +120,14 @@ jacocoTestCoverageVerification {
 			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*']
 		}
 	}
+}
+
+task testCoverage {
+	group 'verification'
+	description 'Runs the unit tests with coverage'
+
+	dependsOn('test', 'jacocoTestReport', 'jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.woowacourse'
@@ -56,6 +57,8 @@ ext {
 test {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+
+	finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -75,5 +78,50 @@ bootJar {
 	dependsOn createDocument
 	from("${asciidoctor.outputDir}") {
 		into 'static/docs'
+	}
+}
+
+jacoco {
+	toolVersion('0.8.7')
+}
+
+jacocoTestReport {
+	reports {
+		html.enabled true
+		csv.enabled true
+		xml.enabled false
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes: ['**/support/**', '**/dto/**', '**/*Application*', '**/*BaseEntity*', '**/*Github*'])
+				})
+		)
+	}
+
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			element = 'CLASS'
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+
+			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*']
+		}
 	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -93,7 +93,9 @@ jacocoTestReport {
 	afterEvaluate {
 		classDirectories.setFrom(
 				files(classDirectories.files.collect {
-					fileTree(dir: it, excludes: ['**/support/**', '**/dto/**', '**/*Application*', '**/*BaseEntity*', '**/*Github*'])
+					fileTree(dir: it,
+							excludes: ['**/support/**', '**/dto/**', '**/*Application*', '**/*BaseEntity*',
+									   '**/*Github*', '**/aspect/**', '**/*Config*'])
 				})
 		)
 	}
@@ -117,14 +119,14 @@ jacocoTestCoverageVerification {
 				minimum = 0.80
 			}
 
-			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*']
+			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*', '*aspect*', '*Config*']
 		}
 	}
 }
 
 task testCoverage {
 	group 'verification'
-	description 'Runs the unit tests with coverage'
+	description 'Run tests with coverage'
 
 	dependsOn('test', 'jacocoTestReport', 'jacocoTestCoverageVerification')
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -86,8 +86,8 @@ jacoco {
 jacocoTestReport {
 	reports {
 		html.enabled true
-		csv.enabled true
-		xml.enabled false
+		csv.enabled false
+		xml.enabled true
 	}
 
 	afterEvaluate {

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 구현 기능
- 코드 커버리지 분석을 위해 Jacoco 라이브러리 적용

## 논의하고 싶은 내용
### 현재 커버리지 측정에서 제외된 파일(excludes)
- 우리가 직접 구현한 로직이 아닌 클래스들
  - AuthorizationExtractor, JwtTokenProvider, BaseEntity(Auditing)
- 메인 어플리케이션
- DTO 파일들
- 전략 패턴을 위한 프로덕션용 구현체(외부 라이브러리 사용)
  -  LocalTimeStandard, GithubOAuthClient

excludes에 추가로 포함하거나 빼고 싶은 클래스들이 있다면 코멘트 남겨주세요

### 코드 커버리지 검증 기준
현재 코드 커버리지 최소 기준을 80%로 설정한 상태입니다. (80% 미만이면 빌드 실패)
개인적으로 백사장 분들 모두 꼼꼼한 테스트 작성을 지향하기 때문에 커버리지 기준을 90%까지는 아니더라도 조금 더 높여도 될 거 같은데 어떻게 생각하시나요? 일반적으로 검증 기준은 80%로 설정하는 경우가 많은 것 같긴 합니다.
참고로 현재 코드 커버리지 측정 결과 52개의 클래스 중 6개를 제외하고는 모두 100% 입니다👍🏼 (6개의 클래스 중 커버리지가 가장 낮은 파일도 90%)

## 공유하고 싶은 내용
- 코드 커버리지 분석 결과 테스트 케이스가 부족한 부분들은 #280 이슈로 발행해 놨습니다. 꼭 100%를 만족해야 할 필요는 없다고 생각하기에 굳이 필요 없는 테스트 케이스라고 생각하시면 코멘트 남기고 이슈 마감해주세용
- 소나 큐브까지 적용하고 한꺼번에 PR 올릴까 하다가 코드 커버리지와 관련된 부분들 따로 논의해 보면 좋을 거 같아서 먼저 올립니다.