### PR TITLE
feat: 참가자 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -102,10 +102,10 @@ public class TeamService {
         validateHost(memberId, team);
         team.update(request.toEntity(team.getProfileUrl()), timeStandard.now());
         
-        final Participants updatedParticipants = createParticipants(team, memberId, request.getParticipants().getIds());
-        team.validParticipantNumber(updatedParticipants.size());
+        final Participants participants = createParticipants(team, memberId, request.getParticipants().getIds());
+        team.validParticipantNumber(participants.size());
         participantRepository.deleteByTeam(team);
-        participantRepository.saveAll(updatedParticipants.getValues());
+        participantRepository.saveAll(participants.getValues());
     }
 
     @Transactional


### PR DESCRIPTION
## 구현 기능
- 참가자 수정 기능 구현

## 공유하고 싶은 내용
- 기존 `team`의 참가자들(Participants)을 모두 삭제하고 새로운 참가자를 저장하는 방식으로 구현(`deleteAll` ➡️ `saveAll`)하였습니다. 더 좋은 아이디어 환영합니다🙌

Close #282 
