### PR TITLE
feat: 사전 질문 상세 조회 시 작성자를 응답에 포함하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/application/InterviewQuestionService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/application/InterviewQuestionService.java
@@ -74,7 +74,7 @@ public class InterviewQuestionService {
                 .getTeam()
                 .validateInProgress(timeStandard.now(), "인터뷰 시작 전에 인터뷰 질문을 수정 할 수 없습니다.");
 
-        interviewQuestion.updateContent(request.getInterviewQuestion(), author);
+        interviewQuestion.updateContent(request.getContent(), author);
     }
 
     @Transactional

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/dto/InterviewQuestionWriteDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/dto/InterviewQuestionWriteDto.java
@@ -17,13 +17,13 @@ import lombok.NoArgsConstructor;
 public class InterviewQuestionWriteDto {
 
     @NotBlank
-    private String interviewQuestion;
+    private String content;
 
     public static InterviewQuestionWriteDto from(final String interviewQuestion) {
         return new InterviewQuestionWriteDto(interviewQuestion);
     }
 
     public InterviewQuestion toInterviewQuestion(final Member fromMember, final Levellog levellog) {
-        return InterviewQuestion.of(fromMember, levellog, interviewQuestion);
+        return InterviewQuestion.of(fromMember, levellog, content);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
@@ -61,7 +61,7 @@ public class PreQuestionService {
         validateLevellog(preQuestion, levellog);
         validateMyQuestion(preQuestion, questioner);
 
-        preQuestion.update(request.getPreQuestion());
+        preQuestion.update(request.getContent());
     }
 
     @Transactional

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/application/PreQuestionService.java
@@ -10,6 +10,7 @@ import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.prequestion.domain.PreQuestionRepository;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionAlreadyExistException;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import com.woowacourse.levellog.prequestion.exception.PreQuestionNotFoundException;
 import com.woowacourse.levellog.team.domain.ParticipantRepository;
 import com.woowacourse.levellog.team.domain.Participants;
@@ -29,7 +30,7 @@ public class PreQuestionService {
     private final ParticipantRepository participantRepository;
 
     @Transactional
-    public Long save(final PreQuestionDto request, final Long levellogId, final Long memberId) {
+    public Long save(final PreQuestionWriteDto request, final Long levellogId, final Long memberId) {
         final Levellog levellog = getLevellog(levellogId);
         final Member questioner = getMember(memberId);
 
@@ -47,11 +48,11 @@ public class PreQuestionService {
                 .orElseThrow(() -> new PreQuestionNotFoundException("사전 질문이 존재하지 않습니다. "
                         + "[ levellogId : " + levellogId + " memberId : " + questionerId + " ]"));
 
-        return PreQuestionDto.from(preQuestion.getContent());
+        return PreQuestionDto.from(questioner, preQuestion.getContent());
     }
 
     @Transactional
-    public void update(final PreQuestionDto request, final Long preQuestionId, final Long levellogId,
+    public void update(final PreQuestionWriteDto request, final Long preQuestionId, final Long levellogId,
                        final Long memberId) {
         final PreQuestion preQuestion = getPreQuestion(preQuestionId);
         final Levellog levellog = getLevellog(levellogId);

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionDto.java
@@ -1,9 +1,7 @@
 package com.woowacourse.levellog.prequestion.dto;
 
-import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.member.domain.Member;
-import com.woowacourse.levellog.prequestion.domain.PreQuestion;
-import javax.validation.constraints.NotBlank;
+import com.woowacourse.levellog.member.dto.MemberDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -16,14 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PreQuestionDto {
 
-    @NotBlank
-    private String preQuestion;
+    private MemberDto author;
+    private String content;
 
-    public static PreQuestionDto from(final String preQuestionContent) {
-        return new PreQuestionDto(preQuestionContent);
-    }
-
-    public PreQuestion toEntity(final Levellog levellog, final Member from) {
-        return new PreQuestion(levellog, from, preQuestion);
+    public static PreQuestionDto from(final Member author, final String content) {
+        return new PreQuestionDto(MemberDto.from(author), content);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionWriteDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionWriteDto.java
@@ -1,0 +1,29 @@
+package com.woowacourse.levellog.prequestion.dto;
+
+import com.woowacourse.levellog.levellog.domain.Levellog;
+import com.woowacourse.levellog.member.domain.Member;
+import com.woowacourse.levellog.prequestion.domain.PreQuestion;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PreQuestionWriteDto {
+
+    @NotBlank
+    private String preQuestion;
+
+    public static PreQuestionWriteDto from(String content) {
+        return new PreQuestionWriteDto(content);
+    }
+
+    public PreQuestion toEntity(final Levellog levellog, final Member from) {
+        return new PreQuestion(levellog, from, preQuestion);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionWriteDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/dto/PreQuestionWriteDto.java
@@ -17,13 +17,13 @@ import lombok.NoArgsConstructor;
 public class PreQuestionWriteDto {
 
     @NotBlank
-    private String preQuestion;
+    private String content;
 
-    public static PreQuestionWriteDto from(String content) {
+    public static PreQuestionWriteDto from(final String content) {
         return new PreQuestionWriteDto(content);
     }
 
     public PreQuestion toEntity(final Levellog levellog, final Member from) {
-        return new PreQuestion(levellog, from, preQuestion);
+        return new PreQuestion(levellog, from, content);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/presentation/PreQuestionController.java
@@ -3,6 +3,7 @@ package com.woowacourse.levellog.prequestion.presentation;
 import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.prequestion.application.PreQuestionService;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class PreQuestionController {
     private final PreQuestionService preQuestionService;
 
     @PostMapping
-    public ResponseEntity<Void> save(@RequestBody @Valid final PreQuestionDto request,
+    public ResponseEntity<Void> save(@RequestBody @Valid final PreQuestionWriteDto request,
                                      @PathVariable final Long levellogId,
                                      @Authentic final Long memberId) {
         final Long preQuestionId = preQuestionService.save(request, levellogId, memberId);
@@ -39,7 +40,7 @@ public class PreQuestionController {
     }
 
     @PutMapping("/{preQuestionId}")
-    public ResponseEntity<Void> update(@RequestBody @Valid final PreQuestionDto request,
+    public ResponseEntity<Void> update(@RequestBody @Valid final PreQuestionWriteDto request,
                                        @PathVariable final Long levellogId,
                                        @PathVariable final Long preQuestionId,
                                        @Authentic final Long memberId) {

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/AcceptanceTest.java
@@ -21,7 +21,7 @@ import com.woowacourse.levellog.fixture.MemberFixture;
 import com.woowacourse.levellog.fixture.RestAssuredResponse;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionWriteDto;
 import com.woowacourse.levellog.levellog.dto.LevellogWriteDto;
-import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import com.woowacourse.levellog.team.dto.ParticipantIdsDto;
 import com.woowacourse.levellog.team.dto.TeamWriteDto;
 import io.restassured.RestAssured;
@@ -151,7 +151,7 @@ abstract class AcceptanceTest {
 
     protected RestAssuredResponse savePreQuestion(final String content, final String levellogId,
                                                   final MemberFixture author) {
-        final PreQuestionDto request = PreQuestionDto.from(content);
+        final PreQuestionWriteDto request = PreQuestionWriteDto.from(content);
 
         return post("/api/levellogs/" + levellogId + "/pre-questions/", author.getToken(), request);
     }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/PreQuestionAcceptanceTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.woowacourse.levellog.fixture.MemberFixture;
-import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +36,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         final String teamId = saveTeam("잠실 제이슨조", PEPPER, 1, EVE).getTeamId();
         final String levellogId = saveLevellog("페퍼의 레벨로그", teamId, PEPPER).getLevellogId();
 
-        final PreQuestionDto request = PreQuestionDto.from("이브가 쓴 사전 질문");
+        final PreQuestionWriteDto request = PreQuestionWriteDto.from("이브가 쓴 사전 질문");
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -72,9 +72,9 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
 
         final String preQuestionId = savePreQuestion("이브가 쓴 사전 질문", levellogId, EVE).getPreQuestionId();
 
-        // when
-        final PreQuestionDto request = PreQuestionDto.from("이브가 수정한 사전 질문");
+        final PreQuestionWriteDto request = PreQuestionWriteDto.from("이브가 수정한 사전 질문");
 
+        // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + EVE.getToken())
                 .body(request)
@@ -87,7 +87,7 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.NO_CONTENT.value());
         requestFindMyPreQuestions(levellogId, EVE)
-                .body("preQuestion", equalTo("이브가 수정한 사전 질문"));
+                .body("content", equalTo("이브가 수정한 사전 질문"));
     }
 
     /*
@@ -120,7 +120,8 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.OK.value())
-                .body("preQuestion", equalTo("이브가 쓴 사전 질문"));
+                .body("content", equalTo("이브가 쓴 사전 질문"),
+                        "author.id", equalTo(EVE.getId().intValue()));
     }
 
     /*
@@ -157,6 +158,6 @@ class PreQuestionAcceptanceTest extends AcceptanceTest {
     }
 
     private ValidatableResponse requestFindMyPreQuestions(final String levellogId, final MemberFixture member) {
-        return get("/api/levellogs/" + levellogId + "/pre-questions/" + "my", member.getToken()).getResponse();
+        return get("/api/levellogs/" + levellogId + "/pre-questions/my", member.getToken()).getResponse();
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/PreQuestionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/PreQuestionServiceTest.java
@@ -12,6 +12,7 @@ import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.prequestion.domain.PreQuestion;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionAlreadyExistException;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import com.woowacourse.levellog.prequestion.exception.InvalidPreQuestionException;
 import com.woowacourse.levellog.prequestion.exception.PreQuestionNotFoundException;
 import com.woowacourse.levellog.team.domain.Participant;
@@ -32,7 +33,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void success() {
             //given
             final String preQuestion = "로마가 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -40,7 +41,7 @@ public class PreQuestionServiceTest extends ServiceTest {
             final Levellog levellog = saveLevellog(author, team);
 
             //when
-            final Long id = preQuestionService.save(preQuestionDto, levellog.getId(), questioner.getId());
+            final Long id = preQuestionService.save(preQuestionWriteDto, levellog.getId(), questioner.getId());
 
             //then
             final PreQuestion actual = preQuestionRepository.findById(id).orElseThrow();
@@ -56,7 +57,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void save_fromNotParticipant_exception() {
             // given
             final String preQuestion = "로마가 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -66,7 +67,7 @@ public class PreQuestionServiceTest extends ServiceTest {
             participantRepository.save(new Participant(team, author, true));
 
             // when, then
-            assertThatThrownBy(() -> preQuestionService.save(preQuestionDto, levellog.getId(), questioner.getId()))
+            assertThatThrownBy(() -> preQuestionService.save(preQuestionWriteDto, levellog.getId(), questioner.getId()))
                     .isInstanceOf(UnauthorizedException.class)
                     .hasMessageContaining("같은 팀에 속한 멤버만 사전 질문을 작성할 수 있습니다.");
         }
@@ -76,7 +77,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void save_levellogIsMine_exception() {
             // given
             final String preQuestion = "알린이 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -84,7 +85,7 @@ public class PreQuestionServiceTest extends ServiceTest {
             final Levellog levellog = saveLevellog(author, team);
 
             // when, then
-            assertThatThrownBy(() -> preQuestionService.save(preQuestionDto, levellog.getId(), author.getId()))
+            assertThatThrownBy(() -> preQuestionService.save(preQuestionWriteDto, levellog.getId(), author.getId()))
                     .isInstanceOf(InvalidPreQuestionException.class)
                     .hasMessageContaining("자기 자신에게 사전 질문을 등록할 수 없습니다.");
         }
@@ -94,7 +95,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void save_preQuestionAlreadyExist_exception() {
             // given
             final String preQuestion = "알린이 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -104,7 +105,7 @@ public class PreQuestionServiceTest extends ServiceTest {
             savePreQuestion(levellog, questioner);
 
             // when, then
-            assertThatThrownBy(() -> preQuestionService.save(preQuestionDto, levellog.getId(), questioner.getId()))
+            assertThatThrownBy(() -> preQuestionService.save(preQuestionWriteDto, levellog.getId(), questioner.getId()))
                     .isInstanceOf(PreQuestionAlreadyExistException.class)
                     .hasMessageContainingAll("사전 질문을 이미 작성하였습니다.",
                             String.valueOf(levellog.getId()),
@@ -133,7 +134,10 @@ public class PreQuestionServiceTest extends ServiceTest {
             final PreQuestionDto response = preQuestionService.findMy(levellog.getId(), questioner.getId());
 
             //then
-            assertThat(response.getPreQuestion()).isEqualTo(content);
+            assertAll(
+                    () -> assertThat(response.getContent()).isEqualTo(content),
+                    () -> assertThat(response.getAuthor().getId()).isEqualTo(questioner.getId())
+            );
         }
 
         @Test
@@ -185,11 +189,11 @@ public class PreQuestionServiceTest extends ServiceTest {
             final Long id = savePreQuestion(levellog, questioner).getId();
 
             //when
-            preQuestionService.update(PreQuestionDto.from("수정된 사전 질문"), id, levellog.getId(), questioner.getId());
+            preQuestionService.update(PreQuestionWriteDto.from("수정된 사전 질문"), id, levellog.getId(), questioner.getId());
 
             //then
             final PreQuestionDto response = preQuestionService.findMy(levellog.getId(), questioner.getId());
-            assertThat(response.getPreQuestion()).isEqualTo("수정된 사전 질문");
+            assertThat(response.getContent()).isEqualTo("수정된 사전 질문");
         }
 
         @Test
@@ -197,7 +201,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void update_preQuestionNotFound_exception() {
             // given
             final String preQuestion = "로마가 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -206,7 +210,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
             // when, then
             assertThatThrownBy(
-                    () -> preQuestionService.update(preQuestionDto, 1L, levellog.getId(), questioner.getId()))
+                    () -> preQuestionService.update(preQuestionWriteDto, 1L, levellog.getId(), questioner.getId()))
                     .isInstanceOf(PreQuestionNotFoundException.class)
                     .hasMessageContaining("사전 질문이 존재하지 않습니다.");
         }
@@ -215,7 +219,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         @DisplayName("타인의 사전 질문을 수정하는 경우 예외를 던진다.")
         void update_fromNotMyPreQuestion_exception() {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("로마가 쓴 사전 질문");
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from("로마가 쓴 사전 질문");
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -228,7 +232,7 @@ public class PreQuestionServiceTest extends ServiceTest {
 
             // when, then
             assertThatThrownBy(
-                    () -> preQuestionService.update(preQuestionDto, preQuestionId, levellog.getId(),
+                    () -> preQuestionService.update(preQuestionWriteDto, preQuestionId, levellog.getId(),
                             questioner.getId()))
                     .isInstanceOf(UnauthorizedException.class)
                     .hasMessageContaining("자신의 사전 질문이 아닙니다.");
@@ -239,7 +243,7 @@ public class PreQuestionServiceTest extends ServiceTest {
         void update_levellogWrongId_exception() {
             //given
             final String preQuestion = "로마가 쓴 사전 질문";
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto preQuestionWriteDto = PreQuestionWriteDto.from(preQuestion);
 
             final Member author = saveMember("알린");
             final Member questioner = saveMember("로마");
@@ -250,11 +254,11 @@ public class PreQuestionServiceTest extends ServiceTest {
             final Team team2 = saveTeam(author2);
             final Levellog levellog2 = saveLevellog(author2, team2);
 
-            final Long id = preQuestionService.save(preQuestionDto, levellog.getId(), questioner.getId());
+            final Long id = preQuestionService.save(preQuestionWriteDto, levellog.getId(), questioner.getId());
 
             // when, then
             assertThatThrownBy(
-                    () -> preQuestionService.update(preQuestionDto, id, levellog2.getId(), questioner.getId()))
+                    () -> preQuestionService.update(preQuestionWriteDto, id, levellog2.getId(), questioner.getId()))
                     .isInstanceOf(InvalidLevellogException.class)
                     .hasMessageContaining("입력한 levellogId와 사전 질문의 levellogId가 다릅니다.");
         }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionControllerTest.java
@@ -42,7 +42,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message").value("interviewQuestion must not be blank")
+                    jsonPath("message").value("content must not be blank")
             );
 
             // docs
@@ -238,7 +238,7 @@ class InterviewQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message").value("interviewQuestion must not be blank")
+                    jsonPath("message").value("content must not be blank")
             );
 
             // docs

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -9,7 +9,7 @@ import com.woowacourse.levellog.common.exception.UnauthorizedException;
 import com.woowacourse.levellog.levellog.exception.InvalidLevellogException;
 import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.prequestion.dto.PreQuestionAlreadyExistException;
-import com.woowacourse.levellog.prequestion.dto.PreQuestionDto;
+import com.woowacourse.levellog.prequestion.dto.PreQuestionWriteDto;
 import com.woowacourse.levellog.prequestion.exception.InvalidPreQuestionException;
 import com.woowacourse.levellog.prequestion.exception.PreQuestionNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -35,10 +35,10 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("사전 질문으로 공백이나 null이 들어오면 예외를 던진다.")
         void save_preQuestionNullAndBlank_exception(final String preQuestion) throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from(preQuestion);
 
             // when
-            final ResultActions perform = requestCreatePreQuestion(1L, preQuestionDto);
+            final ResultActions perform = requestCreatePreQuestion(1L, request);
 
             // then
             perform.andExpectAll(
@@ -53,14 +53,14 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("참가자가 아닌 멤버가 사전 질문을 등록하는 경우 예외를 던진다.")
         void save_fromNotParticipant_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
             final String message = "권한이 없습니다.";
             willThrow(new UnauthorizedException(message))
                     .given(preQuestionService)
-                    .save(preQuestionDto, 1L, 1L);
+                    .save(request, 1L, 1L);
 
             // when
-            final ResultActions perform = requestCreatePreQuestion(1L, preQuestionDto);
+            final ResultActions perform = requestCreatePreQuestion(1L, request);
 
             // then
             perform.andExpectAll(
@@ -75,15 +75,15 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("내 레벨로그에 사전 질문을 등록하는 경우 예외를 던진다.")
         void save_levellogIsMine_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
 
             final String message = "자기 자신에게 사전 질문을 등록할 수 없습니다.";
             willThrow(new InvalidPreQuestionException("[levellogId : 1]", message))
                     .given(preQuestionService)
-                    .save(preQuestionDto, 1L, 1L);
+                    .save(request, 1L, 1L);
 
             // when
-            final ResultActions perform = requestCreatePreQuestion(1L, preQuestionDto);
+            final ResultActions perform = requestCreatePreQuestion(1L, request);
 
             // then
             perform.andExpectAll(
@@ -98,15 +98,15 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("사전 질문이 이미 등록되었을 때 사전 질문을 등록하는 경우 예외를 던진다.")
         void save_preQuestionAlreadyExist_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
 
             final String message = "레벨로그의 사전 질문을 이미 작성했습니다.";
             willThrow(new PreQuestionAlreadyExistException(message))
                     .given(preQuestionService)
-                    .save(preQuestionDto, 1L, 1L);
+                    .save(request, 1L, 1L);
 
             // when
-            final ResultActions perform = requestCreatePreQuestion(1L, preQuestionDto);
+            final ResultActions perform = requestCreatePreQuestion(1L, request);
 
             // then
             perform.andExpectAll(
@@ -118,8 +118,8 @@ class PreQuestionControllerTest extends ControllerTest {
         }
 
         private ResultActions requestCreatePreQuestion(final Long levellogId,
-                                                       final PreQuestionDto preQuestionDto) throws Exception {
-            return requestPost("/api/levellogs/" + levellogId + "/pre-questions", preQuestionDto);
+                                                       final PreQuestionWriteDto request) throws Exception {
+            return requestPost("/api/levellogs/" + levellogId + "/pre-questions", request);
         }
     }
 
@@ -135,10 +135,10 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("사전 질문으로 공백이나 null이 들어오면 예외를 던진다.")
         void update_preQuestionNullAndBlank_exception(final String preQuestion) throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from(preQuestion);
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from(preQuestion);
 
             // when
-            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, preQuestionDto);
+            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, request);
 
             // then
             perform.andExpectAll(
@@ -153,15 +153,15 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("잘못된 레벨로그의 사전 질문을 수정하면 예외를 던진다.")
         void update_levellogWrongId_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
 
             final String message = "입력한 levellogId와 사전 질문의 levellogId가 다릅니다.";
             willThrow(new InvalidLevellogException(message, "[ 입력한 levellogId : 1 ]"))
                     .given(preQuestionService)
-                    .update(preQuestionDto, 1L, 1L, 1L);
+                    .update(request, 1L, 1L, 1L);
 
             // when
-            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, preQuestionDto);
+            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, request);
 
             // then
             perform.andExpectAll(
@@ -176,15 +176,15 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("저장되어있지 않은 사전 질문을 수정하는 경우 예외를 던진다.")
         void update_preQuestionNotFound_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
 
             final String message = "사전 질문이 존재하지 않습니다.";
             willThrow(new PreQuestionNotFoundException(message))
                     .given(preQuestionService)
-                    .update(preQuestionDto, 1L, 1L, 1L);
+                    .update(request, 1L, 1L, 1L);
 
             // when
-            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, preQuestionDto);
+            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, request);
 
             // then
             perform.andExpectAll(
@@ -199,15 +199,15 @@ class PreQuestionControllerTest extends ControllerTest {
         @DisplayName("타인의 사전 질문을 수정하는 경우 예외를 던진다.")
         void update_fromNotMyPreQuestion_exception() throws Exception {
             // given
-            final PreQuestionDto preQuestionDto = PreQuestionDto.from("사전 질문");
+            final PreQuestionWriteDto request = PreQuestionWriteDto.from("사전 질문");
 
             final String message = "권한이 없습니다.";
             willThrow(new UnauthorizedException(message))
                     .given(preQuestionService)
-                    .update(preQuestionDto, 1L, 1L, 1L);
+                    .update(request, 1L, 1L, 1L);
 
             // when
-            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, preQuestionDto);
+            final ResultActions perform = requestUpdatePreQuestion(1L, 1L, request);
 
             // then
             perform.andExpectAll(
@@ -220,7 +220,7 @@ class PreQuestionControllerTest extends ControllerTest {
 
         private ResultActions requestUpdatePreQuestion(final Long levellogId,
                                                        final Long preQuestionId,
-                                                       final PreQuestionDto request) throws Exception {
+                                                       final PreQuestionWriteDto request) throws Exception {
             return requestPut("/api/levellogs/" + levellogId + "/pre-questions/" + preQuestionId, request);
         }
     }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/PreQuestionControllerTest.java
@@ -43,7 +43,7 @@ class PreQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message").value("preQuestion must not be blank"));
+                    jsonPath("message").value("content must not be blank"));
 
             // docs
             perform.andDo(document(BASE_SNIPPET_PATH + "blank"));
@@ -143,7 +143,7 @@ class PreQuestionControllerTest extends ControllerTest {
             // then
             perform.andExpectAll(
                     status().isBadRequest(),
-                    jsonPath("message").value("preQuestion must not be blank"));
+                    jsonPath("message").value("content must not be blank"));
 
             // docs
             perform.andDo(document(BASE_SNIPPET_PATH + "blank"));


### PR DESCRIPTION
[이전 PR](https://github.com/woowacourse-teams/2022-levellog/pull/307)
[이전 PR](https://github.com/woowacourse-teams/2022-levellog/pull/315)

## 구현 기능
- 내가 작성한 사전 질문 상세 조회 시 사전 질문을 작성한 작성자의 정보를 포함하도록 수정

### 변경 전 

```JSON
{
  "preQuestion" : "이브가 쓴 사전 질문"
}
```

### 변경 후

```JSON
{
  "author" : {
    "id" : 2,
    "nickname" : "이브",
    "profileUrl" : "이브.com"
  },
  "content" : "이브가 쓴 사전 질문"
}
```

---

## 논의하고 싶은 내용
- 인터뷰 질문도 그렇고 여기도 그렇고 상세 조회지만 id값을 주지 않는데 괜찮을까요?
```JSON
{
  "id" : 1, // 지금은 이게 없는데 상관없을까요? 쓰는곳은 없어보이긴해요!
  "author" : {
    "id" : 2,
    "nickname" : "이브",
    "profileUrl" : "이브.com"
  },
  "content" : "이브가 쓴 사전 질문"
}
```

## 기타
- 하나의 DTO를 생성/수정/조회에 사용하고 있어서 생성/수정 용 DTO(`PreQuestionWriteDto`), 조회용 DTO(`PreQuestionDto`)로 분리했습니다.
- `PreQuestionDto`에서 `preQuestion`을 `content`로 수정했습니다.

Close #292 
