### PR TITLE
refactor: 테스트 코드 네이밍 컨벤션 수정

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -22,8 +22,8 @@ operation::auth/login[]
 
 ==== 유효하지 않은 authorizationCode
 
-include::{snippets}/auth/login/null/http-response.adoc[]
+include::{snippets}/auth/login/exception/blank/http-response.adoc[]
 
 ==== 깃허브에서 토큰 받아오기 실패
 
-include::{snippets}/auth/login/github-fail/http-response.adoc[]
+include::{snippets}/auth/login/exception/github-fail/http-response.adoc[]

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -20,9 +20,9 @@ operation::auth/login[]
 [[login-exception]]
 === 깃허브 로그인 예외
 
-==== 유효하지 않은 authorizationCode
+==== authorizationCode에 공백이나 null이 들어올 경우
 
-include::{snippets}/auth/login/exception/blank/http-response.adoc[]
+include::{snippets}/auth/login/exception/null/http-response.adoc[]
 
 ==== 깃허브에서 토큰 받아오기 실패
 

--- a/backend/src/docs/asciidoc/feedback.adoc
+++ b/backend/src/docs/asciidoc/feedback.adoc
@@ -6,6 +6,7 @@
 
 [[home]]
 == home
+
 * link:index.html[목록으로 가기]
 
 [[save]]
@@ -20,21 +21,27 @@ operation::feedback/save[]
 === 피드백 작성 예외
 
 ==== 요청을 보낸 사용자가 해당 레벨로그에 작성한 피드백이 이미 존재하는 경우
+
 include::{snippets}/feedback/save/exception/exist/http-response.adoc[]
 
 ==== 자신의 레벨로그에 피드백을 남기려는 경우
+
 include::{snippets}/feedback/save/exception/self/http-response.adoc[]
 
 ==== 팀에 속하지 않은 멤버가 피드백을 작성하려는 경우
+
 include::{snippets}/feedback/save/exception/team/http-response.adoc[]
 
 ==== 존재하지 않는 레벨로그에 대해 피드백을 작성하려는 경우
+
 include::{snippets}/feedback/save/exception/levellog/http-response.adoc[]
 
 ==== 인터뷰 시작 전에 피드백을 작성하려는 경우
+
 include::{snippets}/feedback/save/exception/before-interview/http-response.adoc[]
 
 ==== 인터뷰 종료 후에 피드백을 작성하려는 경우
+
 include::{snippets}/feedback/save/exception/after-interview/http-response.adoc[]
 
 [[find-all]]
@@ -49,6 +56,7 @@ operation::feedback/find-all[]
 === 피드백 목록 조회 예외
 
 ==== 존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하는 경우
+
 include::{snippets}/feedback/find-all/exception/levellog/http-response.adoc[]
 
 [[update]]
@@ -63,13 +71,17 @@ operation::feedback/update[]
 === 피드백 수정 예외
 
 ==== 다른 사용자가 작성한 피드백을 수정하려는 경우
-include::{snippets}/feedback/update/exception/author/http-response.adoc[]
+
+include::{snippets}/feedback/update/exception/not-author/http-response.adoc[]
 
 ==== 존재하지 않는 피드백 정보로 피드백을 수정하려는 경우
+
 include::{snippets}/feedback/update/exception/feedback/http-response.adoc[]
 
 ==== 인터뷰 시작 전에 피드백을 수정하려는 경우
+
 include::{snippets}/feedback/update/exception/before-interview/http-response.adoc[]
 
 ==== 인터뷰 종료 후에 피드백을 수정하려는 경우
+
 include::{snippets}/feedback/update/exception/after-interview/http-response.adoc[]

--- a/backend/src/docs/asciidoc/interviewquestion.adoc
+++ b/backend/src/docs/asciidoc/interviewquestion.adoc
@@ -22,11 +22,11 @@ operation::interview-question/save[]
 
 ==== 인터뷰 질문 내용이 공백인 경우
 
-include::{snippets}/interview-question/save/exception/contents/blank/http-response.adoc[]
+include::{snippets}/interview-question/save/exception/contents-blank/http-response.adoc[]
 
 ==== 인터뷰 질문 내용 길이가 255 글자 초과인 경우
 
-include::{snippets}/interview-question/save/exception/contents/length/http-response.adoc[]
+include::{snippets}/interview-question/save/exception/contents-length/http-response.adoc[]
 
 ==== 인터뷰 질문에 해당하는 레벨로그가 존재하지 않는 경우
 
@@ -91,11 +91,11 @@ include::{snippets}/interview-question/update/exception/unauthorized/http-respon
 
 ==== 인터뷰 질문 내용이 공백인 경우
 
-include::{snippets}/interview-question/update/exception/contents/blank/http-response.adoc[]
+include::{snippets}/interview-question/update/exception/contents-blank/http-response.adoc[]
 
 ==== 인터뷰 질문 내용 길이가 255 글자 초과인 경우
 
-include::{snippets}/interview-question/update/exception/contents/length/http-response.adoc[]
+include::{snippets}/interview-question/update/exception/contents-length/http-response.adoc[]
 
 ==== 인터뷰가 이미 종료된 경우
 

--- a/backend/src/docs/asciidoc/interviewquestion.adoc
+++ b/backend/src/docs/asciidoc/interviewquestion.adoc
@@ -44,24 +44,24 @@ include::{snippets}/interview-question/save/exception/is-closed/http-response.ad
 
 include::{snippets}/interview-question/save/exception/is-ready/http-response.adoc[]
 
-[[findAll]]
+[[find-all]]
 == 인터뷰 질문 목록 조회
 
-[[findAll-success]]
+[[find-all-success]]
 === 인터뷰 질문 목록 조회 성공
 
-operation::interview-question/findAll[]
+operation::interview-question/find-all[]
 
-[[findAll-exception]]
+[[find-all-exception]]
 === 인터뷰 질문 조회 실패
 
 ==== 인터뷰 질문에 해당하는 레벨로그가 존재하지 않는 경우
 
-include::{snippets}/interview-question/findAll/exception/levellog-not-found/http-response.adoc[]
+include::{snippets}/interview-question/find-all/exception/levellog-not-found/http-response.adoc[]
 
 ==== 인터뷰 질문 작성자 멤버를 찾을 수 없는 경우
 
-include::{snippets}/interview-question/findAll/exception/member-not-found/http-response.adoc[]
+include::{snippets}/interview-question/find-all/exception/member-not-found/http-response.adoc[]
 
 [[update]]
 == 인터뷰 질문 내용 수정

--- a/backend/src/docs/asciidoc/levellog.adoc
+++ b/backend/src/docs/asciidoc/levellog.adoc
@@ -6,6 +6,7 @@
 
 [[home]]
 == home
+
 * link:index.html[목록으로 가기]
 
 [[save]]
@@ -20,13 +21,16 @@ operation::levellog/save[]
 === 레벨로그 작성 실패
 
 ==== 이미 작성한 레벨로그가 존재하는 경우
-include::{snippets}/levellog/save/exception-already-exists/http-response.adoc[]
+
+include::{snippets}/levellog/save/exception/already-exists/http-response.adoc[]
 
 ==== 레벨로그 내용이 공백인 경우
-include::{snippets}/levellog/save/exception-contents/http-response.adoc[]
+
+include::{snippets}/levellog/save/exception/contents/http-response.adoc[]
 
 ==== 인터뷰가 진행중이거나 끝난 팀에 레벨로그 작성을 하려는 경우
-include::{snippets}/levellog/save/exception-after-start/http-response.adoc[]
+
+include::{snippets}/levellog/save/exception/after-start/http-response.adoc[]
 
 [[find]]
 == 레벨로그 상세 조회
@@ -40,7 +44,8 @@ operation::levellog/find[]
 === 레벨로그 조회 실패
 
 ==== 레벨로그가 존재하지 않는 경우
-include::{snippets}/levellog/find/exception-exist/http-response.adoc[]
+
+include::{snippets}/levellog/find/exception/exist/http-response.adoc[]
 
 [[update]]
 == 레벨로그 수정
@@ -54,10 +59,13 @@ operation::levellog/update[]
 === 레벨로그 수정 실패
 
 ==== 작성자가 아닌 멤버가 수정하려는 경우
-include::{snippets}/levellog/update/exception-author/http-response.adoc[]
+
+include::{snippets}/levellog/update/exception/not-author/http-response.adoc[]
 
 ==== 레벨로그 내용이 공백인 경우
-include::{snippets}/levellog/update/exception-contents/http-response.adoc[]
+
+include::{snippets}/levellog/update/exception/blank/http-response.adoc[]
 
 ==== 인터뷰가 진행중이거나 끝난 팀에 레벨로그 수정을 하려는 경우
-include::{snippets}/levellog/update/exception-after-start/http-response.adoc[]
+
+include::{snippets}/levellog/update/exception/after-start/http-response.adoc[]

--- a/backend/src/docs/asciidoc/myinfo.adoc
+++ b/backend/src/docs/asciidoc/myinfo.adoc
@@ -1,4 +1,4 @@
-= MyInfo
+= my-info
 :toc: left
 :toclevels: 2
 :sectlinks:
@@ -15,7 +15,7 @@
 [[read-success]]
 === 내 정보 조회 성공
 
-operation::myinfo/read[]
+operation::my-info/read[]
 
 [[update-nickname]]
 == 닉네임 변경
@@ -23,18 +23,18 @@ operation::myinfo/read[]
 [[update-nickname-success]]
 === 닉네임 변경 성공
 
-operation::myinfo/update/nickname[]
+operation::my-info/update/nickname[]
 
 [[update-nickname-fail]]
 === 닉네임 변경 실패
 
 ==== 50자를 초과한 닉네임으로 요청 보낼 경우
 
-include::{snippets}/myinfo/update/nickname-invalid-length/http-response.adoc[]
+include::{snippets}/my-info/update/nickname-invalid-length/http-response.adoc[]
 
 ==== 빈 문자열 혹은 공백으로 요청 보낼 경우
 
-include::{snippets}/myinfo/update/nickname-blank/http-response.adoc[]
+include::{snippets}/my-info/update/nickname-blank/http-response.adoc[]
 
 [[findAllReceivedFeedbacks]]
 == 받은 피드백 전체 조회
@@ -42,7 +42,7 @@ include::{snippets}/myinfo/update/nickname-blank/http-response.adoc[]
 [[findAllReceivedFeedbacks-success]]
 === 받은 피드백 전체 조회 성공
 
-operation::myinfo/findAllReceivedFeedbacks[]
+operation::my-info/find-all-received-feedbacks[]
 
 [[findAllLevellogs]]
 == 작성한 레벨로그 전체 조회
@@ -50,7 +50,7 @@ operation::myinfo/findAllReceivedFeedbacks[]
 [[findAllLevellogs-success]]
 === 작성한 레벨로그 전체 조회 성공
 
-operation::myinfo/findAllMyLevellogs[]
+operation::my-info/find-all-my-levellogs[]
 
 [[findAllTeams]]
 == 참가한 팀 전체 조회
@@ -58,4 +58,4 @@ operation::myinfo/findAllMyLevellogs[]
 [[findAllTeams-succes]]
 === 참가한 팀 전체 조회 성공
 
-operation::myinfo/findAllMyTeam[]
+operation::my-info/find-all-my-team[]

--- a/backend/src/docs/asciidoc/prequestion.adoc
+++ b/backend/src/docs/asciidoc/prequestion.adoc
@@ -85,7 +85,7 @@ include::{snippets}/pre-question/update/exception/wrong-levellog/http-response.a
 [[update-exception-notfound]]
 ==== 없는 사전 질문을 수정하는 경우
 
-include::{snippets}/pre-question/update/exception/notfound/http-response.adoc[]
+include::{snippets}/pre-question/update/exception/not-found/http-response.adoc[]
 
 [[update-exception-not-my-pre-question]]
 ==== 다른 사용자의 사전 질문을 수정하는 경우

--- a/backend/src/docs/asciidoc/prequestion.adoc
+++ b/backend/src/docs/asciidoc/prequestion.adoc
@@ -6,6 +6,7 @@
 
 [[home]]
 == home
+
 * link:index.html[목록으로 가기]
 
 [[create]]
@@ -20,9 +21,9 @@ operation::pre-question/create[]
 === 사전 질문 등록 예외
 
 [[create-exception-prequestion-null]]
-==== 등록 시 preQuestion이 null 또는 공백인 경우
+==== 등록 시 preQuestion 이 null 또는 공백인 경우
 
-include::{snippets}/pre-question/create/exception/null-and-blank/http-response.adoc[]
+include::{snippets}/pre-question/create/exception/blank/http-response.adoc[]
 
 [[create-exception-not-participant]]
 ==== 팀의 참가자가 아닌데 사전 질문을 등록하는 경우
@@ -72,12 +73,12 @@ operation::pre-question/update[]
 === 사전 질문 수정 예외
 
 [[update-exception-prequestion-null]]
-==== 수정 시 preQuestion이 null 또는 공백인 경우
+==== 수정 시 preQuestion 이 null 또는 공백인 경우
 
-include::{snippets}/pre-question/update/exception/null-and-blank/http-response.adoc[]
+include::{snippets}/pre-question/update/exception/blank/http-response.adoc[]
 
 [[update-exception-prequestion-wrong-levellog]]
-==== url의 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
+==== 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
 
 include::{snippets}/pre-question/update/exception/wrong-levellog/http-response.adoc[]
 
@@ -103,7 +104,7 @@ operation::pre-question/delete[]
 === 사전 질문 삭제 예외
 
 [[delete-exception-wrong-levellog]]
-==== url의 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
+==== 레벨로그 id와 사전 질문의 레벨로그 id가 일치하지 않는 경우
 
 include::{snippets}/pre-question/delete/exception/wrong-levellog/http-response.adoc[]
 

--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -300,7 +300,7 @@ operation::team/close[]
 [[close-exception-notfound]]
 ==== 없는 팀의 인터뷰를 종료하려는 경우
 
-include::{snippets}/team/close/exception/notfound/http-response.adoc[]
+include::{snippets}/team/close/exception/not-found/http-response.adoc[]
 
 [[close-exception-unauthorized]]
 ==== 호스트가 아닌 사용자가 인터뷰를 종료하려는 경우

--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -23,62 +23,62 @@ operation::team/create[]
 [[create-exception-participants-duplicate]]
 ==== 저장 시 중복된 참가자가 존재하는 경우
 
-include::{snippets}/team/create/exception/participants/duplicate/http-response.adoc[]
+include::{snippets}/team/create/exception/participants-duplicate/http-response.adoc[]
 
 [[create-exception-participants-host]]
 ==== 저장 시 참가자 목록에 Host가 포함된 경우
 
