### PR TITLE
chore: 로그 개선

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/common/aspect/LogAspect.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/aspect/LogAspect.java
@@ -28,7 +28,7 @@ public class LogAspect {
         final String methodName = joinPoint.getSignature()
                 .getName();
 
-        log.info("[{}]{}.{} took {}ms", correlationId, className, methodName, executionTimeMillis);
+        log.info("[{}] {}.{} took {}ms", correlationId, className, methodName, executionTimeMillis);
 
         return result;
     }

--- a/backend/src/main/java/com/woowacourse/levellog/common/aspect/LogAspect.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/aspect/LogAspect.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,7 +18,6 @@ public class LogAspect {
         result = joinPoint.proceed();
         final long endTime = System.currentTimeMillis();
 
-        final String correlationId = MDC.get("correlationId");
         final long executionTimeMillis = endTime - startTime;
 
         final String className = joinPoint.getSignature()
@@ -28,7 +26,7 @@ public class LogAspect {
         final String methodName = joinPoint.getSignature()
                 .getName();
 
-        log.info("[{}] {}.{} took {}ms", correlationId, className, methodName, executionTimeMillis);
+        log.info("{}.{} took {}ms", className, methodName, executionTimeMillis);
 
         return result;
     }

--- a/backend/src/main/java/com/woowacourse/levellog/common/config/LogInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/config/LogInterceptor.java
@@ -3,9 +3,11 @@ package com.woowacourse.levellog.common.config;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@Slf4j
 public class LogInterceptor implements HandlerInterceptor {
 
     @Override
@@ -15,6 +17,19 @@ public class LogInterceptor implements HandlerInterceptor {
                 .toString()
                 .substring(0, 8);
         MDC.put("correlationId", correlationId);
+
+        final String httpMethod = request.getMethod();
+        final String uri = request.getRequestURI();
+
+        String queryString = request.getQueryString();
+        if (queryString == null) {
+            queryString = "";
+        } else {
+            queryString = "?" + queryString;
+        }
+
+        log.info("[{}] {} {}{}", correlationId, httpMethod, uri, queryString);
+
         return true;
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/config/LogInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/config/LogInterceptor.java
@@ -28,7 +28,7 @@ public class LogInterceptor implements HandlerInterceptor {
             queryString = "?" + queryString;
         }
 
-        log.info("[{}] {} {}{}", correlationId, httpMethod, uri, queryString);
+        log.info("{} {}{}", httpMethod, uri, queryString);
 
         return true;
     }

--- a/backend/src/main/java/com/woowacourse/levellog/common/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/config/WebConfig.java
@@ -20,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(new LogInterceptor());
+        registry.addInterceptor(new LogInterceptor())
+                .order(-1);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
@@ -17,7 +17,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        log.info("[{}]{} : {}", getCorrelationId(), e.getClass().getSimpleName(), e.getMessage());
+        log.info("[{}] {} : {}", getCorrelationId(), e.getClass().getSimpleName(), e.getMessage());
         return toResponseEntity(e.getClientMessage(), e.getHttpStatus());
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
@@ -3,7 +3,6 @@ package com.woowacourse.levellog.common.presentation;
 import com.woowacourse.levellog.common.dto.ExceptionResponse;
 import com.woowacourse.levellog.common.exception.LevellogException;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -17,7 +16,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        log.info("[{}] {} : {}", getCorrelationId(), e.getClass().getSimpleName(), e.getMessage());
+        log.info("{} : {}", e.getClass().getSimpleName(), e.getMessage());
         return toResponseEntity(e.getClientMessage(), e.getHttpStatus());
     }
 
@@ -31,7 +30,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
-        log.warn("[{}]", getCorrelationId(), e);
+        log.warn("Internal server error", e);
         return toResponseEntity("예상치 못한 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -40,9 +39,5 @@ public class ControllerAdvice {
         return ResponseEntity
                 .status(httpStatus)
                 .body(response);
-    }
-
-    private String getCorrelationId() {
-        return MDC.get("correlationId");
     }
 }

