### PR TITLE
feature: 팀 목록 조회 기능에 페이징 적용

### DIFF
--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -91,7 +91,38 @@ include::{snippets}/team/create/exception/not-independent/http-response.adoc[]
 include::{snippets}/team/create/exception/host-existence/http-response.adoc[]
 
 [[find-all]]
-== 팀 전체 목록 조회
+== 팀 목록 조회
+
+*Query Parameter*
+
+[cols="1,1,1,1"]
+|===
+|*Parameter*
+|*Description*
+|*Type*
+|*Default Value*
+
+|status
+|인터뷰 진행 상태에 따라 필터링 조건을 적용한다.
+|String(ready / in-progress / closed / all)
+|all
+
+|page
+|페이지 넘버를 지정한다.
+|정수형
+|0
+
+|size
+|가져올 데이터 개수를 지정한다.
+|정수형
+|100
+
+|sort
+|정렬 조건을 적용한다. 다중 조건인 경우 앞에 선언된 조건이 우선 적용된다.
+|String,String
+|isClosed,asc&createdAt,desc
+|<<find-all>>
+|===
 
 *STATUS 응답 종류*
 
@@ -110,75 +141,13 @@ include::{snippets}/team/create/exception/host-existence/http-response.adoc[]
 |인터뷰가 종료된 상태이다.
 |===
 
-*Pagination*
-
-[cols="1,1"]
-|===
-|*Parameter*
-|*Default Value*
-
-|page
-|0
-
-|size
-|20
-
-|sort
-|인터뷰 종료 여부 기준 오름차순 정렬(아직 종료되지 않은 팀 -> 종료 된 팀), 생성일 기준 내림차순 정렬
-|===
-
 [[find-all-success]]
-=== 팀 전체 목록 조회 성공
+=== 팀 목록 조회 성공
 
 operation::team/find-all[]
 
-[[find-all-by-status]]
-== Status로 필터링 된 팀 목록 조회
-
-*status 쿼리 파라미터 종류*
-
-[cols="1,1"]
-|===
-|*Parameter*
-|*설명*
-
-|ready
-|인터뷰 시작 전인 팀 목록을 조회한다.
-
-|in-progress
-|인터뷰가 진행 중인 팀 목록을 조회한다.
-
-|closed
-|인터뷰가 종료된 팀 목록을 조회한다.
-
-|all (Default)
-|<<find-all>>
-|===
-
-*Pagination*
-
-[cols="1,1"]
-|===
-|*Parameter*
-|*Default Value*
-
-|page
-|0
-
-|size
-|20
-
-|sort
-|생성일 기준 내림차순 정렬
-|===
-
-[[find-all-by-status-success]]
-=== Status로 필터링 된 팀 목록 조회 성공
-
-operation::team/find-all/filtering-by-status[]
-
-[[find-all-by-status-exception]]
-=== Status로 필터링 된 팀 목록 조회 예외
+[[find-all-exception]]
+=== 팀 목록 조회 예외
 
 ==== 쿼리 파라미터로 잘못된 status를 입력한 경우
 

--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -130,8 +130,6 @@ include::{snippets}/team/create/exception/host-existence/http-response.adoc[]
 [[find-all-success]]
 === 팀 전체 목록 조회 성공
 
-팀 전체 목록 조회 응답은 인터뷰 진행 상태와 최근 생성일 순으로 정렬되어 있다.
-
 operation::team/find-all[]
 
 [[find-all-by-status]]
@@ -152,6 +150,9 @@ operation::team/find-all[]
 
 |closed
 |인터뷰가 종료된 팀 목록을 조회한다.
+
+|all (Default)
+|<<find-all>>
 |===
 
 *Pagination*
@@ -173,8 +174,6 @@ operation::team/find-all[]
 
 [[find-all-by-status-success]]
 === Status로 필터링 된 팀 목록 조회 성공
-
-Status로 필터링 된 팀 목록 조회 응답은 최근 생성일 순으로 정렬되어 있다.
 
 operation::team/find-all/filtering-by-status[]
 