-include::{snippets}/team/create/exception/participants/host/http-response.adoc[]
+include::{snippets}/team/create/exception/participants-have-host/http-response.adoc[]
 
 [[create-exception-title-null]]
 ==== 저장 시 title이 null 또는 공백인 경우
 
-include::{snippets}/team/create/exception/title/null-and-blank/http-response.adoc[]
+include::{snippets}/team/create/exception/title-blank/http-response.adoc[]
 
 [[create-exception-title-length]]
 ==== 저장 시 title의 길이가 255자 초과인 경우
 
-include::{snippets}/team/create/exception/title/length/http-response.adoc[]
+include::{snippets}/team/create/exception/title-length/http-response.adoc[]
 
 [[create-exception-place-null]]
 ==== 저장 시 place이 null 또는 공백인 경우
 
-include::{snippets}/team/create/exception/place/null-and-blank/http-response.adoc[]
+include::{snippets}/team/create/exception/place-blank/http-response.adoc[]
 
 [[create-exception-place-length]]
 ==== 저장 시 place의 길이가 255자 초과인 경우
 
-include::{snippets}/team/create/exception/place/length/http-response.adoc[]
+include::{snippets}/team/create/exception/place-length/http-response.adoc[]
 
 [[create-exception-start-at-null]]
 ==== 저장 시 startAt가 null인 경우
 
-include::{snippets}/team/create/exception/startat/null/http-response.adoc[]
+include::{snippets}/team/create/exception/start-at-null/http-response.adoc[]
 
 [[create-exception-start-at-past]]
 ==== 저장 시 startAt가 과거인 경우
 
-include::{snippets}/team/create/exception/startat/past/http-response.adoc[]
+include::{snippets}/team/create/exception/start-at-past/http-response.adoc[]
 
 [[create-exception-participants-empty]]
 ==== 저장 시 호스트 이외의 참가자가 없는 경우
 
-include::{snippets}/team/create/exception/participants/empty/http-response.adoc[]
+include::{snippets}/team/create/exception/participants-empty/http-response.adoc[]
 
 [[create-exception-participants-null]]
 ==== 저장 시 participants가 null인 경우
 
-include::{snippets}/team/create/exception/participants/null/http-response.adoc[]
+include::{snippets}/team/create/exception/participants-null/http-response.adoc[]
 
 [[create-exception-interviewer-number-not-positive]]
 ==== 저장 시 인터뷰어 수가 1미만인 경우
 
-include::{snippets}/team/create/exception/interviewer-number/not-positive/http-response.adoc[]
+include::{snippets}/team/create/exception/interviewer-number-not-positive/http-response.adoc[]
 
 [[create-exception-interviewer-number-not-positive]]
 ==== 저장 시 인터뷰어 수가 참가자 수 보다 많거나 같은 경우
 
-include::{snippets}/team/create/exception/interviewer-number/more-than-participant/http-response.adoc[]
+include::{snippets}/team/create/exception/interviewer-number-more-than-participant/http-response.adoc[]
 
 [[findAll]]
 == 팀 목록 조회
@@ -100,10 +100,10 @@ include::{snippets}/team/create/exception/interviewer-number/more-than-participa
 |인터뷰가 종료된 상태이다.
 |===
 
-[[findAll-success]]
+[[find-all-success]]
 === 팀 목록 조회 성공
 
-operation::team/findAll[]
+operation::team/find-all[]
 
 [[find]]
 == 팀 상세 조회
@@ -187,67 +187,67 @@ operation::team/update[]
 [[update-exception-title-null]]
 ==== 수정 시 title이 null 또는 공백인 경우
 
-include::{snippets}/team/update/exception/title/null-and-blank/http-response.adoc[]
+include::{snippets}/team/update/exception/title-blank/http-response.adoc[]
 
 [[update-exception-title-length]]
 ==== 수정 시 title의 길이가 255자 초과인 경우
 
-include::{snippets}/team/update/exception/title/length/http-response.adoc[]
+include::{snippets}/team/update/exception/title-length/http-response.adoc[]
 
 [[update-exception-place-null]]
 ==== 수정 시 place이 null 또는 공백인 경우
 
-include::{snippets}/team/update/exception/place/null-and-blank/http-response.adoc[]
+include::{snippets}/team/update/exception/place-blank/http-response.adoc[]
 
 [[update-exception-place-length]]
 ==== 수정 시 place의 길이가 255자 초과인 경우
 
-include::{snippets}/team/update/exception/place/length/http-response.adoc[]
+include::{snippets}/team/update/exception/place-length/http-response.adoc[]
 
 [[update-exception-start-at-null]]
 ==== 수정 시 startAt가 null인 경우
 
-include::{snippets}/team/update/exception/startat/null/http-response.adoc[]
+include::{snippets}/team/update/exception/start-at-null/http-response.adoc[]
 
 [[update-exception-start-at-past]]
 ==== 수정 시 startAt가 과거인 경우
 
-include::{snippets}/team/update/exception/startat/past/http-response.adoc[]
+include::{snippets}/team/update/exception/start-at-past/http-response.adoc[]
 
 [[update-exception-notFound]]
 ==== 없는 팀을 수정하는 경우
 
-include::{snippets}/team/update/exception/notfound/http-response.adoc[]
+include::{snippets}/team/update/exception/not-found/http-response.adoc[]
 
 [[update-exception-participants-duplicate]]
 ==== 수정 시 중복된 참가자가 존재하는 경우
 
-include::{snippets}/team/update/exception/participants/duplicate/http-response.adoc[]
+include::{snippets}/team/update/exception/participants-duplicate/http-response.adoc[]
 
 [[update-exception-participants-host]]
 ==== 수정 시 참가자 목록에 Host가 포함된 경우 (hostId = 1)
 
-include::{snippets}/team/update/exception/participants/host/http-response.adoc[]
+include::{snippets}/team/update/exception/participants-have-host/http-response.adoc[]
 
 [[update-exception-participants-empty]]
 ==== 수정 시 호스트 이외의 참가자가 없는 경우
 
-include::{snippets}/team/update/exception/participants/empty/http-response.adoc[]
+include::{snippets}/team/update/exception/participants-empty/http-response.adoc[]
 
 [[update-exception-participants-null]]
 ==== 수정 시 participants가 null인 경우
 
-include::{snippets}/team/update/exception/participants/null/http-response.adoc[]
+include::{snippets}/team/update/exception/participants-null/http-response.adoc[]
 
 [[update-exception-interviewer-number-not-positive]]
 ==== 수정 시 인터뷰어 수가 1미만인 경우
 
-include::{snippets}/team/update/exception/interviewer-number/not-positive/http-response.adoc[]
+include::{snippets}/team/update/exception/interviewer-number-not-positive/http-response.adoc[]
 
 [[update-exception-interviewer-number-not-positive]]
 ==== 수정 시 인터뷰어 수가 참가자 수 보다 많거나 같은 경우
 
-include::{snippets}/team/update/exception/interviewer-number/more-than-participant/http-response.adoc[]
+include::{snippets}/team/update/exception/interviewer-number-more-than-participant/http-response.adoc[]
 
 [[update-exception-after-start-at]]
 ==== 수정 시 인터뷰 시작 이후인 경우

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionAcceptanceTest.java
@@ -100,7 +100,7 @@ class InterviewQuestionAcceptanceTest extends AcceptanceTest {
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("interview-question/findAll"))
+                .filter(document("interview-question/find-all"))
                 .when()
                 .get("/api/levellogs/{levellogId}/interview-questions", pepperLevellogId)
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -44,7 +44,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("myinfo/read"))
+                .filter(document("my-info/read"))
                 .when()
                 .get("/api/my-info")
                 .then().log().all();
@@ -74,7 +74,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .body(nicknameDto)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("myinfo/update/nickname"))
+                .filter(document("my-info/update/nickname"))
                 .when()
                 .put("/api/my-info")
                 .then().log().all();
@@ -134,7 +134,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + rickToken)
-                .filter(document("myinfo/findAllReceivedFeedbacks"))
+                .filter(document("my-info/find-all-received-feedbacks"))
                 .when()
                 .get("/api/my-info/feedbacks")
                 .then().log().all();
@@ -184,7 +184,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
-                .filter(document("myinfo/findAllMyLevellogs"))
+                .filter(document("my-info/find-all-my-levellogs"))
                 .when()
                 .get("/api/my-info/levellogs")
                 .then().log().all();
@@ -227,7 +227,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + romaToken)
-                .filter(document("myinfo/findAllMyTeam"))
+                .filter(document("my-info/find-all-my-team"))
                 .when()
                 .get("/api/my-info/teams")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/MyInfoAcceptanceTest.java
@@ -106,7 +106,7 @@ class MyInfoAcceptanceTest extends AcceptanceTest {
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + RICK.getToken())
-                .filter(document("myinfo/find-all-received-feedbacks"))
+                .filter(document("my-info/find-all-received-feedbacks"))
                 .when()
                 .get("/api/my-info/feedbacks")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -86,7 +86,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + pepper.getToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("team/findAll"))