--- a/backend/src/main/resources/appender/console/console-appender.xml
+++ b/backend/src/main/resources/appender/console/console-appender.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+    <appender name="console-appender" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${CONSOLE_PATTERN}</pattern>
+        </layout>
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/console/parameter-appender.xml
+++ b/backend/src/main/resources/appender/console/parameter-appender.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+    <appender name="parameter-appender" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${PARAMETER_PATTERN}</pattern>
+        </layout>
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/console/query-appender.xml
+++ b/backend/src/main/resources/appender/console/query-appender.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+    <appender name="query-appender" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${QUERY_PATTERN}</pattern>
+        </layout>
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/file/error-appender.xml
+++ b/backend/src/main/resources/appender/file/error-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${ARCHIVE_PATH}/error.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${ARCHIVE_PATH}/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>100MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/backend/src/main/resources/appender/file/error-appender.xml
+++ b/backend/src/main/resources/appender/file/error-appender.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<included>
+    <appender name="error-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <file>${LOG_PATH}/error.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder>
+            <pattern>${ERROR_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVE_PATH}/error.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>180</maxHistory>
+        </rollingPolicy>
+
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/file/info-appender.xml
+++ b/backend/src/main/resources/appender/file/info-appender.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<included>
+    <appender name="info-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <file>${LOG_PATH}/info.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder>
+            <pattern>${INFO_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVE_PATH}/info.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>180</maxHistory>
+        </rollingPolicy>
+
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/file/info-appender.xml
+++ b/backend/src/main/resources/appender/file/info-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${ARCHIVE_PATH}/info.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${ARCHIVE_PATH}/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>100MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/backend/src/main/resources/appender/file/warn-appender.xml
+++ b/backend/src/main/resources/appender/file/warn-appender.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<included>
+    <appender name="warn-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <file>${LOG_PATH}/warn.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder>
+            <pattern>${WARN_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVE_PATH}/warn.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>180</maxHistory>
+        </rollingPolicy>
+
+    </appender>
+</included>

--- a/backend/src/main/resources/appender/file/warn-appender.xml
+++ b/backend/src/main/resources/appender/file/warn-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${ARCHIVE_PATH}/warn.%d{${DATE_FORMAT}}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${ARCHIVE_PATH}/warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>100MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/backend/src/main/resources/appender/pattern.xml
+++ b/backend/src/main/resources/appender/pattern.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<included>
+    <property name="INFO_PATTERN" value="%highlight([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+    <property name="WARN_PATTERN" value="%highlight([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+    <property name="SQL_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg%n"/>
+</included>

--- a/backend/src/main/resources/appender/pattern.xml
+++ b/backend/src/main/resources/appender/pattern.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<included>
-    <property name="INFO_PATTERN" value="%highlight([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
-    <property name="WARN_PATTERN" value="%highlight([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
-    <property name="SQL_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg%n"/>
-</included>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<included>
+    <property name="INFO_PATTERN" value="%blue([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+    <property name="WARN_PATTERN" value="%red([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+    <property name="ERROR_PATTERN" value="%boldRed([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+
+    <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%logger{20}]) - %msg %n"/>
+    <property name="QUERY_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
+    <property name="PARAMETER_PATTERN" value="%yellow(#) %msg %n"/>
+
+    <property name="LOGS_PATH" value="./logs"/>
+    <property name="ARCHIVE_PATH" value="./was-logs"/>
+
+    <timestamp key="DATE_FORMAT" datePattern="yyyy-MM-dd"/>
+</included>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <included>
-    <property name="INFO_PATTERN" value="%blue([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
-    <property name="WARN_PATTERN" value="%red([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
-    <property name="ERROR_PATTERN" value="%boldRed([%-5level])[%d{MM-dd HH:mm:ss}] - %msg %n"/>
+    <property name="INFO_PATTERN"
+              value="%blue([%-5level])[%d{MM-dd HH:mm:ss}] %blue(-) %msg %n"/>
+    <property name="WARN_PATTERN"
+              value="%red([%-5level])[%d{MM-dd HH:mm:ss}]%highlight([%logger{20}:%line]) %red(-) %msg %n"/>
+    <property name="ERROR_PATTERN"
+              value="%boldRed([%-5level])[%d{MM-dd HH:mm:ss}]%highlight([%logger{20}:%line]) %boldRed(-) %msg %n"/>
 
     <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%logger{20}]) - %msg %n"/>
     <property name="QUERY_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
     <property name="PARAMETER_PATTERN" value="%yellow(#) %msg %n"/>
 
-    <property name="LOGS_PATH" value="./logs"/>
+    <property name="LOG_PATH" value="./logs"/>
     <property name="ARCHIVE_PATH" value="./was-logs"/>
 
     <timestamp key="DATE_FORMAT" datePattern="yyyy-MM-dd"/>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -8,7 +8,7 @@
     <property name="ERROR_PATTERN"
               value="%boldRed([%-5level])[%d{MM-dd HH:mm:ss}]%highlight([%logger{20}:%line]) %boldRed(-) %msg %n"/>
 
