### PR TITLE
fix: HttpMessageNotReadableException 핸들러 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
@@ -17,7 +17,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        logInfo(e);
+        log.info("{} : {}", ((Exception) e).getClass().getSimpleName(), e.getMessage());
         return toResponseEntity(e.getClientMessage(), e.getHttpStatus());
     }
 
@@ -32,7 +32,6 @@ public class ControllerAdvice {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
             final HttpMessageNotReadableException e) {
-        logInfo(e);
         return toResponseEntity("RequestBody가 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
     }
 
@@ -48,7 +47,4 @@ public class ControllerAdvice {
                 .body(response);
     }
 
-    private void logInfo(final Exception e) {
-        log.info("{} : {}", e.getClass().getSimpleName(), e.getMessage());
-    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/presentation/ControllerAdvice.java
@@ -5,6 +5,7 @@ import com.woowacourse.levellog.common.exception.LevellogException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,7 +17,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(LevellogException.class)
     public ResponseEntity<ExceptionResponse> handleLevellogException(final LevellogException e) {
-        log.info("{} : {}", e.getClass().getSimpleName(), e.getMessage());
+        logInfo(e);
         return toResponseEntity(e.getClientMessage(), e.getHttpStatus());
     }
 
@@ -28,6 +29,13 @@ public class ControllerAdvice {
         return toResponseEntity(message, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
+            final HttpMessageNotReadableException e) {
+        logInfo(e);
+        return toResponseEntity("RequestBody가 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleUnexpectedException(final Exception e) {
         log.warn("Internal server error", e);
@@ -36,8 +44,11 @@ public class ControllerAdvice {
 
     private ResponseEntity<ExceptionResponse> toResponseEntity(final String message, final HttpStatus httpStatus) {
         final ExceptionResponse response = new ExceptionResponse(message);
-        return ResponseEntity
-                .status(httpStatus)
+        return ResponseEntity.status(httpStatus)
                 .body(response);
+    }
+
+    private void logInfo(final Exception e) {
+        log.info("{} : {}", e.getClass().getSimpleName(), e.getMessage());
     }
 }


### PR DESCRIPTION
## 구현 기능
- HttpMessageNotReadableException 핸들러 구현

## 논의하고 싶은 내용
- 논의할 내용을 적습니다.

## 공유하고 싶은 내용
- `HttpMessageNotReadableException`은 RequestBody를 MessageConvertor가 coverting에 실패하는 경우 터지는 예외여서 메시지를 `RequestBody가 올바르지 않습니다.`라고 하였습니당


Close #376