+                .filter(document("team/find-all"))
                 .when()
                 .get("/api/teams")
                 .then().log().all();

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -104,11 +104,11 @@ class FeedbackServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("update 메서드는")
-    class update {
+    class Update {
 
         @Test
         @DisplayName("피드백을 수정한다.")
-        void update_feedback_success() {
+        void success() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -133,7 +133,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("작성자가 아닌 사용자가 피드백을 수정하려는 경우 예외를 발생시킨다.")
-        void update_noAuthor_exceptionThrown() {
+        void update_noAuthor_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -154,7 +154,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간 이전에 피드백을 수정하려는 경우 예외가 발생한다.")
-        void update_beforeStartAt_exceptionThrown() {
+        void update_beforeStartAt_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -173,7 +173,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 종료 이후에 피드백을 수정하려는 경우 예외가 발생한다.")
-        void update_alreadyClosed_exceptionThrown() {
+        void update_alreadyClosed_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -197,11 +197,11 @@ class FeedbackServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("save 메서드는")
-    class save {
+    class Save {
 
         @Test
         @DisplayName("피드백을 저장한다.")
-        void save_feedback_success() {
+        void success() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -224,7 +224,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("레벨로그에 내가 작성한 피드백이 이미 존재하는 경우 새로운 피드백을 작성하면 예외를 던진다.")
-        void save_alreadyExist_exceptionThrown() {
+        void save_alreadyExist_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -246,7 +246,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("작성자가 직접 피드백을 작성하면 예외를 던진다.")
-        void save_selfFeedback_exceptionThrown() {
+        void save_selfFeedback_exception() {
             // given
             final Member eve = saveMember("이브");
             final Team team = saveTeam(eve);
@@ -264,7 +264,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("팀에 속하지 않은 멤버가 피드백을 작성할 경우 예외를 발생시킨다.")
-        void save_otherMember_exceptionThrown() {
+        void save_otherMember_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -283,7 +283,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 시작 전 피드백을 작성하면 예외를 던진다.")
-        void save_beforeStartAt_exceptionThrown() {
+        void save_beforeStartAt_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
@@ -303,7 +303,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 종료 후 피드백을 작성하면 예외를 던진다.")
-        void save_alreadyClosed_exceptionThrown() {
+        void save_alreadyClosed_exception() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");

--- a/backend/src/test/java/com/woowacourse/levellog/application/InterviewQuestionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/InterviewQuestionServiceTest.java
@@ -223,7 +223,7 @@ class InterviewQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("id에 해당하는 레벨로그가 존재하지 않으면 예외를 던진다.")
-        void findAllByLevellog_levellogNotExist_exceptionThrown() {
+        void findAllByLevellog_levellogNotExist_exception() {
             // given
             final Long invalidLevellogId = 999L;
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/LevellogServiceTest.java
@@ -219,7 +219,7 @@ class LevellogServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("작성자의 id와 로그인한 id가 다를 경우 권한 없음 예외를 던진다.")
-        void update_unauthorized_Exception() {
+        void update_unauthorized_exception() {
             // given
             final Member author = saveMember("알린");
             final Team team = saveTeam(author);

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -81,7 +81,7 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전에 깃허브 닉네임에 대한 특수한 닉네임을 등록한 멤버가 저장될 때는 미리 저장한 닉네임으로 변경하여 멤버를 저장한다.")
-        void successBySpecial() {
+        void save_nicknameMapping_success() {
             // given
             nicknameMappingRepository.save(new NicknameMapping("깃허브로마", "우테코로마"));
             final MemberCreateDto memberCreateDto = new MemberCreateDto("깃허브로마", 12345678, "profileUrl.image");
@@ -98,7 +98,7 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("동일한 깃허브로 가입한 멤버가 존재하면 예외를 던진다.")
-        void memberAlreadyExist_exception() {
+        void save_memberAlreadyExist_exception() {
             // given
             final MemberCreateDto beforeSavedDto = new MemberCreateDto("로마", 12345678, "profileUrl.image");
             memberService.save(beforeSavedDto);
@@ -134,7 +134,7 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("존재하지 않는 Id로 요청을 보낼 경우 예외를 던진다.")
-        void memberNotFound_exception() {
+        void findMemberById_memberNotFound_exception() {
             // when & then
             assertThatThrownBy(() -> memberService.findMemberById(1000L))
                     .isInstanceOf(MemberNotFoundException.class)
@@ -149,7 +149,7 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("깃허브 아이디로 저장된 멤버가 있으면 가입된 멤버의 ID를 반환한다.")
-        void ifExist_returnSavedId() {
+        void saveIfNotExist_ifExist_success() {
             // given
             final Member savedMember = saveMember("로마");
             final Integer githubId = savedMember.getGithubId();
@@ -165,12 +165,12 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("깃허브 아이디로 저장된 멤버가 없으면 새 멤버를 저장하고 멤버의 ID를 반환한다.")
-        void ifNotExist_saveAndReturnSavedId() {
+        void saveIfNotExist_ifNotExist_success() {
             // given
             final Member savedMember = saveMember("로마");
-            final Integer githubId = savedMember.getGithubId() + 999;
+            final int githubId = savedMember.getGithubId() + 999;
 
-            final GithubProfileDto githubProfileDto = new GithubProfileDto(githubId.toString(), "test", "test.image");
+            final GithubProfileDto githubProfileDto = new GithubProfileDto(Integer.toString(githubId), "test", "test.image");
 
             // when
             final Long id = memberService.saveIfNotExist(githubProfileDto, githubId);

--- a/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/MemberServiceTest.java
@@ -65,7 +65,7 @@ class MemberServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전에 깃허브 닉네임을 등록하지 않은 새로운 멤버를 저장한다.")
-        void success() {
+        void save_notRegistered_success() {
             // given
             final MemberCreateDto memberCreateDto = new MemberCreateDto("로마", 12345678, "profileUrl.image");
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -16,11 +16,11 @@ class OAuthServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("login 메서드는")
-    class login {
+    class Login {
 
         @Test
         @DisplayName("첫 로그인 시 회원가입하고 id, 토큰, 이미지 URL를 반환한다.")
-        void login_first_signUp() throws Exception {
+        void login_ifFirst_success() throws Exception {
             // given
             final GithubProfileDto request = new GithubProfileDto("1234", "릭", "rick.org");
 
@@ -41,7 +41,7 @@ class OAuthServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("첫 로그인이 아닌 경우 회원가입 하지 않고 토큰과 이미지 URL를 반환한다.")
-        void login_notFirst_signIn() throws Exception {
+        void login_ifNotFirst_success() throws Exception {
             // given
             final Member member = saveMember("로마");
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/PreQuestionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/PreQuestionServiceTest.java
@@ -29,7 +29,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문을 생성한다.")
-        void save() {
+        void success() {
             //given
             final String preQuestion = "로마가 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -53,7 +53,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("참가자가 아닌 멤버가 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_FromNotParticipant_Exception() {
+        void save_fromNotParticipant_exception() {
             // given
             final String preQuestion = "로마가 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -73,7 +73,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("내 레벨로그에 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_LevellogIsMine_Exception() {
+        void save_levellogIsMine_exception() {
             // given
             final String preQuestion = "알린이 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -91,7 +91,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문이 이미 등록되었을 때 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_PreQuestionAlreadyExist_Exception() {
+        void save_preQuestionAlreadyExist_exception() {
             // given
             final String preQuestion = "알린이 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -118,7 +118,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문을 조회한다.")
-        void findMy() {
+        void success() {
             //given
             final String content = "로마가 쓴 사전 질문";
 
@@ -138,7 +138,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("레벨로그가 존재하지 않으면 예외를 던진다.")
-        void findMy_LevellogWrongId_Exception() {
+        void findMy_levellogWrongId_exception() {
             //given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -155,7 +155,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문이 존재하지 않으면 예외를 던진다.")
-        void findMy_PreQuestionNotFound_Exception() {
+        void findMy_preQuestionNotFound_exception() {
             // given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -175,7 +175,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문을 수정한다.")
-        void update() {
+        void success() {
             //given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -194,7 +194,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("저장되어있지 않은 사전 질문을 수정하는 경우 예외를 던진다.")
-        void update_PreQuestionNotFound_Exception() {
+        void update_preQuestionNotFound_exception() {
             // given
             final String preQuestion = "로마가 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -213,7 +213,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("타인의 사전 질문을 수정하는 경우 예외를 던진다.")
-        void update_FromNotMyPreQuestion_Exception() {
+        void update_fromNotMyPreQuestion_exception() {
             // given
             final PreQuestionDto preQuestionDto = PreQuestionDto.from("로마가 쓴 사전 질문");
 
@@ -236,7 +236,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 수정하면 예외를 던진다.")
-        void update_LevellogWrongId_Exception() {
+        void update_levellogWrongId_exception() {
             //given
             final String preQuestion = "로마가 쓴 사전 질문";
             final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
@@ -266,7 +266,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("사전 질문을 삭제한다.")
-        void deleteById() {
+        void success() {
             //given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -284,7 +284,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("타인의 사전 질문을 삭제하는 경우 예외를 던진다.")
-        void deleteById_FromNotMyPreQuestion_Exception() {
+        void deleteById_fromNotMyPreQuestion_exception() {
             // given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -303,7 +303,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("저장되어있지 않은 사전 질문을 삭제하는 경우 예외를 던진다.")
-        void deleteById_PreQuestionNotFound_Exception() {
+        void deleteById_preQuestionNotFound_exception() {
             // given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -318,7 +318,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 삭제하면 예외를 던진다.")
-        void deleteById_LevellogWrongId_Exception() {
+        void deleteById_levellogWrongId_exception() {
             //given
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -44,7 +44,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("전체 팀 목록을 조회한다.")
-        void success() {
+        void findAll_allTeam_success() {
             //given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -294,7 +294,7 @@ class TeamServiceTest extends ServiceTest {
 
             @Test
             @DisplayName("인터뷰어와 인터뷰이, isParticipant를 true로 응답한다.")
-            void success() {
+            void findByTeamIdAndMemberId_intervieweeAndInterviewer_success() {
                 //given
                 final Member rick = saveMember("릭");
                 final Member pepper = saveMember("페퍼");
@@ -391,7 +391,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 시작 전인 팀의 상태를 조회하면 READY를 반환한다.")
-        void success_ready() {
+        void findStatus_ready_success() {
             // given
             final Member pepper = saveMember("페퍼");
             final Member rick = saveMember("릭");
@@ -407,7 +407,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 진행 중인 팀의 상태를 조회하면 IN_PROGRESS를 반환한다.")
-        void success_inProgress() {
+        void findStatus_inProgress_success() {
             // given
             final Member pepper = saveMember("페퍼");
             final Member rick = saveMember("릭");
@@ -425,7 +425,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 종료 후인 팀의 상태를 조회하면 CLOSED를 반환한다.")
-        void success_closed() {
+        void findStatus_closed_success() {
             // given
             final Member pepper = saveMember("페퍼");
             final Member rick = saveMember("릭");
@@ -443,7 +443,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
-        void findStatus_notExistTeam_exceptionThrown() {
+        void findStatus_notExistTeam_exception() {
             // when & then
             assertThatThrownBy(() -> teamService.findStatus(999L))
                     .isInstanceOf(TeamNotFoundException.class);
@@ -545,7 +545,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("참가자가 중복되면 예외가 발생한다.")
-        void duplicate_exceptionThrown() {
+        void update_duplicate_exception() {
             //given
             final Member alien = saveMember("알린");
             final Member pepper = saveMember("페퍼");
@@ -564,7 +564,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("호스트 이외의 참가자가 없으면 예외가 발생한다.")
-        void noParticipant_exceptionThrown() {
+        void update_noParticipant_exception() {
             //given
             final Member alien = saveMember("알린");
             final Member pepper = saveMember("페퍼");

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -43,7 +43,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("전체 팀 목록을 조회한다.")
-        void findAll() {
+        void success() {
             //given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -95,7 +95,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("삭제된 팀을 제외한 팀 목록을 조회한다.")
-        void findAll_exceptDeleted() {
+        void findAll_exceptDeletedTeam_success() {
             //given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -120,7 +120,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("팀을 생성한다.")
-        void save() {
+        void success() {
             //given
             final Long alien = saveMember("알린").getId();
             final Long pepper = saveMember("페퍼").getId();
@@ -139,7 +139,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("참가자가 중복되면 예외가 발생한다.")
-        void save_duplicate_exceptionThrown() {
+        void save_duplicate_exception() {
             //given
             final Long alien = saveMember("알린").getId();
             final Long pepper = saveMember("페퍼").getId();
@@ -156,7 +156,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("호스트 이외의 참가자가 없으면 예외가 발생한다.")
-        void save_noParticipant_exceptionThrown() {
+        void save_noParticipant_exception() {
             //given
             final Long alienId = saveMember("알린").getId();
             final TeamWriteDto teamDto = new TeamWriteDto("잠실 준조", "트랙룸", 1, TEAM_START_TIME,
@@ -175,7 +175,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("팀의 참가자에 대한 나의 역할을 조회한다. - interviewer")
-        void success_interviewer() {
+        void findMyRole_interviewer_success() {
             // given
             final Member rick = saveMember("릭");
             final Member harry = saveMember("해리");
@@ -196,7 +196,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("팀의 참가자에 대한 나의 역할을 조회한다. - observer")
-        void success_observer() {
+        void findMyRole_observer_success() {
             // given
             final Member rick = saveMember("릭");
             final Member harry = saveMember("해리");
@@ -217,7 +217,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("팀의 참가자가 아닌 member가 요청하면 예외를 던진다.")
-        void iAmNotParticipant_exceptionThrown() {
+        void findMyRole_iAmNotParticipant_exception() {
             // given
             final Member rick = saveMember("릭");
             final Member harry = saveMember("해리");
@@ -236,7 +236,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("targetMember가 팀의 참가자가 아니면 예외를 던진다.")
-        void targetNotParticipant_exceptionThrown() {
+        void findMyRole_targetNotParticipant_exception() {
             // given
             final Member rick = saveMember("릭");
             final Member harry = saveMember("해리");
@@ -260,7 +260,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("id에 해당하는 팀을 조회한다.")
-        void findByTeamIdAndMemberId() {
+        void success() {
             //given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -280,7 +280,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("없는 id에 해당하는 팀을 조회하면 예외를 던진다.")
-        void teamNotFound_Exception() {
+        void findByTeamIdAndMemberId_notFound_exception() {
             // when & then
             assertThatThrownBy(() -> teamService.findByTeamIdAndMemberId(1000L, 1L))
                     .isInstanceOf(TeamNotFoundException.class)
@@ -293,7 +293,7 @@ class TeamServiceTest extends ServiceTest {
 
             @Test
             @DisplayName("인터뷰어와 인터뷰이, isParticipant를 true로 응답한다.")
-            void findByTeamIdAndMemberId() {
+            void success() {
                 //given
                 final Member rick = saveMember("릭");
                 final Member pepper = saveMember("페퍼");
@@ -329,7 +329,7 @@ class TeamServiceTest extends ServiceTest {
 
             @Test
             @DisplayName("참가자가 3명이고, 인터뷰어 수는 2명이면 인터뷰어와 인터뷰이가 동일하다.")
-            void findByTeamIdAndMemberId_manyInterviewerNumber() {
+            void findByTeamIdAndMemberId_manyInterviewerNumber_success() {
                 //given
                 final Member rick = saveMember("릭");
                 final Member pepper = saveMember("페퍼");
@@ -359,7 +359,7 @@ class TeamServiceTest extends ServiceTest {
 
             @Test
             @DisplayName("인터뷰어와 인터뷰이가 빈 상태이고 isParticipant를 false로 응답한다.")
-            void findByTeamIdAndMemberId() {
+            void success() {
                 //given
                 final Member rick = saveMember("릭");
                 final Member pepper = saveMember("페퍼");
@@ -417,7 +417,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("호스트가 아닌 멤버가 팀을 수정하는 경우 예외를 던진다.")
-        void hostUnauthorized_Exception() {
+        void update_hostUnauthorized_exception() {
             // given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -437,7 +437,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("없는 id에 해당하는 팀을 수정하면 예외를 던진다.")
-        void teamNotFound_Exception() {
+        void update_teamNotFound_exception() {
             //given
             final Long memberId = saveMember("릭").getId();
             final TeamWriteDto request = new TeamWriteDto("잠실 네오조", "트랙룸", 1, TEAM_START_TIME,
@@ -451,7 +451,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("인터뷰 시작 이후에 팀을 수정하려고 하면 예외를 던진다.")
-        void updateAfterStartAt_Exception() {
+        void update_afterStartAt_exception() {
             //given
             final Member member = saveMember("릭");
             final Team team = saveTeam(member);
@@ -475,7 +475,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("입력 받은 팀의 인터뷰를 종료한다.")
-        void close() {
+        void success() {
             // given
             final Member rick = saveMember("릭");
             final Team team = saveTeam(rick);
@@ -492,7 +492,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("호스트가 아닌 사용자가 인터뷰를 종료하면 예외가 발생한다.")
-        void close_notHost_exceptionThrown() {
+        void close_notHost_exception() {
             // given
             final Member rick = saveMember("릭");
             final Member alien = saveMember("알린");
@@ -531,7 +531,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("호스트가 아닌 멤버가 팀을 삭제하는 경우 예외를 던진다.")
-        void hostUnauthorized_Exception() {
+        void delete_hostUnauthorized_exception() {
             // given
             final Member rick = saveMember("릭");
             final Member pepper = saveMember("페퍼");
@@ -547,7 +547,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("없는 id에 해당하는 팀을 수정하면 예외를 던진다.")
-        void teamNotFound_Exception() {
+        void delete_teamNotFound_exception() {
             //given
             final Member member = saveMember("릭");
             final Team team = saveTeam(member);
@@ -560,7 +560,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("이미 삭제된 팀을 삭제하는 경우 팀이 존재하지 않는다는 예외를 던진다.")
-        void alreadyDeleted_Exception() {
+        void delete_alreadyDeleted_exception() {
             //given
             final Member member = saveMember("릭");
             final Team team = saveTeam(member);
@@ -602,7 +602,7 @@ class TeamServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("주어진 memberId의 멤버가 존재하지 않을 때 예외를 던진다.")
-        void memberNotFound_exception() {
+        void findAllByMemberId_memberNotFound_exception() {
             // when & then
             assertThatThrownBy(() -> teamService.findAllByMemberId(100_000L))
                     .isInstanceOf(MemberNotFoundException.class)

--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackTest.java
@@ -18,11 +18,11 @@ class FeedbackTest {
 
     @Nested
     @DisplayName("생성자는")
-    class create {
+    class Create {
 
         @Test
         @DisplayName("Study 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void feedback_studyLength_exceptionThrown() {
+        void create_feedbackStudyLength_exception() {
             // given
             final String feedback = "f".repeat(1001);
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
@@ -41,7 +41,7 @@ class FeedbackTest {
 
         @Test
         @DisplayName("Speak 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void feedback_SpeakLength_exceptionThrown() {
+        void create_feedbackSpeakLength_exception() {
             // given
             final String feedback = "f".repeat(1001);
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
@@ -60,7 +60,7 @@ class FeedbackTest {
 
         @Test
         @DisplayName("Etc 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void feedback_EtcLength_exceptionThrown() {
+        void create_feedbackEtcLength_exception() {
             // given
             final String feedback = "f".repeat(1001);
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
@@ -80,11 +80,11 @@ class FeedbackTest {
 
     @Nested
     @DisplayName("updateFeedback 메소드는")
-    class update {
+    class Update {
 
         @Test
         @DisplayName("Study 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void update_studyLength_exceptionThrown() {
+        void update_studyLength_exception() {
             // given
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Study 피드백", "Speak 피드백", "Etc 피드백");
@@ -105,7 +105,7 @@ class FeedbackTest {
 
         @Test
         @DisplayName("Speak 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void update_SpeakLength_exceptionThrown() {
+        void update_speakLength_exception() {
             // given
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Study 피드백", "Speak 피드백", "Etc 피드백");
@@ -126,7 +126,7 @@ class FeedbackTest {
 
         @Test
         @DisplayName("Etc 피드백의 길이가 1000자 초과일 경우 예외를 발생시킨다.")
-        void update_EtcLength_exceptionThrown() {
+        void update_etcLength_exception() {
             // given
             final FeedbackContentDto feedbackContentDto = new FeedbackContentDto(
                     "Study 피드백", "Speak 피드백", "Etc 피드백");

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionTest.java
@@ -20,7 +20,7 @@ class InterviewQuestionTest {
 
     @Nested
     @DisplayName("생성자는")
-    class ConstructorTest {
+    class Constructor {
 
         @Test
         @DisplayName("인터뷰 질문을 생성한다.")
@@ -38,7 +38,7 @@ class InterviewQuestionTest {
 
         @Test
         @DisplayName("인터뷰 질문의 길이가 255자 초과일 경우 예외를 던진다.")
-        void interviewQuestion_contentLength_exception() {
+        void constructor_interviewQuestionContentLength_exception() {
             // given
             final Member author = new Member("페퍼", 1111, "pepper.png");
             final Member to = new Member("이브", 123123, "image.png");
@@ -55,7 +55,7 @@ class InterviewQuestionTest {
 
     @Nested
     @DisplayName("updateContent 메서드는")
-    class UpdateContentTest {
+    class UpdateContent {
 
         @Test
         @DisplayName("인터뷰 질문 내용을 수정한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogRepositoryTest.java
@@ -61,11 +61,11 @@ class LevellogRepositoryTest extends RepositoryTest {
 
     @Nested
     @DisplayName("existsByAuthorIdAndTeamId 메서드는")
-    class ExistsByAuthorIdAndTeamIdTest {
+    class ExistsByAuthorIdAndTeamId {
 
         @Test
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하는 경우 true를 반환한다.")
-        void exists() {
+        void existsByAuthorIdAndTeamId_exists_success() {
             // given
             final Member author = saveMember("pepper");
             final Team team = saveTeam(author);
@@ -83,7 +83,7 @@ class LevellogRepositoryTest extends RepositoryTest {
 
         @Test
         @DisplayName("memberId와 teamId이 모두 일치하는 레벨로그가 존재하지 않는 경우 false를 반환한다.")
-        void notExists() {
+        void existsByAuthorIdAndTeamId_notExists_success() {
             // given
             final Member author = saveMember("pepper");
             final Team team = saveTeam(author);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/LevellogTest.java
@@ -22,7 +22,7 @@ class LevellogTest {
 
     @Nested
     @DisplayName("생성자는")
-    class ConstructorTest {
+    class Constructor {
 
         @Test
         @DisplayName("레벨로그를 생성한다.")
@@ -54,7 +54,7 @@ class LevellogTest {
 
     @Nested
     @DisplayName("updateContent 메서드는")
-    class UpdateContentTest {
+    class UpdateContent {
 
         @Test
         @DisplayName("레벨로그 내용을 업데이트한다.")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/MemberTest.java
@@ -21,7 +21,7 @@ class MemberTest {
 
         @Test
         @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
-        void nicknameInvalidLength_exception() {
+        void constructor_nicknameInvalidLength_exception() {
             // given
             final String invalidNickname = "a".repeat(51);
 
@@ -35,7 +35,7 @@ class MemberTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("닉네임이 공백이나 null일 경우 예외를 던진다.")
-        void nicknameBlank_exception(final String invalidNickname) {
+        void constructor_nicknameBlank_exception(final String invalidNickname) {
             // when & then
             assertThatThrownBy(() -> new Member(invalidNickname, 123456, "validProfileUrl"))
                     .isInstanceOf(InvalidFieldException.class)
@@ -44,7 +44,7 @@ class MemberTest {
 
         @Test
         @DisplayName("githubId가 null일 경우 예외를 던진다.")
-        void githubIdNull_exception() {
+        void constructor_githubIdNull_exception() {
             // when & then
             assertThatThrownBy(() -> new Member("test", null, "validProfileUrl"))
                     .isInstanceOf(InvalidFieldException.class)
@@ -53,7 +53,7 @@ class MemberTest {
 
         @Test
         @DisplayName("프로필 url은 2048자를 초과할 경우 예외를 던진다.")
-        void profileUrlInvalidLength_exception() {
+        void constructor_profileUrlInvalidLength_exception() {
             // given
             final String invalidProfileUrl = "a".repeat(2049);
 
@@ -67,7 +67,7 @@ class MemberTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("프로필 url이 공백이나 null일 경우 예외를 던진다.")
-        void profileUrlBlank_exception(final String invalidProfileUrl) {
+        void constructor_profileUrlBlank_exception(final String invalidProfileUrl) {
             // when & then
             assertThatThrownBy(() -> new Member("test", 123456, invalidProfileUrl))
                     .isInstanceOf(InvalidFieldException.class)
@@ -77,7 +77,7 @@ class MemberTest {
 
     @Nested
     @DisplayName("updateNickname 메서드는")
-    class UpdateNicknameMapping {
+    class UpdateNickname {
 
         @Test
         @DisplayName("닉네임을 변경한다.")
@@ -94,7 +94,7 @@ class MemberTest {
 
         @Test
         @DisplayName("닉네임이 50자를 초과할 경우 예외를 던진다.")
-        void nicknameInvalidLength_exception() {
+        void updateNickname_nicknameInvalidLength_exception() {
             // given
             final Member member = new Member("로마", 123456, "image.png");
             final String invalidNickname = "a".repeat(51);
@@ -109,7 +109,7 @@ class MemberTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("닉네임이 공백이나 null일 경우 예외를 던진다.")
-        void nicknameBlank_exception(final String invalidNickname) {
+        void updateNickname_nicknameBlank_exception(final String invalidNickname) {
             // given
             final Member member = new Member("로마", 123456, "image.png");
 

--- a/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantsTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/ParticipantsTest.java
@@ -40,7 +40,7 @@ class ParticipantsTest {
 
     @Nested
     @DisplayName("toInterviewerIds 메서드는")
-    class toInterviewerIds {
+    class ToInterviewerIds {
 
         @ParameterizedTest(name = "인터뷰어 수가 {0}명이고 참가자 아이디가 [1, 2, 3, 4, 5]인 팀에서 아이디가 {1}인 참가자의 인터뷰어 아이디는 [{2}]이다.")
         @CsvSource(value = {"2:1:2, 3", "2:4:5, 1", "4:3:4, 5, 1, 2"}, delimiter = ':')
@@ -70,7 +70,7 @@ class ParticipantsTest {
 
         @Test
         @DisplayName("타겟 멤버가 참가자가 아니면 빈 리스트를 반환한다.")
-        void emptyList() {
+        void toInterviewerIds_emptyList_success() {
             // given
             final int interviewerNumber = 1;
             final Team team = new Team("레벨로그팀", "선릉 트랙룸", TEAM_START_TIME, "레벨로그팀.com",
@@ -94,7 +94,7 @@ class ParticipantsTest {
 
     @Nested
     @DisplayName("toIntervieweeIds 메서드는")
-    class toIntervieweeIds {
+    class ToIntervieweeIds {
 
         @ParameterizedTest(name = "인터뷰어 수가 {0}명이고 참가자 아이디가 [1, 2, 3, 4, 5]인 팀에서 아이디가 {1}인 참가자의 인터뷰이 아이디는 [{2}]이다.")
         @CsvSource(value = {"2:1:4, 5", "2:4:2, 3", "4:3:4, 5, 1, 2"}, delimiter = ':')
@@ -125,7 +125,7 @@ class ParticipantsTest {
 
         @Test
         @DisplayName("타겟 멤버가 참가자가 아니면 빈 리스트를 반환한다.")
-        void emptyList() {
+        void toIntervieweeIds_emptyList_success() {
             // given
             final int interviewerNumber = 1;
             final Team team = new Team("레벨로그팀", "선릉 트랙룸", TEAM_START_TIME, "레벨로그팀.com",
@@ -149,7 +149,7 @@ class ParticipantsTest {
 
     @Nested
     @DisplayName("toInterviewRole 메서드는")
-    class toInterviewRole {
+    class ToInterviewRole {
 
         @ParameterizedTest(name = "참가자 아이디가 [1, 2, 3, 4, 5]이고 인터뷰어 수가 2명인 팀에서 아이디가 {0}인 타겟 멤버에 대해 아이디가 {1}인 참가자의 인터뷰 역할은 {2}이다.")
         @CsvSource(value = {"1,2,INTERVIEWER", "1,3,INTERVIEWER", "1,4,OBSERVER", "1,5,OBSERVER"})
@@ -177,7 +177,7 @@ class ParticipantsTest {
 
         @Test
         @DisplayName("타겟 멤버가 요청한 멤버와 같으면 ME를 반환한다.")
-        void me() {
+        void toInterviewRole_me_success() {
             // given
             final int interviewerNumber = 2;
             final Team team = MockEntityFactory.setId(1L,
@@ -199,7 +199,7 @@ class ParticipantsTest {
 
         @Test
         @DisplayName("요청한 멤버가 참가자가 아니라면 예외를 던진다.")
-        void requestMemberIdNotContains_exceptionThrown() {
+        void toInterviewRole_requestMemberIdNotContains_exception() {
             // given
             final int interviewerNumber = 2;
             final Team team = MockEntityFactory.setId(1L,
@@ -220,7 +220,7 @@ class ParticipantsTest {
 
         @Test
         @DisplayName("타겟 멤버가 참가자가 아니라면 예외를 던진다.")
-        void targetMemberIdNotContains_exceptionThrown() {
+        void toInterviewRole_targetMemberIdNotContains_exception() {
             // given
             final int interviewerNumber = 2;
             final Team team = MockEntityFactory.setId(1L,

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionRepositoryTest.java
@@ -8,7 +8,6 @@ import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.team.domain.Team;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -73,11 +72,11 @@ class PreQuestionRepositoryTest extends RepositoryTest {
 
     @Nested
     @DisplayName("existsByLevellogAndAuthor 메서드는")
-    class ExistsByLevellogAndAuthorTest {
+    class ExistsByLevellogAndAuthor {
 
         @Test
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하는 경우 true를 반환한다.")
-        void exists() {
+        void existsByLevellogAndAuthor_exists_success() {
             // given
             final Member levellogAuthor = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -95,7 +94,7 @@ class PreQuestionRepositoryTest extends RepositoryTest {
 
         @Test
         @DisplayName("levellog와 사전 질문의 author가 모두 일치하는 사전 질문이 존재하지 않는 경우 false를 반환한다.")
-        void notExists() {
+        void existsByLevellogAndAuthor_notExists_success() {
             // given
             final Member levellogAuthor = saveMember("알린");
             final Member questioner = saveMember("로마");

--- a/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/PreQuestionTest.java
@@ -28,7 +28,7 @@ public class PreQuestionTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("사전 질문이 null 또는 공백이 들어오면 예외를 던진다.")
-        void constructor_PreQuestionNullOrBlank_Exception(final String preQuestion) {
+        void constructor_preQuestionNullOrBlank_exception(final String preQuestion) {
             // given
             final Member author = new Member("알린", 12345678, "알린.img");
             final Team team = new Team("선릉 네오조", "목성방", TEAM_START_TIME, "네오조.img", 1);
@@ -44,7 +44,7 @@ public class PreQuestionTest {
 
         @Test
         @DisplayName("내가 쓴 레벨로그의 사전 질문을 작성하면 예외를 던진다.")
-        void constructor_PreQuestionMyLevellog_Exception() {
+        void constructor_preQuestionMyLevellog_exception() {
             // given
             final Member author = new Member("알린", 12345678, "알린.img");
             final Team team = new Team("선릉 네오조", "목성방", TEAM_START_TIME, "네오조.img", 1);
@@ -65,7 +65,7 @@ public class PreQuestionTest {
 
         @Test
         @DisplayName("사전 질문을 수정한다.")
-        void update() {
+        void success() {
             // given
             final Member author = new Member("알린", 12345678, "알린.img");
             final Team team = new Team("선릉 네오조", "목성방", TEAM_START_TIME, "네오조.img", 1);
@@ -86,7 +86,7 @@ public class PreQuestionTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("사전 질문이 null 또는 공백이 들어오면 예외를 던진다.")
-        void update_PreQuestionNullOrBlank_Exception(final String preQuestion) {
+        void update_preQuestionNullOrBlank_exception(final String preQuestion) {
             // given
             final Member author = new Member("알린", 12345678, "알린.img");
             final Team team = new Team("선릉 네오조", "목성방", TEAM_START_TIME, "네오조.img", 1);

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamTest.java
@@ -33,7 +33,7 @@ class TeamTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 이름이 null 또는 공백이 들어오면 예외를 던진다.")
-        void titleNullOrBlank_Exception(final String title) {
+        void constructor_titleNullOrBlank_exception(final String title) {
             // given
             final String place = "선릉 트랙룸";
             final String profileUrl = "profile.img";
@@ -46,7 +46,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 이름이 255자를 초과할 경우 예외를 던진다.")
-        void titleInvalidLength_Exception() {
+        void constructor_titleInvalidLength_exception() {
             // given
             final String title = "a".repeat(256);
             final String place = "선릉 트랙룸";
@@ -62,7 +62,7 @@ class TeamTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 장소가 null 또는 공백이 들어오면 예외를 던진다.")
-        void placeNullOrBlank_Exception(final String place) {
+        void constructor_placeNullOrBlank_exception(final String place) {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String profileUrl = "profile.img";
@@ -75,7 +75,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 장소가 255자를 초과할 경우 예외를 던진다.")
-        void placeInvalidLength_Exception() {
+        void constructor_placeInvalidLength_exception() {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "a".repeat(256);
@@ -90,7 +90,7 @@ class TeamTest {
         @ParameterizedTest
         @NullSource
         @DisplayName("인터뷰 시작 시간이 null이 들어오면 예외를 던진다.")
-        void startAtNull_Exception(final LocalDateTime startAt) {
+        void constructor_startAtNull_exception(final LocalDateTime startAt) {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "선릉 트랙룸";
@@ -104,7 +104,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간이 과거인 경우 예외를 던진다.")
-        void startAtInvalidDateTime_Exception() {
+        void constructor_startAtInvalidDateTime_exception() {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "선릉 트랙룸";
@@ -121,7 +121,7 @@ class TeamTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 프로필 사진 url이 null 또는 공백이 들어오면 예외를 던진다.")
-        void profileUrlNullOrBlank_Exception(final String profileUrl) {
+        void constructor_profileUrlNullOrBlank_exception(final String profileUrl) {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "선릉 트랙룸";
@@ -134,7 +134,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 프로필 사진 url이 2048자를 초과할 경우 예외를 던진다.")
-        void profileUrlInvalidLength_Exception() {
+        void constructor_profileUrlInvalidLength_exception() {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "선릉 트랙룸";
@@ -148,7 +148,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰어 수가 1명 미만이면 예외를 던진다.")
-        void minInterviewerNumber_exceptionThrown() {
+        void constructor_minInterviewerNumber_exception() {
             // given
             final String title = "네오와 함께하는 레벨 인터뷰";
             final String place = "선릉 트랙룸";
@@ -167,7 +167,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 이름, 장소, 시작 시간을 수정한다.")
-        void update() {
+        void success() {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
             final Team updatedTeam = new Team("브라운과 카페 투어", "잠실 어드레스룸", TEAM_START_TIME, "profile.img", 2);
@@ -188,7 +188,7 @@ class TeamTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 이름이 null 또는 공백이 들어오면 예외를 던진다.")
-        void titleNullOrBlank_Exception(final String updateTitle) {
+        void update_titleNullOrBlank_exception(final String updateTitle) {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
 
@@ -202,7 +202,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 이름이 255자를 초과할 경우 예외를 던진다.")
-        void titleInvalidLength_Exception() {
+        void update_titleInvalidLength_exception() {
             // given
             final String updateTitle = "a".repeat(256);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
@@ -219,7 +219,7 @@ class TeamTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 장소가 null 또는 공백이 들어오면 예외를 던진다.")
-        void placeNullOrBlank_Exception(final String updatePlace) {
+        void update_placeNullOrBlank_exception(final String updatePlace) {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
 
@@ -231,7 +231,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 장소가 255자를 초과할 경우 예외를 던진다.")
-        void placeInvalidLength_Exception() {
+        void update_placeInvalidLength_exception() {
             // given
             final String updatePlace = "a".repeat(256);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
@@ -247,7 +247,7 @@ class TeamTest {
         @ParameterizedTest
         @NullSource
         @DisplayName("인터뷰 시작 시간이 null이 들어오면 예외를 던진다.")
-        void startAtNull_Exception(final LocalDateTime updateStartAt) {
+        void update_startAtNull_exception(final LocalDateTime updateStartAt) {
             // given
             final LocalDateTime presentTime = LocalDateTime.now();
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
@@ -261,7 +261,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간이 과거인 경우 예외를 던진다.")
-        void startAtInvalidDateTime_Exception() {
+        void update_startAtInvalidDateTime_exception() {
             // given
             final LocalDateTime presentTime = LocalDateTime.now();
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profile.img", 1);
@@ -276,7 +276,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰 시작 이후인 경우 예외를 던진다.")
-        void updateAfterStartAt_Exception() {
+        void update_updateAfterStartAt_exception() {
             // given
             final LocalDateTime now = LocalDateTime.now();
             final LocalDateTime presentTime = now.plusDays(2);
@@ -292,12 +292,12 @@ class TeamTest {
 
     @Nested
     @DisplayName("validParticipantNumber 메서드는")
-    class validParticipantNumber {
+    class ValidParticipantNumber {
 
         @ParameterizedTest
         @CsvSource(value = {"1,1", "2,1", "2,2"})
         @DisplayName("isValidParticipantNumber 메서드는 인터뷰어 수를 참고해서 참가자 수가 유효한지 계산한다.")
-        void throwException(final int interviewerNumber, final int participantNumber) {
+        void validParticipantNumber_ifNotValid_exception(final int interviewerNumber, final int participantNumber) {
             // given
             final Team team = new Team("레벨로그팀", "우리집", TEAM_START_TIME, "profile.url",
                     interviewerNumber);
@@ -310,7 +310,7 @@ class TeamTest {
         @ParameterizedTest
         @CsvSource(value = {"1,2", "2,3"})
         @DisplayName("isValidParticipantNumber 메서드는 인터뷰어 수를 참고해서 참가자 수가 유효한지 계산한다.")
-        void notThrownException(final int interviewerNumber, final int participantNumber) {
+        void validParticipantNumber_ifValid_success(final int interviewerNumber, final int participantNumber) {
             // given
             final Team team = new Team("레벨로그팀", "우리집", TEAM_START_TIME, "profile.url",
                     interviewerNumber);
@@ -327,7 +327,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀 인터뷰를 종료 상태로 바꾼다.")
-        void close_success() {
+        void success() {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 
@@ -340,7 +340,7 @@ class TeamTest {
 
         @Test
         @DisplayName("이미 종료된 인터뷰를 종료하려는 경우 예외가 발생한다.")
-        void close_alreadyClosed_exceptionThrown() {
+        void close_alreadyClosed_exception() {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 
@@ -354,7 +354,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간 전 종료를 요청할 경우 예외가 발생한다.")
-        void close_beforeStart_exceptionThrown() {
+        void close_beforeStart_exception() {
             // given
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 
@@ -371,7 +371,7 @@ class TeamTest {
 
         @Test
         @DisplayName("팀을 deleted 상태로 만든다.")
-        void delete_success() {
+        void success() {
             // given
             final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
@@ -385,7 +385,7 @@ class TeamTest {
 
         @Test
         @DisplayName("인터뷰 시작 이후 삭제를 요청할 경우 예외가 발생한다.")
-        void delete_afterStart_exceptionThrown() {
+        void delete_afterStart_exception() {
             // given
             final LocalDateTime startAt = LocalDateTime.now().plusDays(3);
             final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", startAt, "profileUrl", 2);
@@ -405,7 +405,7 @@ class TeamTest {
 
             @Test
             @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이전이면 예외가 발생한다.")
-            void validate_afterStartAt_thrownException() {
+            void validate_afterStartAt_exception() {
                 // given
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 
@@ -417,7 +417,7 @@ class TeamTest {
 
             @Test
             @DisplayName("팀 인터뷰가 이미 종료된 상태면 예외를 발생시킨다.")
-            void validate_BeforeClose_thrownException() {
+            void validate_beforeClose_exception() {
                 // given
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 
@@ -436,7 +436,7 @@ class TeamTest {
 
             @Test
             @DisplayName("현재 시간이 인터뷰 시작 시간보다 이전인 경우 READY를 반환한다.")
-            void readyStatus_success() {
+            void status_ready_success() {
                 // given
                 final LocalDateTime presentTime = LocalDateTime.now();
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(3), "profileUrl", 2);
@@ -450,7 +450,7 @@ class TeamTest {
 
             @Test
             @DisplayName("인터뷰 시작시간이 현재 시간보다 이후이면서 종료되지 않은 경우 IN_PROGRESS를 반환한다.")
-            void inProgressStatus_success() {
+            void status_inProgress_success() {
                 // given
                 final LocalDateTime presentTime = LocalDateTime.now();
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(1), "profileUrl", 2);
@@ -464,7 +464,7 @@ class TeamTest {
 
             @Test
             @DisplayName("인터뷰가 종료된 경우 CLOSED를 반환한다.")
-            void closedStatus_success() {
+            void status_closed_success() {
                 // given
                 final LocalDateTime presentTime = LocalDateTime.now();
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", presentTime.plusDays(1), "profileUrl", 2);
@@ -484,7 +484,7 @@ class TeamTest {
 
             @Test
             @DisplayName("입력 받은 시간이 인터뷰 시작 시간보다 이후면 예외가 발생한다.")
-            void validate_beforeStartAt_thrownException() {
+            void validateBeforeStartAt_beforeStartAt_exception() {
                 // given
                 final Team team = new Team("네오와 함께하는 레벨 인터뷰", "선릉 트랙룸", TEAM_START_TIME, "profileUrl", 2);
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -25,6 +25,8 @@ class FeedbackControllerTest extends ControllerTest {
     @DisplayName("save 메서드는")
     class Save {
 
+        private static final String BASE_SNIPPET_PATH = "feedback/save/exception/";
+
         @Test
         @DisplayName("레벨로그에 내가 작성한 피드백이 이미 존재하는 경우 새로운 피드백을 작성하면 예외를 던진다.")
         void save_alreadyExist_exception() throws Exception {
@@ -48,7 +50,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/exist"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "exist"));
         }
 
         @Test
@@ -74,7 +76,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/self"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "self"));
         }
 
         @Test
@@ -100,7 +102,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/team"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "team"));
         }
 
         @Test
@@ -126,7 +128,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/levellog"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog"));
         }
 
         @Test
@@ -152,7 +154,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/before-interview"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "before-interview"));
         }
 
         @Test
@@ -178,7 +180,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/save/exception/after-interview"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-interview"));
         }
 
         private ResultActions requestCreateFeedback(final Long levellogId, final FeedbackWriteDto request)
@@ -190,6 +192,8 @@ class FeedbackControllerTest extends ControllerTest {
     @Nested
     @DisplayName("update 메서드는")
     class Update {
+
+        private static final String BASE_SNIPPET_PATH = "feedback/update/exception/";
 
         @Test
         @DisplayName("피드백에 관련이 없는 멤버가 피드백을 수정하면 예외가 발생한다.")
@@ -217,7 +221,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/update/exception/not-author"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-author"));
         }
 
         @Test
@@ -245,7 +249,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/update/exception/feedback"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "feedback"));
         }
 
         @Test
@@ -273,7 +277,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/update/exception/before-interview"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "before-interview"));
         }
 
         @Test
@@ -301,7 +305,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/update/exception/after-interview"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-interview"));
         }
 
         private ResultActions requestUpdateFeedback(final Long levellogId, final Long feedbackId,
@@ -313,6 +317,8 @@ class FeedbackControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findAll 메서드는")
     class FindAll {
+
+        private static final String BASE_SNIPPET_PATH = "feedback/find-all/exception/";
 
         @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하면 예외가 발생한다.")
@@ -335,7 +341,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/find-all/exception/levellog"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog"));
         }
 
         @Test
@@ -359,7 +365,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/find-all/exception/not-my-team"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-my-team"));
         }
 
         private ResultActions requestFindAllFeedback(final Long levellogId) throws Exception {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -235,7 +235,7 @@ class FeedbackControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("feedback/update/exception/author"));
+            perform.andDo(document("feedback/update/exception/not-author"));
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/FeedbackControllerTest.java
@@ -13,7 +13,6 @@ import com.woowacourse.levellog.feedback.exception.FeedbackAlreadyExistException
 import com.woowacourse.levellog.feedback.exception.FeedbackNotFoundException;
 import com.woowacourse.levellog.feedback.exception.InvalidFeedbackException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
-import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,7 +31,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("레벨로그에 내가 작성한 피드백이 이미 존재하는 경우 새로운 피드백을 작성하면 예외를 던진다.")
-        void save_alreadyExist_exceptionThrown() throws Exception {
+        void save_alreadyExist_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -60,7 +59,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("작성자가 직접 피드백을 작성하면 예외를 던진다.")
-        void save_selfFeedback_exceptionThrown() throws Exception {
+        void save_selfFeedback_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -89,7 +88,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀에 속하지 않은 멤버가 피드백을 작성할 경우 예외를 발생시킨다.")
-        void save_otherMember_exceptionThrown() throws Exception {
+        void save_otherMember_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -118,7 +117,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 피드백 작성을 요청하면 예외가 발생한다.")
-        void save_notFoundLevellog_exceptionThrown() throws Exception {
+        void save_notFoundLevellog_exception() throws Exception {
             // given
             final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaWF0IjoxNjU4ODkyNDI4LCJleHAiOjE2NTg5Mjg0Mjh9.G3l0GRTBXZjqYSBRggI4h56DLrBhO1cgsI0idgmeyMQ";
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
@@ -146,7 +145,7 @@ class FeedbackControllerTest extends ControllerTest {
         }
         @Test
         @DisplayName("팀 인터뷰 시작 전에 피드백을 작성할 경우 예외를 발생시킨다.")
-        void save_beforeStartAt_exceptionThrown() throws Exception {
+        void save_beforeStartAt_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -174,7 +173,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 인터뷰 종료 후에 피드백을 작성할 경우 예외를 발생시킨다.")
-        void save_alreadyClosed_exceptionThrown() throws Exception {
+        void save_alreadyClosed_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -207,7 +206,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("피드백에 관련이 없는 멤버가 피드백을 수정하면 예외가 발생한다.")
-        void update_otherMember_exceptionThrown() throws Exception {
+        void update_otherMember_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -240,7 +239,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("존재하지 않는 피드백 정보로 피드백 수정을 요청하면 예외가 발생한다.")
-        void update_notFoundFeedback_exceptionThrown() throws Exception {
+        void update_notFoundFeedback_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -272,7 +271,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 전에 피드백을 수정하면 예외가 발생한다.")
-        void update_beforeStartAt_exceptionThrown() throws Exception {
+        void update_beforeStartAt_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -303,7 +302,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 종료 후에 피드백을 수정하면 예외가 발생한다.")
-        void update_alreadyClosed_exceptionThrown() throws Exception {
+        void update_alreadyClosed_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
@@ -340,7 +339,7 @@ class FeedbackControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 피드백 목록 조회를 요청하면 예외가 발생한다.")
-        void findAll_notFoundLevellog_exceptionThrown() throws Exception {
+        void findAll_notFoundLevellog_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(token)).willReturn("1");
             given(jwtTokenProvider.validateToken(token)).willReturn(true);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
@@ -183,7 +183,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("레벨로그가 존재하지 않습니다."));
 
             // docs
-            perform.andDo(document("interview-question/findAll/exception/levellog-not-found"));
+            perform.andDo(document("interview-question/find-all/exception/levellog-not-found"));
         }
 
         @Test
@@ -205,7 +205,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("멤버가 존재하지 않습니다."));
 
             // docs
-            perform.andDo(document("interview-question/findAll/exception/member-not-found"));
+            perform.andDo(document("interview-question/find-all/exception/member-not-found"));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
@@ -67,7 +67,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 질문으로 255자를 초과하는 경우 예외를 던진다.")
-        void save_interviewQuestionInvalidLength_Exception() throws Exception {
+        void save_interviewQuestionInvalidLength_exception() throws Exception {
             // given
             mockLogin();
 
@@ -233,7 +233,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 질문으로 255자를 초과하는 경우 예외를 던진다.")
-        void update_interviewQuestionInvalidLength_Exception() throws Exception {
+        void update_interviewQuestionInvalidLength_exception() throws Exception {
             // given
             final InterviewQuestionDto request = InterviewQuestionDto.from("a".repeat(256));
 

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
@@ -7,11 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.levellog.common.exception.InvalidFieldException;
 import com.woowacourse.levellog.common.exception.UnauthorizedException;
-import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionDto;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionWriteDto;
 import com.woowacourse.levellog.interviewquestion.exception.InterviewQuestionNotFoundException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
-import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.exception.InterviewTimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +25,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("save 메서드는")
     class Save {
+
+        private static final String BASE_SNIPPET_PATH = "interview-question/save/exception/";
 
         @Test
         @DisplayName("인터뷰 질문이 공백인 경우 예외를 던진다.")
@@ -44,7 +44,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/save/exception/contents/blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "contents-blank"));
         }
 
         @Test
@@ -67,7 +67,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/save/exception/contents/length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "contents-length"));
         }
 
         @Test
@@ -92,7 +92,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/save/exception/levellog-not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog-not-found"));
         }
 
         @ParameterizedTest
@@ -117,10 +117,11 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/save/exception/" + snippet));
+            perform.andDo(document(BASE_SNIPPET_PATH + snippet));
         }
 
-        private ResultActions requestCreateInterviewQuestion(final Long levellogId, final InterviewQuestionWriteDto request)
+        private ResultActions requestCreateInterviewQuestion(final Long levellogId,
+                                                             final InterviewQuestionWriteDto request)
                 throws Exception {
             return requestPost("/api/levellogs/" + levellogId + "/interview-questions", request);
         }
@@ -129,6 +130,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findAllByLevellog 메서드는")
     class FindAllByLevellog {
+
+        private static final String BASE_SNIPPET_PATH = "interview-question/find-all-by-levellog/exception/";
 
         @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 인터뷰 질문 목록 조회를 요청하면 예외를 던진다.")
@@ -150,7 +153,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/find-all-by-levellog/exception/levellog-not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog-not-found"));
         }
 
         private ResultActions requestFindAllByLevellog(final Long levellogId) throws Exception {
@@ -161,6 +164,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findAllMyInterviewQuestion 메서드는")
     class FindAllMyInterviewQuestion {
+
+        private static final String BASE_SNIPPET_PATH = "interview-question/find-all-my-interview-question/exception/";
 
         @Test
         @DisplayName("존재하지 않는 레벨로그 정보로 인터뷰 질문 목록 조회를 요청하면 예외를 던진다.")
@@ -182,7 +187,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/find-all-my-interview-question/exception/levellog-not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog-not-found"));
         }
 
         private ResultActions requestFindAllMyInterviewQuestion(final Long levellogId) throws Exception {
@@ -193,6 +198,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("update 메서드는")
     class Update {
+
+        private static final String BASE_SNIPPET_PATH = "interview-question/update/exception/";
 
         @Test
         @DisplayName("인터뷰 질문이 공백인 경우 예외를 던진다.")
@@ -210,7 +217,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/update/exception/contents/blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "contents-blank"));
         }
 
         @Test
@@ -233,7 +240,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/update/exception/contents/length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "contents-length"));
         }
 
         @Test
@@ -258,7 +265,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/update/exception/not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -281,7 +288,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/update/exception/unauthorized"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "unauthorized"));
         }
 
         @ParameterizedTest
@@ -304,7 +311,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/update/exception/" + snippet));
+            perform.andDo(document(BASE_SNIPPET_PATH + snippet));
         }
 
         private ResultActions requestUpdateInterviewQuestion(final Long levellogId, final Long interviewQuestionId,
@@ -316,6 +323,8 @@ class InterviewQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("deleteById 메서드는")
     class DeleteById {
+
+        private static final String BASE_SNIPPET_PATH = "interview-question/delete/exception/";
 
         @Test
         @DisplayName("존재하지 않는 인터뷰 질문을 삭제하면 예외를 던진다.")
@@ -337,7 +346,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/delete/exception/not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -359,7 +368,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/delete/exception/unauthorized"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "unauthorized"));
         }
 
         @ParameterizedTest
@@ -381,7 +390,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("interview-question/delete/exception/" + snippet));
+            perform.andDo(document(BASE_SNIPPET_PATH + "" + snippet));
         }
 
         private ResultActions requestDeleteInterviewQuestion(final Long levellogId,

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -22,6 +22,8 @@ class LevellogControllerTest extends ControllerTest {
     @DisplayName("save 메서드는")
     class Save {
 
+        private static final String BASE_SNIPPET_PATH = "levellog/save/exception/";
+
         @Test
         @DisplayName("팀에서 이미 레벨로그를 작성한 경우 새로운 레벨로그를 작성하면 예외를 던진다.")
         void save_alreadyExists_exception() throws Exception {
@@ -44,7 +46,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/save/exception/already-exists"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "already-exists"));
         }
 
         @Test
@@ -64,7 +66,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/save/exception/contents"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "contents"));
         }
 
         @Test
@@ -90,7 +92,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/save/exception/after-start"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-start"));
         }
 
         private ResultActions requestCreateLevellog(final Long teamId, final LevellogWriteDto request)
@@ -102,6 +104,8 @@ class LevellogControllerTest extends ControllerTest {
     @Nested
     @DisplayName("find 메서드는")
     class Find {
+
+        private static final String BASE_SNIPPET_PATH = "levellog/find/exception/";
 
         @Test
         @DisplayName("존재하지 않는 레벨로그를 조회하면 예외를 던진다.")
@@ -125,7 +129,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/find/exception/exist"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "exist"));
         }
 
         private ResultActions requestFindLevellog(final Long teamId, final Long levellogId) throws Exception {
@@ -137,6 +141,8 @@ class LevellogControllerTest extends ControllerTest {
     @Nested
     @DisplayName("update 메서드는")
     class Update {
+
+        private static final String BASE_SNIPPET_PATH = "levellog/update/exception/";
 
         @Test
         @DisplayName("내용으로 공백이 들어오면 예외를 던진다.")
@@ -156,7 +162,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/update/exception/blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "blank"));
         }
 
         @Test
@@ -183,7 +189,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/update/exception/not-author"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-author"));
         }
 
         @Test
@@ -210,7 +216,7 @@ class LevellogControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("levellog/update/exception/after-start"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-start"));
         }
 
         private ResultActions requestUpdateLevellog(final Long teamId, final Long levellogId,

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -46,7 +46,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("팀에 레벨로그를 이미 작성했습니다."));
 
             // docs
-            perform.andDo(document("levellog/save/exception-already-exists"));
+            perform.andDo(document("levellog/save/exception/already-exists"));
         }
 
         @Test
@@ -67,7 +67,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("content must not be blank"));
 
             // docs
-            perform.andDo(document("levellog/save/exception-contents"));
+            perform.andDo(document("levellog/save/exception/contents"));
         }
 
         @Test
@@ -92,7 +92,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("인터뷰 시작 전에만 레벨로그 작성이 가능합니다."));
 
             // docs
-            perform.andDo(document("levellog/save/exception-after-start"));
+            perform.andDo(document("levellog/save/exception/after-start"));
         }
 
         private ResultActions requestSaveLevellog(final Long teamId, final Object request) throws Exception {
@@ -123,7 +123,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("레벨로그가 존재하지 않습니다."));
 
             // docs
-            perform.andDo(document("levellog/find/exception-exist"));
+            perform.andDo(document("levellog/find/exception/exist"));
         }
     }
 
@@ -150,7 +150,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("content must not be blank"));
 
             // docs
-            perform.andDo(document("levellog/update/exception-contents"));
+            perform.andDo(document("levellog/update/exception/blank"));
         }
 
         @Test
@@ -176,7 +176,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("권한이 없습니다."));
 
             // docs
-            perform.andDo(document("levellog/update/exception-author"));
+            perform.andDo(document("levellog/update/exception/not-author"));
         }
 
         @Test
@@ -203,7 +203,7 @@ class LevellogControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("인터뷰 시작 전에만 레벨로그 수정이 가능합니다."));
 
             // docs
-            perform.andDo(document("levellog/update/exception-after-start"));
+            perform.andDo(document("levellog/update/exception/after-start"));
         }
 
         private ResultActions requestUpdateLevellog(final Long teamId, final Long levellogId, final Object request)

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/LevellogControllerTest.java
@@ -51,7 +51,7 @@ class LevellogControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("내용으로 공백이 들어오면 예외를 던진다.")
-        void save_nameNullOrEmpty_Exception() throws Exception {
+        void save_nameNullOrEmpty_exception() throws Exception {
             // given
             final Long teamId = 1L;
             final LevellogWriteDto request = LevellogWriteDto.from(" ");
@@ -106,7 +106,7 @@ class LevellogControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("존재하지 않는 레벨로그를 조회하면 예외를 던진다.")
-        void find_levellogNoExist_Exception() throws Exception {
+        void find_levellogNoExist_exception() throws Exception {
             // given
             final Long teamId = 1L;
             final Long levellogId = 1000L;
@@ -133,7 +133,7 @@ class LevellogControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("내용으로 공백이 들어오면 예외를 던진다.")
-        void update_nameNullOrEmpty_Exception() throws Exception {
+        void update_nameNullOrEmpty_exception() throws Exception {
             // given
             final Long teamId = 1L;
             final Long levellogId = 2L;
@@ -155,7 +155,7 @@ class LevellogControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("본인이 작성하지 않은 레벨로그를 수정하려는 경우 예외를 던진다.")
-        void update_unauthorized_Exception() throws Exception {
+        void update_unauthorized_exception() throws Exception {
             // given
             final Long teamId = 1L;
             final Long levellogId = 2L;

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -23,6 +23,8 @@ class MyInfoControllerTest extends ControllerTest {
     @DisplayName("updateNickname 메서드는 ")
     class UpdateNickname {
 
+        private static final String BASE_SNIPPET_PATH = "my-info/update/";
+
         @Test
         @DisplayName("닉네임에 50자를 초과한 문자열이 들어올 경우 예외를 던진다.")
         void updateNickname_nicknameInvalidLength_exception() throws Exception {
@@ -45,7 +47,7 @@ class MyInfoControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("my-info/update/nickname-invalid-length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "nickname-invalid-length"));
         }
 
         @ParameterizedTest
@@ -65,7 +67,7 @@ class MyInfoControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("my-info/update/nickname-blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "nickname-blank"));
         }
 
         private ResultActions requestUpdateNickname(final NicknameUpdateDto request) throws Exception {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -27,11 +27,11 @@ class MyInfoControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("updateNickname 메서드는 ")
-    class UpdateNicknameMapping {
+    class UpdateNickname {
 
         @Test
         @DisplayName("닉네임에 50자를 초과한 문자열이 들어올 경우 예외를 던진다.")
-        void nicknameInvalidLength_Exception() throws Exception {
+        void updateNickname_nicknameInvalidLength_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
             given(jwtTokenProvider.validateToken(any())).willReturn(true);
@@ -63,7 +63,7 @@ class MyInfoControllerTest extends ControllerTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("닉네임에 null 또는 빈 값이 들어온 경우 예외를 던진다.")
-        void nicknameNullAndEmpty_Exception(final String invalidNickname) throws Exception {
+        void updateNickname_nicknameNullAndEmpty_exception(final String invalidNickname) throws Exception {
             // given
             given(jwtTokenProvider.getPayload(anyString())).willReturn("123");
             given(jwtTokenProvider.validateToken(any())).willReturn(true);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/MyInfoControllerTest.java
@@ -56,7 +56,7 @@ class MyInfoControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("닉네임은 50자 이하여야합니다."));
 
             // docs
-            perform.andDo(document("myinfo/update/nickname-invalid-length"));
+            perform.andDo(document("my-info/update/nickname-invalid-length"));
         }
 
         @ParameterizedTest
@@ -84,7 +84,7 @@ class MyInfoControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("myinfo/update/nickname-blank"));
+            perform.andDo(document("my-info/update/nickname-blank"));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -29,7 +29,7 @@ class OAuthControllerTest extends ControllerTest {
         @ValueSource(strings = {" "})
         @NullAndEmptySource
         @DisplayName("코드에 공백이나 null이 들어오면 예외를 던진다.")
-        void login_nullAndEmptyCode_exceptionThrown(final String code) throws Exception {
+        void login_nullAndEmptyCode_exception(final String code) throws Exception {
             // given
             final GithubCodeDto request = new GithubCodeDto(code);
             final String requestContent = objectMapper.writeValueAsString(request);
@@ -47,7 +47,7 @@ class OAuthControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("깃허브에 accessToken 요청에 실패하면 예외를 던진다.")
-        void login_failToGetAccessToken_exceptionThrown() throws Exception {
+        void login_failToGetAccessToken_exception() throws Exception {
             // given
             final GithubCodeDto request = new GithubCodeDto(AUTHORIZATION_CODE);
             final String requestContent = objectMapper.writeValueAsString(request);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -42,7 +42,7 @@ class OAuthControllerTest extends ControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andDo(document("auth/login/null"));
+                    .andDo(document("auth/login/exception/blank"));
         }
 
         @Test
@@ -63,7 +63,7 @@ class OAuthControllerTest extends ControllerTest {
 
             // then
             perform.andExpect(status().isInternalServerError())
-                    .andDo(document("auth/login/github-fail"));
+                    .andDo(document("auth/login/exception/github-fail"));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/OAuthControllerTest.java
@@ -23,6 +23,8 @@ class OAuthControllerTest extends ControllerTest {
     @DisplayName("login 메서드는")
     class Login {
 
+        private static final String BASE_SNIPPET_PATH = "auth/login/exception/";
+
         @ParameterizedTest
         @ValueSource(strings = {" "})
         @NullAndEmptySource
@@ -41,7 +43,7 @@ class OAuthControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("auth/login/null"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "null"));
         }
 
         @Test
@@ -66,7 +68,7 @@ class OAuthControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("auth/login/github-fail"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "github-fail"));
         }
 
         private ResultActions requestLoginWithoutToken(final String requestContent) throws Exception {

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -284,8 +284,8 @@ class PreQuestionControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("delete 메서드는")
-    class Delete {
+    @DisplayName("deleteById 메서드는")
+    class DeleteById {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 삭제하면 예외를 던진다.")

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -27,6 +27,8 @@ class PreQuestionControllerTest extends ControllerTest {
     @DisplayName("save 메서드는")
     class Save {
 
+        private static final String BASE_SNIPPET_PATH = "pre-question/create/exception/";
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {" "})
@@ -44,7 +46,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("preQuestion must not be blank"));
 
             // docs
-            perform.andDo(document("pre-question/create/exception/blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "blank"));
         }
 
         @Test
@@ -66,7 +68,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/create/exception/not-participant"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-participant"));
         }
 
         @Test
@@ -89,7 +91,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/create/exception/levellog-is-mine"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "levellog-is-mine"));
         }
 
         @Test
@@ -112,7 +114,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/create/exception/already-exist"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "already-exist"));
         }
 
         private ResultActions requestCreatePreQuestion(final Long levellogId,
@@ -124,6 +126,8 @@ class PreQuestionControllerTest extends ControllerTest {
     @Nested
     @DisplayName("update 메서드는")
     class Update {
+
+        private static final String BASE_SNIPPET_PATH = "pre-question/update/exception/";
 
         @ParameterizedTest
         @NullAndEmptySource
@@ -142,7 +146,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("preQuestion must not be blank"));
 
             // docs
-            perform.andDo(document("pre-question/update/exception/blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "blank"));
         }
 
         @Test
@@ -165,7 +169,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/update/exception/wrong-levellog"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "wrong-levellog"));
         }
 
         @Test
@@ -188,7 +192,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/update/exception/notfound"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -211,7 +215,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value(message));
 
             // docs
-            perform.andDo(document("pre-question/update/exception/not-my-pre-question"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-my-pre-question"));
         }
 
         private ResultActions requestUpdatePreQuestion(final Long levellogId,
@@ -278,6 +282,8 @@ class PreQuestionControllerTest extends ControllerTest {
     @DisplayName("deleteById 메서드는")
     class DeleteById {
 
+        private final String BASE_SNIPPET_PATH = "pre-question/delete/exception/";
+
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 삭제하면 예외를 던진다.")
         void deleteById_levellogWrongId_exception() throws Exception {
@@ -297,7 +303,7 @@ class PreQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("pre-question/delete/exception/wrong-levellog"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "wrong-levellog"));
         }
 
         @Test
@@ -319,7 +325,7 @@ class PreQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("pre-question/delete/exception/notfound"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -341,7 +347,7 @@ class PreQuestionControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("pre-question/delete/exception/not-my-pre-question"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-my-pre-question"));
         }
 
         private ResultActions requestDeletePreQuestion(final Long levellogId, final Long preQuestionId)

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -34,7 +34,7 @@ class PreQuestionControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("사전 질문으로 공백이나 null이 들어오면 예외를 던진다.")
-        void save_PreQuestionNullAndBlank_Exception(final String preQuestion) throws Exception {
+        void save_preQuestionNullAndBlank_exception(final String preQuestion) throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -55,7 +55,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("참가자가 아닌 멤버가 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_FromNotParticipant_Exception() throws Exception {
+        void save_fromNotParticipant_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -80,7 +80,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("내 레벨로그에 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_LevellogIsMine_Exception() throws Exception {
+        void save_levellogIsMine_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -105,7 +105,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("사전 질문이 이미 등록되었을 때 사전 질문을 등록하는 경우 예외를 던진다.")
-        void save_PreQuestionAlreadyExist_Exception() throws Exception {
+        void save_preQuestionAlreadyExist_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -137,7 +137,7 @@ class PreQuestionControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("사전 질문으로 공백이나 null이 들어오면 예외를 던진다.")
-        void update_PreQuestionNullAndBlank_Exception(final String preQuestion) throws Exception {
+        void update_preQuestionNullAndBlank_exception(final String preQuestion) throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -158,7 +158,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 수정하면 예외를 던진다.")
-        void update_LevellogWrongId_Exception() throws Exception {
+        void update_levellogWrongId_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -183,7 +183,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("저장되어있지 않은 사전 질문을 수정하는 경우 예외를 던진다.")
-        void update_PreQuestionNotFound_Exception() throws Exception {
+        void update_preQuestionNotFound_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -208,7 +208,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("타인의 사전 질문을 수정하는 경우 예외를 던진다.")
-        void update_FromNotMyPreQuestion_Exception() throws Exception {
+        void update_fromNotMyPreQuestion_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -238,7 +238,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("레벨로그가 존재하지 않으면 예외를 던진다.")
-        void findMy_LevellogWrongId_Exception() throws Exception {
+        void findMy_levellogWrongId_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -261,7 +261,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("사전 질문이 존재하지 않으면 예외를 던진다.")
-        void findMy_PreQuestionNotFound_Exception() throws Exception {
+        void findMy_preQuestionNotFound_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -289,7 +289,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("잘못된 레벨로그의 사전 질문을 삭제하면 예외를 던진다.")
-        void deleteById_LevellogWrongId_Exception() throws Exception {
+        void deleteById_levellogWrongId_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -312,7 +312,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("저장되어있지 않은 사전 질문을 삭제하는 경우 예외를 던진다.")
-        void deleteById_PreQuestionNotFound_Exception() throws Exception {
+        void deleteById_preQuestionNotFound_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -335,7 +335,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("타인의 사전 질문을 삭제하는 경우 예외를 던진다.")
-        void deleteById_FromNotMyPreQuestion_Exception() throws Exception {
+        void deleteById_fromNotMyPreQuestion_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -50,7 +50,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("preQuestion must not be blank"));
 
             // docs
-            perform.andDo(document("pre-question/create/exception/null-and-blank"));
+            perform.andDo(document("pre-question/create/exception/blank"));
         }
 
         @Test
@@ -153,7 +153,7 @@ class PreQuestionControllerTest extends ControllerTest {
                     jsonPath("message").value("preQuestion must not be blank"));
 
             // docs
-            perform.andDo(document("pre-question/update/exception/null-and-blank"));
+            perform.andDo(document("pre-question/update/exception/blank"));
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -74,7 +74,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("title must not be blank");
 
             // docs
-            perform.andDo(document("team/create/exception/title/null-and-blank"));
+            perform.andDo(document("team/create/exception/title-blank"));
         }
 
         @Test
@@ -100,7 +100,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 팀 이름을 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/create/exception/title/length"));
+            perform.andDo(document("team/create/exception/title-length"));
         }
 
         @ParameterizedTest
@@ -123,7 +123,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("place must not be blank");
 
             // docs
-            perform.andDo(document("team/create/exception/place/null-and-blank"));
+            perform.andDo(document("team/create/exception/place-blank"));
         }
 
         @Test
@@ -149,7 +149,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 장소를 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/create/exception/place/length"));
+            perform.andDo(document("team/create/exception/place-length"));
         }
 
         @Test
@@ -169,7 +169,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("startAt must not be null");
 
             // docs
-            perform.andDo(document("team/create/exception/startat/null"));
+            perform.andDo(document("team/create/exception/start-at-null"));
         }
 
         @Test
@@ -194,7 +194,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 시작 시간을 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/create/exception/startat/past"));
+            perform.andDo(document("team/create/exception/start-at-past"));
         }
 
         @Test
@@ -219,7 +219,7 @@ class TeamControllerTest extends ControllerTest {
             perform.andExpect(status().isBadRequest());
 
             // docs
-            perform.andDo(document("team/create/exception/participants/empty"));
+            perform.andDo(document("team/create/exception/participants-empty"));
         }
 
         @Test
@@ -237,7 +237,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("participants must not be null");
 
             // docs
-            perform.andDo(document("team/create/exception/participants/null"));
+            perform.andDo(document("team/create/exception/participants-null"));
         }
 
         @Test
@@ -258,7 +258,7 @@ class TeamControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value(startsWith("interviewerNumber")));
 
             // docs
-            perform.andDo(document("team/create/exception/interviewer-number/not-positive"));
+            perform.andDo(document("team/create/exception/interviewer-number-not-positive"));
         }
 
         @Test
@@ -283,7 +283,7 @@ class TeamControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("참가자 수는 인터뷰어 수 보다 많아야 합니다."));
 
             // docs
-            perform.andDo(document("team/create/exception/interviewer-number/more-than-participant"));
+            perform.andDo(document("team/create/exception/interviewer-number-more-than-participant"));
         }
 
         @Test
@@ -313,7 +313,7 @@ class TeamControllerTest extends ControllerTest {
                     jsonPath("message").value("중복되는 참가자가 존재합니다."));
 
             // docs
-            perform.andDo(document("team/create/exception/participants/duplicate"));
+            perform.andDo(document("team/create/exception/participants-duplicate"));
         }
 
         @Test
@@ -343,7 +343,7 @@ class TeamControllerTest extends ControllerTest {
                     jsonPath("message").value("중복되는 참가자가 존재합니다."));
 
             // docs
-            perform.andDo(document("team/create/exception/participants/host"));
+            perform.andDo(document("team/create/exception/participants-have-host"));
         }
     }
 
@@ -372,7 +372,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("팀 이름이 null 또는 공백입니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/title/null-and-blank"));
+            perform.andDo(document("team/update/exception/title-blank"));
         }
 
         @Test
@@ -399,7 +399,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 팀 이름을 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/title/length"));
+            perform.andDo(document("team/update/exception/title-length"));
         }
 
         @ParameterizedTest
@@ -423,7 +423,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("장소가 null 또는 공백입니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/place/null-and-blank"));
+            perform.andDo(document("team/update/exception/place-blank"));
         }
 
         @Test
@@ -450,7 +450,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 장소를 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/place/length"));
+            perform.andDo(document("team/update/exception/place-length"));
         }
 
         @Test
@@ -471,7 +471,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("시작 시간이 없습니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/startat/null"));
+            perform.andDo(document("team/update/exception/start-at-null"));
         }
 
         @Test
@@ -497,7 +497,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("잘못된 시작 시간을 입력했습니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/startat/past"));
+            perform.andDo(document("team/update/exception/start-at-past"));
         }
 
         @Test
@@ -522,7 +522,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("팀이 존재하지 않습니다.");
 
             // docs
-            perform.andDo(document("team/update/exception/notfound"));
+            perform.andDo(document("team/update/exception/not-found"));
         }
 
         @Test
@@ -541,7 +541,7 @@ class TeamControllerTest extends ControllerTest {
             perform.andExpect(status().isBadRequest());
 
             // docs
-            perform.andDo(document("team/update/exception/participants/empty"));
+            perform.andDo(document("team/update/exception/participants-empty"));
         }
 
         @Test
@@ -560,7 +560,7 @@ class TeamControllerTest extends ControllerTest {
                     .andReturn().getResponse().getContentAsString().contains("participants must not be null");
 
             // docs
-            perform.andDo(document("team/update/exception/participants/null"));
+            perform.andDo(document("team/update/exception/participants-null"));
         }
 
         @Test
@@ -581,7 +581,7 @@ class TeamControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value(startsWith("interviewerNumber")));
 
             // docs
-            perform.andDo(document("team/update/exception/interviewer-number/not-positive"));
+            perform.andDo(document("team/update/exception/interviewer-number-not-positive"));
         }
 
         @Test
@@ -606,7 +606,7 @@ class TeamControllerTest extends ControllerTest {
                     .andExpect(jsonPath("message").value("참가자 수는 인터뷰어 수 보다 많아야 합니다."));
 
             // docs
-            perform.andDo(document("team/update/exception/interviewer-number/more-than-participant"));
+            perform.andDo(document("team/update/exception/interviewer-number-more-than-participant"));
         }
 
         @Test
@@ -630,7 +630,7 @@ class TeamControllerTest extends ControllerTest {
                     jsonPath("message").value("중복되는 참가자가 존재합니다."));
 
             // docs
-            perform.andDo(document("team/update/exception/participants/duplicate"));
+            perform.andDo(document("team/update/exception/participants-duplicate"));
         }
 
         @Test
@@ -655,7 +655,7 @@ class TeamControllerTest extends ControllerTest {
                     jsonPath("message").value("중복되는 참가자가 존재합니다."));
 
             // docs
-            perform.andDo(document("team/update/exception/participants/host"));
+            perform.andDo(document("team/update/exception/participants-have-host"));
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -685,12 +685,12 @@ class TeamControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("findById 메서드는")
-    class FindById {
+    @DisplayName("findByTeamIdAndMemberId 메서드는")
+    class FindByTeamIdAndMemberId {
 
         @Test
         @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
-        void findById_teamNotFound_exception() throws Exception {
+        void findByTeamIdAndMemberId_teamNotFound_exception() throws Exception {
             // given
             mockLogin();
 
@@ -889,12 +889,12 @@ class TeamControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("delete 메서드는")
-    class Delete {
+    @DisplayName("deleteById 메서드는")
+    class DeleteById {
 
         @Test
         @DisplayName("없는 팀을 제거하려고 하면 예외를 던진다.")
-        void delete_teamNotFound_exception() throws Exception {
+        void deleteById_teamNotFound_exception() throws Exception {
             // given
             mockLogin();
 
@@ -918,7 +918,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간 후에 삭제하려고 하면 예외가 발생한다.")
-        void delete_afterStart_exception() throws Exception {
+        void deleteById_afterStart_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -946,7 +946,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("호스트가 아닌 사용자가 팀을 삭제하려고 하면 예외가 발생한다.")
-        void delete_notHost_exception() throws Exception {
+        void deleteById_notHost_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -58,7 +58,7 @@ class TeamControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 명으로 null이 들어오면 예외를 던진다.")
-        void titleNull_Exception(final String title) throws Exception {
+        void save_titleNull_exception(final String title) throws Exception {
             // given
             mockLogin();
 
@@ -79,7 +79,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 명으로 255자를 초과할 경우 예외를 던진다.")
-        void titleInvalidLength_Exception() throws Exception {
+        void save_titleInvalidLength_exception() throws Exception {
             // given
             mockLogin();
 
@@ -107,7 +107,7 @@ class TeamControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("장소로 null이 들어오면 예외를 던진다.")
-        void placeNull_Exception(final String place) throws Exception {
+        void save_placeNull_exception(final String place) throws Exception {
             // given
             mockLogin();
 
@@ -128,7 +128,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("장소로 255자를 초과할 경우 예외를 던진다.")
-        void placeInvalidLength_Exception() throws Exception {
+        void save_placeInvalidLength_exception() throws Exception {
             // given
             mockLogin();
 
@@ -154,7 +154,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간으로 null이 들어오면 예외를 던진다.")
-        void startAtNull_Exception() throws Exception {
+        void save_startAtNull_exception() throws Exception {
             // given
             mockLogin();
 
@@ -174,7 +174,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간이 현재 시간 기준으로 과거면 예외를 던진다.")
-        void startAtPast_Exception() throws Exception {
+        void save_startAtPast_exception() throws Exception {
             // given
             mockLogin();
 
@@ -199,7 +199,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 빈 리스트가 들어오면 예외를 던진다.")
-        void participantsEmpty_Exception() throws Exception {
+        void save_participantsEmpty_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -224,7 +224,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 null이 들어오면 예외를 던진다.")
-        void participantsNull_Exception() throws Exception {
+        void save_participantsNull_exception() throws Exception {
             // given
             mockLogin();
             final TeamWriteDto request = new TeamWriteDto("잠실 준조", "트랙룸", 1, LocalDateTime.now().plusDays(3), null);
@@ -242,7 +242,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰어가 1명 미만이면 예외를 던진다.")
-        void notPositiveInterviewerNumber_exceptionThrown() throws Exception {
+        void save_notPositiveInterviewerNumber_exception() throws Exception {
             // given
             mockLogin();
 
@@ -263,7 +263,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰어 수가 참가자 수보다 많거나 같으면 예외를 던진다.")
-        void interviewerMoreThanParticipant_exceptionThrown() throws Exception {
+        void save_interviewerMoreThanParticipant_exception() throws Exception {
             // given
             mockLogin();
 
@@ -288,7 +288,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 중복된 Id가 들어오면 예외를 던진다.")
-        void save_duplicateParticipant_exceptionThrown() throws Exception {
+        void save_duplicateParticipant_exception() throws Exception {
             // given
             mockLogin();
 
@@ -318,7 +318,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 호스트 Id가 들어오면 예외를 던진다.")
-        void save_participantsWithHostId_exceptionThrown() throws Exception {
+        void save_participantsWithHostId_exception() throws Exception {
             // given
             mockLogin();
 
@@ -355,7 +355,7 @@ class TeamControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("팀 명으로 null이 들어오면 예외를 던진다.")
-        void titleNull_Exception(final String title) throws Exception {
+        void update_titleNull_exception(final String title) throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -377,7 +377,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 명으로 255자를 초과할 경우 예외를 던진다.")
-        void titleInvalidLength_Exception() throws Exception {
+        void update_titleInvalidLength_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -406,7 +406,7 @@ class TeamControllerTest extends ControllerTest {
         @NullAndEmptySource
         @ValueSource(strings = {" "})
         @DisplayName("장소로 null이 들어오면 예외를 던진다.")
-        void placeNull_Exception(final String place) throws Exception {
+        void update_placeNull_exception(final String place) throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -428,7 +428,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("장소로 255자를 초과할 경우 예외를 던진다.")
-        void placeInvalidLength_Exception() throws Exception {
+        void update_placeInvalidLength_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -455,7 +455,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간으로 null이 들어오면 예외를 던진다.")
-        void startAtNull_Exception() throws Exception {
+        void update_startAtNull_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -476,7 +476,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간이 현재 시간 기준으로 과거면 예외를 던진다.")
-        void startAtPast_Exception() throws Exception {
+        void update_startAtPast_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -502,7 +502,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("없는 팀을 수정하려고 하면 예외를 던진다.")
-        void teamNotFound_Exception() throws Exception {
+        void update_teamNotFound_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -527,7 +527,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 빈 리스트가 들어오면 예외를 던진다.")
-        void participantsEmpty_Exception() throws Exception {
+        void update_participantsEmpty_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -546,7 +546,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 null이 들어오면 예외를 던진다.")
-        void participantsNull_Exception() throws Exception {
+        void update_participantsNull_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -565,7 +565,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰어가 1명 미만이면 예외를 던진다.")
-        void notPositiveInterviewerNumber_exceptionThrown() throws Exception {
+        void update_notPositiveInterviewerNumber_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -586,7 +586,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰어 수가 참가자 수보다 많거나 같으면 예외를 던진다.")
-        void interviewerMoreThanParticipant_exceptionThrown() throws Exception {
+        void update_interviewerMoreThanParticipant_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -611,7 +611,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 중복된 Id가 들어오면 예외를 던진다.")
-        void duplicateParticipant_exceptionThrown() throws Exception {
+        void update_duplicateParticipant_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -635,7 +635,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("팀 구성원 목록으로 호스트 Id가 들어오면 예외를 던진다.")
-        void participantsWithHostId_exceptionThrown() throws Exception {
+        void update_participantsWithHostId_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -660,7 +660,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 이후에 팀을 수정하려고 하면 예외를 던진다.")
-        void updateAfterStartAt_Exception() throws Exception {
+        void update_updateAfterStartAt_exception() throws Exception {
             // given
             mockLogin();
             mockCreateTeam();
@@ -690,7 +690,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
-        void teamNotFound_Exception() throws Exception {
+        void findById_teamNotFound_exception() throws Exception {
             // given
             mockLogin();
 
@@ -720,7 +720,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("요청한 사용자가 소속된 팀이 아니면 예외를 던진다.")
-        void notMyTeam_exceptionThrown() throws Exception {
+        void findMyRole_notMyTeam_exception() throws Exception {
             // given
             final Long teamId = 2L;
             final Long memberId = 5L;
@@ -746,7 +746,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("타겟 멤버가 팀의 참가자가 아니면 예외를 던진다.")
-        void targetNotParticipant_exceptionThrown() throws Exception {
+        void findMyRole_targetNotParticipant_exception() throws Exception {
             // given
             final Long teamId = 2L;
             final Long memberId = 5L;
@@ -777,7 +777,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("존재하지 않는 팀의 인터뷰를 종료하려고 하면 예외가 발생한다.")
-        void close_notFoundTeam_exceptionThrown() throws Exception {
+        void close_notFoundTeam_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -805,7 +805,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("이미 종료된 팀 인터뷰를 종료하려고 하면 예외가 발생한다.")
-        void close_alreadyClosed_exceptionThrown() throws Exception {
+        void close_alreadyClosed_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -833,7 +833,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간 전에 종료하려고 하면 예외가 발생한다.")
-        void close_beforeStart_exceptionThrown() throws Exception {
+        void close_beforeStart_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -861,7 +861,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("호스트가 아닌 사용자가 인터뷰를 종료하려고 하면 예외가 발생한다.")
-        void close_notHost_exceptionThrown() throws Exception {
+        void close_notHost_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -894,7 +894,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("없는 팀을 제거하려고 하면 예외를 던진다.")
-        void delete_teamNotFound_Exception() throws Exception {
+        void delete_teamNotFound_exception() throws Exception {
             // given
             mockLogin();
 
@@ -918,7 +918,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인터뷰 시작 시간 후에 삭제하려고 하면 예외가 발생한다.")
-        void delete_afterStart_exceptionThrown() throws Exception {
+        void delete_afterStart_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);
@@ -946,7 +946,7 @@ class TeamControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("호스트가 아닌 사용자가 팀을 삭제하려고 하면 예외가 발생한다.")
-        void delete_notHost_exceptionThrown() throws Exception {
+        void delete_notHost_exception() throws Exception {
             // given
             given(jwtTokenProvider.getPayload(TOKEN)).willReturn("4");
             given(jwtTokenProvider.validateToken(TOKEN)).willReturn(true);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -35,6 +35,8 @@ class TeamControllerTest extends ControllerTest {
     @DisplayName("save 메서드는")
     class Save {
 
+        private static final String BASE_SNIPPET_PATH = "team/create/exception/";
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {" "})
@@ -55,7 +57,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/title-blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "title-blank"));
         }
 
         @Test
@@ -82,7 +84,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/title-length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "title-length"));
         }
 
         @ParameterizedTest
@@ -105,7 +107,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/place-blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "place-blank"));
         }
 
         @Test
@@ -132,7 +134,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/place-length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "place-length"));
         }
 
         @Test
@@ -152,7 +154,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/start-at-null"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "start-at-null"));
         }
 
         @Test
@@ -178,7 +180,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/start-at-past"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "start-at-past"));
         }
 
         @Test
@@ -197,7 +199,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/participants-empty"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-empty"));
         }
 
         @Test
@@ -216,7 +218,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/participants-null"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-null"));
         }
 
         @Test
@@ -237,7 +239,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/interviewer-number-not-positive"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "interviewer-number-not-positive"));
         }
 
         @Test
@@ -263,7 +265,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/interviewer-number-more-than-participant"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "interviewer-number-more-than-participant"));
         }
 
         @Test
@@ -289,7 +291,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/participants-duplicate"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-duplicate"));
         }
 
         @Test
@@ -315,7 +317,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/create/exception/participants-have-host"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-have-host"));
         }
 
         private ResultActions requestCreateTeam(final TeamWriteDto request) throws Exception {
@@ -326,6 +328,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("update 메서드는")
     class Update {
+
+        private static final String BASE_SNIPPET_PATH = "team/update/exception/";
 
         @ParameterizedTest
         @NullAndEmptySource
@@ -348,7 +352,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/title-blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "title-blank"));
         }
 
         @Test
@@ -376,7 +380,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/title-length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "title-length"));
         }
 
         @ParameterizedTest
@@ -385,7 +389,6 @@ class TeamControllerTest extends ControllerTest {
         @DisplayName("장소로 null이 들어오면 예외를 던진다.")
         void update_placeNull_exception(final String place) throws Exception {
             // given
-//            eam();
             final long id = 1;
             final ParticipantIdsDto participantIds = new ParticipantIdsDto(List.of(2L, 3L));
             final TeamWriteDto request = new TeamWriteDto("잠실 제이슨조", place, 1, LocalDateTime.now().plusDays(3),
@@ -401,7 +404,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/place-blank"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "place-blank"));
         }
 
         @Test
@@ -429,7 +432,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/place-length"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "place-length"));
         }
 
         @Test
@@ -450,7 +453,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/start-at-null"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "start-at-null"));
         }
 
         @Test
@@ -476,7 +479,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/start-at-past"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "start-at-past"));
         }
 
         @Test
@@ -502,7 +505,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -519,7 +522,7 @@ class TeamControllerTest extends ControllerTest {
             perform.andExpect(status().isBadRequest());
 
             // docs
-            perform.andDo(document("team/update/exception/participants-empty"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-empty"));
         }
 
         @Test
@@ -538,7 +541,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/participants-null"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-null"));
         }
 
         @Test
@@ -559,7 +562,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/interviewer-number-not-positive"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "interviewer-number-not-positive"));
         }
 
         @Test
@@ -585,7 +588,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/interviewer-number-more-than-participant"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "interviewer-number-more-than-participant"));
         }
 
         @Test
@@ -610,7 +613,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/participants-duplicate"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-duplicate"));
         }
 
         @Test
@@ -635,7 +638,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/participants-have-host"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "participants-have-host"));
         }
 
         @Test
@@ -661,7 +664,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/update/exception/after-start-at"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-start-at"));
         }
 
         private ResultActions requestUpdateTeam(final Long teamId, final TeamWriteDto request) throws Exception {
@@ -672,6 +675,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findByTeamIdAndMemberId 메서드는")
     class FindByTeamIdAndMemberId {
+
+        private static final String BASE_SNIPPET_PATH = "team/find-by-id/exception/";
 
         @Test
         @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
@@ -692,7 +697,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/find-by-id/exception/notfound"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "notfound"));
         }
 
         private ResultActions requestFindTeam(final Long teamId) throws Exception {
@@ -703,6 +708,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findStatus 메서드는")
     class FindStatus {
+
+        private static final String BASE_SNIPPET_PATH = "team/find-status/exception/";
 
         @Test
         @DisplayName("id에 해당하는 팀이 존재하지 않으면 예외를 던진다.")
@@ -724,7 +731,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/find-status/exception/team-not-found"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "team-not-found"));
         }
 
         private ResultActions requestFindStatus(final Long teamId) throws Exception {
@@ -735,6 +742,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("findMyRole 메서드는")
     class FindMyRole {
+
+        private static final String BASE_SNIPPET_PATH = "team/find-my-role/exception/";
 
         @Test
         @DisplayName("요청한 사용자가 소속된 팀이 아니면 예외를 던진다.")
@@ -757,7 +766,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/find-my-role/exception/not-my-team"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-my-team"));
         }
 
         @Test
@@ -781,7 +790,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/find-my-role/exception/target-not-participant"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "target-not-participant"));
         }
 
         private ResultActions requestFindMyRole(final Long teamId, final Long memberId) throws Exception {
@@ -792,6 +801,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("close 메서드는")
     class Close {
+
+        private static final String BASE_SNIPPET_PATH = "team/close/exception/";
 
         @Test
         @DisplayName("존재하지 않는 팀의 인터뷰를 종료하려고 하면 예외가 발생한다.")
@@ -813,7 +824,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/close/exception/notfound"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "not-found"));
         }
 
         @Test
@@ -837,7 +848,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/close/exception/already-close"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "already-close"));
         }
 
         @Test
@@ -861,7 +872,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/close/exception/before-start"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "before-start"));
         }
 
         @Test
@@ -885,7 +896,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/close/exception/unauthorized"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "unauthorized"));
         }
 
         private ResultActions requestCloseTeam(final Long teamId) throws Exception {
@@ -896,6 +907,8 @@ class TeamControllerTest extends ControllerTest {
     @Nested
     @DisplayName("deleteById 메서드는")
     class DeleteById {
+
+        private static final String BASE_SNIPPET_PATH = "team/delete/exception/";
 
         @Test
         @DisplayName("없는 팀을 제거하려고 하면 예외를 던진다.")
@@ -916,7 +929,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/delete/exception/notfound"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "notfound"));
         }
 
         @Test
@@ -939,7 +952,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/delete/exception/after-start"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "after-start"));
         }
 
         @Test
@@ -963,7 +976,7 @@ class TeamControllerTest extends ControllerTest {
             );
 
             // docs
-            perform.andDo(document("team/delete/exception/unauthorized"));
+            perform.andDo(document(BASE_SNIPPET_PATH + "unauthorized"));
         }
 
         private ResultActions requestDeleteTeam(final Long teamId) throws Exception {

--- a/backend/src/test/java/com/woowacourse/levellog/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/support/JwtTokenProviderTest.java
@@ -30,7 +30,7 @@ class JwtTokenProviderTest {
 
     @Nested
     @DisplayName("getPayload 메서드는")
-    class getPayload {
+    class GetPayload {
 
         @Test
         @DisplayName("페이로드를 반환한다.")
@@ -48,7 +48,7 @@ class JwtTokenProviderTest {
 
         @Test
         @DisplayName("유효기간이 만료된 토큰이면 예외를 던진다.")
-        void expiredToken_Exception() {
+        void getPayload_expiredToken_exception() {
             // given
             final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, 0);
             final String token = jwtTokenProvider.createToken("1234567");
@@ -60,7 +60,7 @@ class JwtTokenProviderTest {
 
         @Test
         @DisplayName("페이로드에 정수가 아닌 값이 들어있으면 예외를 던진다.")
-        void notIntPayload_Exception() {
+        void getPayload_notIntPayload_exception() {
             // given
             final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, EXPIRE_LENGTH);
             final String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJoaWhpIn0.SH1aNhtKVDIbM6uuzx5wzP7i0cMeg-VLsEwyEf7DbBA";


### PR DESCRIPTION
## 구현 기능
- 모든 테스트 코드 네이밍 컨벤션을 통일시킨다.
- 스니펫의 네이밍 컨벤션을 통일시킨다.

## 공유하고 싶은 내용
[네이밍 규칙 이슈](https://github.com/woowacourse-teams/2022-levellog/issues/124)


Close #124