-    <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%logger{20}]) - %msg %n"/>
+    <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%replace(%logger{20}){'\\w\\.', ''}]) - %msg %n"/>
     <property name="QUERY_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
     <property name="PARAMETER_PATTERN" value="%yellow(#) %msg %n"/>
 

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -14,6 +14,4 @@
 
     <property name="LOG_PATH" value="./logs"/>
     <property name="ARCHIVE_PATH" value="./was-logs"/>
-
-    <timestamp key="DATE_FORMAT" datePattern="yyyy-MM-dd"/>
 </included>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -10,7 +10,7 @@
 
     <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%replace(%logger{20}){'\\w\\.', ''}]) - %msg %n"/>
     <property name="QUERY_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
-    <property name="PARAMETER_PATTERN" value="%yellow(#) %msg %n"/>
+    <property name="PARAMETER_PATTERN" value="%yellow(#) %replace(%msg){'binding parameter \\[(\\d*)\\] as \\[\\w*\\] - ', '$1 - '} %n"/>
 
     <property name="LOG_PATH" value="./logs"/>
     <property name="ARCHIVE_PATH" value="./was-logs"/>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -2,15 +2,18 @@
 
 <included>
     <property name="INFO_PATTERN"
-              value="%blue([%-5level])[%d{MM-dd HH:mm:ss}] %blue(-) %msg %n"/>
+              value="%blue([%-5level])[%d{MM-dd HH:mm:ss}]%blue([%replace(%logger{20}){'\\w\\.', ''}]) %blue(-) %msg %n"/>
     <property name="WARN_PATTERN"
-              value="%red([%-5level])[%d{MM-dd HH:mm:ss}]%highlight([%logger{20}:%line]) %red(-) %msg %n"/>
+              value="%red([%level])[%d{MM-dd HH:mm:ss}]%red([%replace(%logger{20}){'\\w\\.', ''}:%line]) %red(-) %msg %n"/>
     <property name="ERROR_PATTERN"
-              value="%boldRed([%-5level])[%d{MM-dd HH:mm:ss}]%highlight([%logger{20}:%line]) %boldRed(-) %msg %n"/>
+              value="%boldRed([%level])[%d{MM-dd HH:mm:ss}]%boldRed([%replace(%logger{20}){'\\w\\.', ''}:%line]) %boldRed(-) %msg %n"/>
 
-    <property name="CONSOLE_PATTERN" value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%replace(%logger{20}){'\\w\\.', ''}]) - %msg %n"/>
-    <property name="QUERY_PATTERN" value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
-    <property name="PARAMETER_PATTERN" value="%yellow(#) %replace(%msg){'binding parameter \\[(\\d*)\\] as \\[\\w*\\] - ', '$1 - '} %n"/>
+    <property name="CONSOLE_PATTERN"
+              value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%replace(%logger{20}){'\\w\\.', ''}]) - %msg %n"/>
+    <property name="QUERY_PATTERN"
+              value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
+    <property name="PARAMETER_PATTERN"
+              value="%yellow(#) %replace(%msg){'binding parameter \\[(\\d*)\\] as \\[\\w*\\] - ', '$1 - '} %n"/>
 
     <property name="LOG_PATH" value="./logs"/>
     <property name="ARCHIVE_PATH" value="./was-logs"/>

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -9,7 +9,7 @@
               value="[%boldRed(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%boldRed(%replace(%logger{20}){'\\w\\.', ''}:%line)] %msg %n"/>
 
     <property name="CONSOLE_PATTERN"
-              value="[%highlight(%-5level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%highlight(%replace(%logger{20}){'\\w\\.', ''})] %msg %n"/>
+              value="[%highlight(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%highlight(%replace(%logger{20}){'\\w\\.', ''})] %msg %n"/>
     <property name="QUERY_PATTERN"
               value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
     <property name="PARAMETER_PATTERN"

--- a/backend/src/main/resources/appender/property.xml
+++ b/backend/src/main/resources/appender/property.xml
@@ -2,14 +2,14 @@
 
 <included>
     <property name="INFO_PATTERN"
-              value="%blue([%-5level])[%d{MM-dd HH:mm:ss}]%blue([%replace(%logger{20}){'\\w\\.', ''}]) %blue(-) %msg %n"/>
+              value="[%blue(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%blue(%replace(%logger{20}){'\\w\\.', ''})] %msg %n"/>
     <property name="WARN_PATTERN"