--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -110,6 +110,23 @@ include::{snippets}/team/create/exception/host-existence/http-response.adoc[]
 |인터뷰가 종료된 상태이다.
 |===
 
+*Pagination*
+
+[cols="1,1"]
+|===
+|*Parameter*
+|*Default Value*
+
+|page
+|0
+
+|size
+|20
+
+|sort
+|인터뷰 종료 여부 기준 오름차순 정렬(아직 종료되지 않은 팀 -> 종료 된 팀), 생성일 기준 내림차순 정렬
+|===
+
 [[find-all-success]]
 === 팀 전체 목록 조회 성공
 
@@ -135,6 +152,23 @@ operation::team/find-all[]
 
 |closed
 |인터뷰가 종료된 팀 목록을 조회한다.
+|===
+
+*Pagination*
+
+[cols="1,1"]
+|===
+|*Parameter*
+|*Default Value*
+
+|page
+|0
+
+|size
+|20
+
+|sort
+|생성일 기준 내림차순 정렬
 |===
 
 [[find-all-by-status-success]]

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,9 +66,9 @@ public class TeamService {
         return savedTeam.getId();
     }
 
-    public TeamsDto findAll(final Optional<String> status, final Long memberId) {
+    public TeamsDto findAll(final Pageable pageable, final Optional<String> status, final Long memberId) {
         final List<Team> teams = status.map(this::findAllByIsClosedAndOrderByCreatedAt)
-                .orElseGet(this::findAllOrderByIsClosedAndCreatedAt);
+                .orElseGet(() -> findAllOrderByIsClosedAndCreatedAt(pageable));
 
         final List<TeamDto> teamDtos = toTeamDtos(memberId, teams);
 
@@ -89,13 +90,8 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
-    private List<Team> findAllOrderByIsClosedAndCreatedAt() {
-        final Sort sort = Sort.by(
-                Sort.Order.asc("isClosed"),
-                Sort.Order.desc("createdAt")
-        );
-
-        return teamRepository.findAll(sort);
+    private List<Team> findAllOrderByIsClosedAndCreatedAt(final Pageable pageable) {
+        return teamRepository.findAll(pageable).getContent();
     }
 
     public TeamDto findByTeamIdAndMemberId(final Long teamId, final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamService.java
@@ -67,7 +67,7 @@ public class TeamService {
     }
 
     public TeamsDto findAll(final Pageable pageable, final Optional<String> status, final Long memberId) {
-        final List<Team> teams = status.map(this::findAllByIsClosedAndOrderByCreatedAt)
+        final List<Team> teams = status.map(it -> findAllByIsClosedAndOrderByCreatedAt(pageable, it))
                 .orElseGet(() -> findAllOrderByIsClosedAndCreatedAt(pageable));
 
         final List<TeamDto> teamDtos = toTeamDtos(memberId, teams);
@@ -75,11 +75,9 @@ public class TeamService {
         return new TeamsDto(teamDtos);
     }
 
-    private List<Team> findAllByIsClosedAndOrderByCreatedAt(final String status) {
-        final List<Team> teams = teamRepository.findAllByIsClosed(
-                TeamStatus.checkClosed(status),
-                Sort.by(DESC, "createdAt")
-        );
+    private List<Team> findAllByIsClosedAndOrderByCreatedAt(final Pageable pageable, final String status) {
+        final List<Team> teams = teamRepository.findAllByIsClosed(TeamStatus.checkClosed(status), pageable)
+                .getContent();
 
         return filteringTeamByStatus(status, teams);
     }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamRepository.java
@@ -1,10 +1,10 @@
 package com.woowacourse.levellog.team.domain;
 
-import java.util.List;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
-    List<Team> findAllByIsClosed(boolean isClosed, Sort sort);
+    Page<Team> findAllByIsClosed(boolean isClosed, Pageable pageable);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamRepository.java
@@ -6,7 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
-    List<Team> findAll(Sort sort);
-
     List<Team> findAllByIsClosed(boolean isClosed, Sort sort);
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -42,7 +42,7 @@ public class TeamController {
 
     @GetMapping
     @PublicAPI
-    public ResponseEntity<TeamsDto> findAll(@PageableDefault(size = 20)
+    public ResponseEntity<TeamsDto> findAll(@PageableDefault(size = 100)
                                             @SortDefault.SortDefaults({
                                                     @SortDefault(sort = "isClosed", direction = Direction.ASC),
                                                     @SortDefault(sort = "createdAt", direction = Direction.DESC)

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -48,7 +48,7 @@ public class TeamController {
                                                     @SortDefault(sort = "isClosed", direction = Direction.ASC),
                                                     @SortDefault(sort = "createdAt", direction = Direction.DESC)
                                             }) final Pageable pageable,
-                                            @RequestParam final Optional<String> status,
+                                            @RequestParam(defaultValue = "all") final String status,
                                             @Authentic final Long memberId) {
         final TeamsDto response = teamService.findAll(pageable, status, memberId);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -12,6 +12,10 @@ import java.net.URI;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,9 +43,14 @@ public class TeamController {
 
     @GetMapping
     @PublicAPI
-    public ResponseEntity<TeamsDto> findAll(@RequestParam final Optional<String> status,
+    public ResponseEntity<TeamsDto> findAll(@PageableDefault(size = 20)
+                                            @SortDefault.SortDefaults({
+                                                    @SortDefault(sort = "isClosed", direction = Direction.ASC),
+                                                    @SortDefault(sort = "createdAt", direction = Direction.DESC)
+                                            }) final Pageable pageable,
+                                            @RequestParam final Optional<String> status,
                                             @Authentic final Long memberId) {
-        final TeamsDto response = teamService.findAll(status, memberId);
+        final TeamsDto response = teamService.findAll(pageable, status, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -9,7 +9,6 @@ import com.woowacourse.levellog.team.dto.TeamStatusDto;
 import com.woowacourse.levellog.team.dto.TeamWriteDto;
 import com.woowacourse.levellog.team.dto.TeamsDto;
 import java.net.URI;
-import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -89,7 +89,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("team/find-all"))
                 .when()
-                .get("/api/teams")
+                .get("/api/teams?page=0&size=3")
                 .then().log().all();
 
         // then

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -104,44 +104,6 @@ class TeamAcceptanceTest extends AcceptanceTest {
     }
 
     /*
-     * Scenario: 진행 상태로 필터링된 레벨 인터뷰 팀 목록 조회하기
-     *   given: 팀이 등록되어 있다.
-     *   when: 진행 중인 팀을 목록 조회를 요청한다.
-     *   then: 200 Ok 상태 코드와 최근 생성일 순으로 정렬된 모든 진행 중인 팀 목록을 응답받는다.
-     */
-    @Test
-    @DisplayName("필터링된 레벨 인터뷰 팀 전체 목록 조회하기")
-    void findAllTeam_filteringByTeamStatus_success() {
-        // given
-        PEPPER.save();
-        EVE.save();
-        RICK.save();
-        POBI.save();
-
-        saveTeam("잠실 제이슨조", PEPPER, 1, List.of(POBI), PEPPER, EVE);
-        saveTeam("잠실 브리조", EVE, 1, EVE, RICK);
-
-        timeStandard.setInProgress();
-
-        // when
-        final ValidatableResponse response = RestAssured.given(specification).log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + PEPPER.getToken())
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .filter(document("team/find-all/filtering-by-status"))
-                .when()
-                .get("/api/teams?status=in-progress")
-                .then().log().all();
-
-        // then
-        response.statusCode(HttpStatus.OK.value())
-                .body("teams.title", contains("잠실 브리조", "잠실 제이슨조"),
-                        "teams.hostId", contains(EVE.getId().intValue(), PEPPER.getId().intValue()),
-                        "teams.status", contains("IN_PROGRESS", "IN_PROGRESS"),
-                        "teams.isParticipant", contains(false, true),
-                        "teams.participants.nickname", contains(List.of("이브", "릭"), List.of("페퍼", "이브")));
-    }
-
-    /*
      * Scenario: 내가 속한 레벨 인터뷰 팀 상세 조회하기
      *   given: 팀이 등록되어 있다.
      *   given: 페퍼의 계정으로 로그인되어있다.

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -56,7 +56,7 @@ class TeamServiceTest extends ServiceTest {
             rickTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), Optional.empty(), rick.getId());
+            final TeamsDto response = teamService.findAll(getPageRequest(), "all", rick.getId());
 
             //then
             assertAll(
@@ -90,7 +90,7 @@ class TeamServiceTest extends ServiceTest {
             romaTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), Optional.of("ready"), rick.getId());
+            final TeamsDto response = teamService.findAll(getPageRequest(), "ready", rick.getId());
 
             //then
             assertAll(
@@ -122,7 +122,7 @@ class TeamServiceTest extends ServiceTest {
             romaTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), Optional.of("in-progress"), rick.getId());
+            final TeamsDto response = teamService.findAll(getPageRequest(), "in-progress", rick.getId());
 
             //then
             assertAll(
@@ -154,7 +154,7 @@ class TeamServiceTest extends ServiceTest {
             eveTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), Optional.of("closed"), rick.getId());
+            final TeamsDto response = teamService.findAll(getPageRequest(), "closed", rick.getId());
 
             //then
             assertAll(
@@ -174,7 +174,7 @@ class TeamServiceTest extends ServiceTest {
             final Member rick = saveMember("릭");
 
             // when & then
-            assertThatThrownBy(() -> teamService.findAll(getPageRequest(), Optional.of("invalid"), rick.getId()))
+            assertThatThrownBy(() -> teamService.findAll(getPageRequest(), "invalid", rick.getId()))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessageContaining("입력 받은 status가 올바르지 않습니다.");
         }
@@ -193,7 +193,7 @@ class TeamServiceTest extends ServiceTest {
             team.delete(BEFORE_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), Optional.empty(), rick.getId());
+            final TeamsDto response = teamService.findAll(getPageRequest(), "all", rick.getId());
 
             //then
             assertThat(response.getTeams()).hasSize(1);

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamServiceTest.java
@@ -56,7 +56,7 @@ class TeamServiceTest extends ServiceTest {
             rickTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), "all", rick.getId());
+            final TeamsDto response = teamService.findAll(getDefaultPageRequest(), "all", rick.getId());
 
             //then
             assertAll(
@@ -90,7 +90,7 @@ class TeamServiceTest extends ServiceTest {
             romaTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), "ready", rick.getId());
+            final TeamsDto response = teamService.findAll(getDefaultPageRequest(), "ready", rick.getId());
 
             //then
             assertAll(
@@ -122,7 +122,7 @@ class TeamServiceTest extends ServiceTest {
             romaTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), "in-progress", rick.getId());
+            final TeamsDto response = teamService.findAll(getDefaultPageRequest(), "in-progress", rick.getId());
 
             //then
             assertAll(
@@ -154,7 +154,7 @@ class TeamServiceTest extends ServiceTest {
             eveTeam.close(AFTER_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), "closed", rick.getId());
+            final TeamsDto response = teamService.findAll(getDefaultPageRequest(), "closed", rick.getId());
 
             //then
             assertAll(
@@ -174,7 +174,7 @@ class TeamServiceTest extends ServiceTest {
             final Member rick = saveMember("릭");
 
             // when & then
-            assertThatThrownBy(() -> teamService.findAll(getPageRequest(), "invalid", rick.getId()))
+            assertThatThrownBy(() -> teamService.findAll(getDefaultPageRequest(), "invalid", rick.getId()))
                     .isInstanceOf(InvalidFieldException.class)
                     .hasMessageContaining("입력 받은 status가 올바르지 않습니다.");
         }
@@ -193,13 +193,13 @@ class TeamServiceTest extends ServiceTest {
             team.delete(BEFORE_START_TIME);
 
             //when
-            final TeamsDto response = teamService.findAll(getPageRequest(), "all", rick.getId());
+            final TeamsDto response = teamService.findAll(getDefaultPageRequest(), "all", rick.getId());
 
             //then
             assertThat(response.getTeams()).hasSize(1);
         }
 
-        private PageRequest getPageRequest() {
+        private PageRequest getDefaultPageRequest() {
             final Sort sort = Sort.by(
                     Sort.Order.asc("isClosed"),
                     Sort.Order.desc("createdAt")

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
@@ -27,7 +27,7 @@ class TeamRepositoryTest extends RepositoryTest {
     class FindAll {
 
         @Test
-        @DisplayName("입력 받은 Sort 조건에 따라 정렬된 Page를 반환한다.")
+        @DisplayName("입력 받은 Sort 조건에 따라 정렬된 팀 List를 반환한다.")
         void findAll_sorting_success() {
             // given
             final Team team1 = saveTeam("잠실 네오조");
@@ -53,7 +53,7 @@ class TeamRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        @DisplayName("입력 받은 페이징 조건에 따라 페이징 된 Page를 반환한다.")
+        @DisplayName("입력 받은 페이징 조건에 따라 페이징 된 팀 List를 반환한다.")
         void findAll_paging_success() {
             // given
             saveTeam("잠실 네오조");

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
@@ -41,10 +42,10 @@ class TeamRepositoryTest extends RepositoryTest {
                     Sort.Order.asc("isClosed"),
                     Sort.Order.desc("createdAt")
             );
-            final PageRequest pageRequest = PageRequest.of(0, 4, sort);
+            final Pageable pageable = PageRequest.of(0, 4, sort);
 
             // when
-            final Page<Team> teamResult = teamRepository.findAll(pageRequest);
+            final Page<Team> teamResult = teamRepository.findAll(pageable);
 
             // then
             final List<Team> teams = teamResult.getContent();
@@ -52,7 +53,7 @@ class TeamRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        @DisplayName("입력 받은 Paging 조건에 따라 페이징된 Page를 반환한다.")
+        @DisplayName("입력 받은 페이징 조건에 따라 페이징 된 Page를 반환한다.")
         void findAll_paging_success() {
             // given
             saveTeam("잠실 네오조");
@@ -64,24 +65,24 @@ class TeamRepositoryTest extends RepositoryTest {
                     Sort.Order.asc("isClosed"),
                     Sort.Order.desc("createdAt")
             );
-            final PageRequest pageRequest = PageRequest.of(1, 2, sort);
+            final Pageable pageable = PageRequest.of(1, 2, sort);
 
             // when
-            final Page<Team> teamResult = teamRepository.findAll(pageRequest);
+            final Page<Team> teamResult = teamRepository.findAll(pageable);
 
             // then
             final List<Team> teams = teamResult.getContent();
-            Assertions.assertAll( () -> {
+            Assertions.assertAll(() -> {
                 assertThat(teams.size()).isEqualTo(2);
-                assertThat(teamResult.getNumber()).isEqualTo(1);
-                assertThat(teamResult.getTotalElements()).isEqualTo(4);
-                assertThat(teamResult.getTotalPages()).isEqualTo(2);
+                assertThat(teamResult.getNumber()).isEqualTo(1); // 현재 페이지 번호
+                assertThat(teamResult.getTotalElements()).isEqualTo(4); // 페이징 되지 않은 데이터 포함 전체 데이터 개수
+                assertThat(teamResult.getTotalPages()).isEqualTo(2); // 총 페이지 개수
             });
         }
     }
 
     @Test
-    @DisplayName("findAllByIsClosed 메소드는 입력 받은 팀 종료 여부와 Sort 조건에 따라 필터링된 List를 반환한다.")
+    @DisplayName("findAllByIsClosed 메소드는 입력 받은 팀 종료 여부와 페이징 조건에 따라 필터링, 페이징 된 List를 반환한다.")
     void findAllByIsClosed() {
         // given
         final Team team1 = saveTeam("잠실 네오조");
@@ -92,12 +93,17 @@ class TeamRepositoryTest extends RepositoryTest {
         team3.close(TimeFixture.AFTER_START_TIME);
         team4.close(TimeFixture.AFTER_START_TIME);
 
-        final Sort sort = Sort.by(Direction.DESC, "createdAt");
+        final Pageable pageable = PageRequest.of(0, 4, Sort.by(Direction.DESC, "createdAt"));
 
         // when
-        final List<Team> closedTeam = teamRepository.findAllByIsClosed(true, sort);
+        final Page<Team> teamResult = teamRepository.findAllByIsClosed(true, pageable);
 
         // then
-        assertThat(closedTeam).containsExactly(team4, team3);
+        final List<Team> closedTeams = teamResult.getContent();
+        Assertions.assertAll(() -> {
+            assertThat(closedTeams).containsExactly(team4, team3);
+            assertThat(teamResult.getNumber()).isEqualTo(0);
+            assertThat(teamResult.getTotalElements()).isEqualTo(2);
+        });
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
@@ -5,8 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.levellog.fixture.TimeFixture;
 import com.woowacourse.levellog.team.domain.Team;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
@@ -17,28 +21,63 @@ class TeamRepositoryTest extends RepositoryTest {
         return teamRepository.save(new Team(title, "트랙룸", TimeFixture.TEAM_START_TIME, "jamsil.img", 1));
     }
 
-    @Test
-    @DisplayName("findAll 메소드는 입력 받은 Sort 조건에 따라 정렬된 List를 반환한다.")
-    void findAll() {
-        // given
-        final Team team1 = saveTeam("잠실 네오조");
-        final Team team2 = saveTeam("잠실 제이슨조");
-        final Team team3 = saveTeam("잠실 토미조");
-        final Team team4 = saveTeam("잠실 브리조");
+    @Nested
+    @DisplayName("findAll 메서드는")
+    class FindAll {
 
-        team3.close(TimeFixture.AFTER_START_TIME);
-        team4.close(TimeFixture.AFTER_START_TIME);
+        @Test
+        @DisplayName("입력 받은 Sort 조건에 따라 정렬된 Page를 반환한다.")
+        void findAll_sorting_success() {
+            // given
+            final Team team1 = saveTeam("잠실 네오조");
+            final Team team2 = saveTeam("잠실 제이슨조");
+            final Team team3 = saveTeam("잠실 토미조");
+            final Team team4 = saveTeam("잠실 브리조");
 
-        final Sort sort = Sort.by(
-                Sort.Order.asc("isClosed"),
-                Sort.Order.desc("createdAt")
-        );
+            team3.close(TimeFixture.AFTER_START_TIME);
+            team4.close(TimeFixture.AFTER_START_TIME);
 
-        // when
-        final List<Team> teams = teamRepository.findAll(sort);
+            final Sort sort = Sort.by(
+                    Sort.Order.asc("isClosed"),
+                    Sort.Order.desc("createdAt")
+            );
+            final PageRequest pageRequest = PageRequest.of(0, 4, sort);
 
-        // then
-        assertThat(teams).containsExactly(team2, team1, team4, team3);
+            // when
+            final Page<Team> teamResult = teamRepository.findAll(pageRequest);
+
+            // then
+            final List<Team> teams = teamResult.getContent();
+            assertThat(teams).containsExactly(team2, team1, team4, team3);
+        }
+
+        @Test
+        @DisplayName("입력 받은 Paging 조건에 따라 페이징된 Page를 반환한다.")
+        void findAll_paging_success() {
+            // given
+            saveTeam("잠실 네오조");
+            saveTeam("잠실 제이슨조");
+            saveTeam("잠실 토미조");
+            saveTeam("잠실 브리조");
+
+            final Sort sort = Sort.by(
+                    Sort.Order.asc("isClosed"),
+                    Sort.Order.desc("createdAt")
+            );
+            final PageRequest pageRequest = PageRequest.of(1, 2, sort);
+
+            // when
+            final Page<Team> teamResult = teamRepository.findAll(pageRequest);
+
+            // then
+            final List<Team> teams = teamResult.getContent();
+            Assertions.assertAll( () -> {
+                assertThat(teams.size()).isEqualTo(2);
+                assertThat(teamResult.getNumber()).isEqualTo(1);
+                assertThat(teamResult.getTotalElements()).isEqualTo(4);
+                assertThat(teamResult.getTotalPages()).isEqualTo(2);
+            });
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamRepositoryTest.java
@@ -102,7 +102,7 @@ class TeamRepositoryTest extends RepositoryTest {
         final List<Team> closedTeams = teamResult.getContent();
         Assertions.assertAll(() -> {
             assertThat(closedTeams).containsExactly(team4, team3);
-            assertThat(teamResult.getNumber()).isEqualTo(0);
+            assertThat(teamResult.getNumber()).isZero();
             assertThat(teamResult.getTotalElements()).isEqualTo(2);
         });
     }

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -21,7 +21,6 @@ import com.woowacourse.levellog.team.exception.TeamNotReadyException;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ class TeamControllerTest extends ControllerTest {
 
         willThrow(new InvalidFieldException(message, DebugMessage.init()))
                 .given(teamService)
-                .findAll(PageRequest.of(0, 20, sort), Optional.of(invalidStatus), 1L);
+                .findAll(PageRequest.of(0, 20, sort), invalidStatus, 1L);
 
         // when
         final ResultActions perform = requestGet("/api/teams?status=" + invalidStatus);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("TeamController의")
@@ -40,9 +42,14 @@ class TeamControllerTest extends ControllerTest {
         final String invalidStatus = "invalid";
         final String message = "입력 받은 status가 올바르지 않습니다.";
 
+        final Sort sort = Sort.by(
+                Sort.Order.asc("isClosed"),
+                Sort.Order.desc("createdAt")
+        );
+
         willThrow(new InvalidFieldException(message, DebugMessage.init()))
                 .given(teamService)
-                .findAll(Optional.of(invalidStatus), 1L);
+                .findAll(PageRequest.of(0, 20, sort), Optional.of(invalidStatus), 1L);
 
         // when
         final ResultActions perform = requestGet("/api/teams?status=" + invalidStatus);

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/TeamControllerTest.java
@@ -34,6 +34,9 @@ import org.springframework.test.web.servlet.ResultActions;
 @DisplayName("TeamController의")
 class TeamControllerTest extends ControllerTest {
 
+    public static final int DEFAULT_PAGE = 0;
+    public static final int DEFAULT_SIZE = 100;
+
     @Test
     @DisplayName("findAll 메서드는 status로 잘못된 값을 입력 받으면 예외가 발생한다.")
     void findAll_invalidStatus_exception() throws Exception {
@@ -48,7 +51,7 @@ class TeamControllerTest extends ControllerTest {
 
         willThrow(new InvalidFieldException(message, DebugMessage.init()))
                 .given(teamService)
-                .findAll(PageRequest.of(0, 20, sort), invalidStatus, 1L);
+                .findAll(PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE, sort), invalidStatus, 1L);
 
         // when
         final ResultActions perform = requestGet("/api/teams?status=" + invalidStatus);


### PR DESCRIPTION
## 구현 기능
- 팀 목록 조회 기능에 페이징 적용
- 쿼리 파라미터 Optional 제거, defaultValue 설정

## 공유하고 싶은 내용
- 기존 API 응답 스펙의 변경 없이 구현하다 보니 현재 페이징 정보(전체 페이지 수, 현재 페이지 넘버, 전체 데이터 개수 등)를 전혀 활용하고 있지 않는 상태입니다. 추후 프론트에서도 페이징을 적용할 때 합의 후 응답 API를 변경해야 합니다.
- default size를 20으로 설정해놨기 때문에 요청 시 최대 20개의 데이터만 반환됩니다. 

Close #372 