-              value="%red([%level])[%d{MM-dd HH:mm:ss}]%red([%replace(%logger{20}){'\\w\\.', ''}:%line]) %red(-) %msg %n"/>
+              value="[%red(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%red(%replace(%logger{20}){'\\w\\.', ''}:%line)] %msg %n"/>
     <property name="ERROR_PATTERN"
-              value="%boldRed([%level])[%d{MM-dd HH:mm:ss}]%boldRed([%replace(%logger{20}){'\\w\\.', ''}:%line]) %boldRed(-) %msg %n"/>
+              value="[%boldRed(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%boldRed(%replace(%logger{20}){'\\w\\.', ''}:%line)] %msg %n"/>
 
     <property name="CONSOLE_PATTERN"
-              value="%highlight([%-5level])[%d{HH:mm:ss}]%highlight([%replace(%logger{20}){'\\w\\.', ''}]) - %msg %n"/>
+              value="[%highlight(%-5level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{correlationId})][%highlight(%replace(%logger{20}){'\\w\\.', ''})] %msg %n"/>
     <property name="QUERY_PATTERN"
               value="%yellow([%d{HH:mm:ss}]) %msg %n"/>
     <property name="PARAMETER_PATTERN"

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -8,20 +8,8 @@ spring:
 
 # JPA
   jpa:
-    show-sql: true
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
-        format_sql: true
-
-# JPA Log
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -8,20 +8,10 @@ spring:
 
 # JPA
   jpa:
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
         format_sql: true
-
-# JPA Log
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,23 +8,13 @@ spring:
 
 # JPA
   jpa:
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
         format_sql: true
-
-# JPA Log
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
 
 security:
   github:

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,89 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <include resource="appender/property.xml"/>
+
     <!-- Console 로그 설정 -->
     <springProfile name="test, local, default">
-        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-            <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>%highlight([%-5level])[%d{yyyy-MM-dd HH:mm:ss.SSS}][%thread]%highlight([%logger{20}]) - %msg%n
-                </pattern>
-            </layout>
-        </appender>
 
-        <root level="INFO">
-            <appender-ref ref="STDOUT"/>
-        </root>
+        <include resource="appender/console/query-appender.xml"/>
+        <include resource="appender/console/parameter-appender.xml"/>
+        <include resource="appender/console/console-appender.xml"/>
+
+        <logger name="org.hibernate.SQL" level="DEBUG">
+            <appender-ref ref="query-appender"/>
+        </logger>
+
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE">
+            <appender-ref ref="parameter-appender"/>
+        </logger>
+
+        <logger name="com.woowacourse.levellog" level="INFO">
+            <appender-ref ref="console-appender"/>
+        </logger>
+
     </springProfile>
-    <!-- Console 로그 설정 끝 -->
 
     <!-- RollingFile 로그 설정 -->
     <springProfile name="prod, dev">
-        <property name="LOGS_ABSOLUTE_PATH" value="./logs"/>
-        <appender name="INFO_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./logs/info.log</file>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>INFO</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-            <encoder>
-                <pattern>%highlight([%-5level])[%d{yyyy-MM-dd HH:mm:ss.SSS}][%thread]%blue([%logger{20}]) - %msg%n
-                </pattern>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./was-logs/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                    <maxFileSize>100MB</maxFileSize>
-                </timeBasedFileNamingAndTriggeringPolicy>
-                <maxHistory>180</maxHistory>
-            </rollingPolicy>
-        </appender>
 
-        <appender name="WARN_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./logs/warn.log</file>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>WARN</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-            <encoder>
-                <pattern>%highlight([%-5level])[%d{yyyy-MM-dd HH:mm:ss.SSS}][%thread]%red([%logger{20}]) - %msg%n
-                </pattern>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./was-logs/warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                    <maxFileSize>100MB</maxFileSize>
-                </timeBasedFileNamingAndTriggeringPolicy>
-                <maxHistory>180</maxHistory>
-            </rollingPolicy>
-        </appender>
+        <include resource="appender/file/info-appender.xml"/>
+        <include resource="appender/file/warn-appender.xml"/>
+        <include resource="appender/file/error-appender.xml"/>
 
-        <appender name="ERROR_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./logs/error.log</file>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>ERROR</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-            <encoder>
-                <pattern>%highlight([%-5level])[%d{yyyy-MM-dd HH:mm:ss.SSS}][%thread]%boldRed([%logger{20}]) - %msg%n
-                </pattern>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./was-logs/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                    <maxFileSize>100MB</maxFileSize>
-                </timeBasedFileNamingAndTriggeringPolicy>
-                <maxHistory>180</maxHistory>
-            </rollingPolicy>
-        </appender>
         <root level="INFO">
-            <appender-ref ref="INFO_LOG"/>
-            <appender-ref ref="WARN_LOG"/>
-            <appender-ref ref="ERROR_LOG"/>
+            <appender-ref ref="info-appender"/>
+            <appender-ref ref="warn-appender"/>
+            <appender-ref ref="error-appender"/>
         </root>
     </springProfile>
-    <!-- RollingFile 로그 설정 끝 -->
 
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -36,6 +36,7 @@
             <appender-ref ref="warn-appender"/>
             <appender-ref ref="error-appender"/>
         </root>
+
     </springProfile>
 
 </configuration>

--- a/backend/src/test/java/com/woowacourse/levellog/domain/NicknameMappingRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/NicknameMappingRepositoryTest.java
@@ -2,23 +2,13 @@ package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.levellog.common.config.JpaConfig;
 import com.woowacourse.levellog.member.domain.NicknameMapping;
-import com.woowacourse.levellog.member.domain.NicknameMappingRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(JpaConfig.class)
 @DisplayName("NicknameMappingRepository의")
-public class NicknameMappingRepositoryTest {
-
-    @Autowired
-    NicknameMappingRepository nicknameMappingRepository;
+class NicknameMappingRepositoryTest extends RepositoryTest {
 
     @Test
     @DisplayName("findByGithubNickname 메서드는 특정 GithubNickname이 포함된 닉네임 객체를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/RepositoryTest.java
@@ -11,6 +11,7 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.levellog.domain.LevellogRepository;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.domain.MemberRepository;
+import com.woowacourse.levellog.member.domain.NicknameMappingRepository;
 import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
 import com.woowacourse.levellog.team.domain.Participant;
@@ -21,10 +22,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import(JpaConfig.class)
 abstract class RepositoryTest {
 
@@ -48,6 +54,9 @@ abstract class RepositoryTest {
 
     @Autowired
     protected TeamRepository teamRepository;
+
+    @Autowired
+    protected NicknameMappingRepository nicknameMappingRepository;
 
     protected Member saveMember(final String nickname) {
         final Member member = new Member(nickname, ((int) System.nanoTime()), nickname + ".org");


### PR DESCRIPTION
## 구현 기능
- #114 관련 내용 구현
  - 불필요한 정보 삭제
  - 요청의 **http method**, **url**, **query param** 로그 추가
- `correlationId` 위치 변경
- **appender** 파일 분리
- **hibernate** 관련 로그 개선
- `LogInterceptor` 보다 `AuthInterceptor`가 먼저 동작해서 correlationId가 null인 버그 해결

## 논의하고 싶은 내용
- 좀 더 수정했으면 하는 부분 의견 주세요 😛 (미리보기 참고)

## 공유하고 싶은 내용
- 문서화해서 공유해보겠습니다... 😉
- RepositoryTest에 `@ActiveProfiles("test")` 다니까 테스트가 깨져서 `@AutoConfigureTestDatabase(replace = Replace.NONE)` 추가로 달았읍니다. [참고자료](https://kangwoojin.github.io/programing/auto-configure-test-database/)
- 미리보기
### 이렇게 생겼던걸 🤢
**INFO 로그**
<img width="1307" alt="스크린샷 2022-08-14 오전 12 38 58" src="https://user-images.githubusercontent.com/68512686/184501033-47af44a0-f6ce-43d5-aad8-cf249655aaa3.png">

**테스트 코드 실행 시 콘솔 창**
![스크린샷 2022-08-14 오전 12 12 35](https://user-images.githubusercontent.com/68512686/184500156-ac3131f7-c841-429e-be86-beed72c38aad.png)


### 이렇게 바꿨어요 😉
**INFO 로그**
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/68512686/184499688-0756715a-4cf9-4ea6-802a-3037ef6be4ef.png">

**테스트 코드 실행 시 콘솔 창**
![스크린샷 2022-08-14 오전 12 08 30](https://user-images.githubusercontent.com/68512686/184500045-a62ea8e0-fafd-4343-aaf4-53e6d03e90dc.png)



Close #114 
