### PR TITLE
feat: 요청에서 에러가 발생해도 정상동작처럼 navigate되는 버그를 수정

### DIFF
--- a/frontend/src/components/teams/TeamForm.tsx
+++ b/frontend/src/components/teams/TeamForm.tsx
@@ -169,7 +169,7 @@ const S = {
     border-radius: 1.25rem;
     box-shadow: 0.0625rem 0.25rem 0.625rem ${(props) => props.theme.new_default.GRAY};
     @media (min-width: 560px) and (max-width: 760px) {
-      width: 520px;
+      width: 32.5rem;
     }
     @media (max-width: 560px) {
       justify-content: center;
@@ -201,8 +201,8 @@ const S = {
     flex-wrap: wrap;
     overflow: auto;
     gap: 0.5rem;
-    width: 42.625rem;
-    padding-bottom: 16px;
+    width: 100%;
+    padding-bottom: 1rem;
     @media (min-width: 560px) and (max-width: 760px) {
       width: 27.5rem;
     }
@@ -219,31 +219,19 @@ const S = {
 
   MembersBox: styled.div<{ isNoneMember: Boolean }>`
     display: ${(props) => (props.isNoneMember ? 'none' : 'block')};
-    box-sizing: content-box;
+    box-sizing: border-box;
     overflow: auto;
-    width: 40.625rem;
+    width: 100%;
     height: 10rem;
     padding: 1rem;
     border: 0.0625rem solid ${(props) => props.theme.default.GRAY};
     border-radius: 0.3125rem;
     background-color: ${(props) => props.theme.default.WHITE};
-    @media (min-width: 560px) and (max-width: 760px) {
-      width: 27.5rem;
-    }
-    @media (max-width: 560px) {
-      width: calc(100vw - 5rem);
-    }
   `,
 
   SubmitButton: styled(Button)`
-    width: 42.625rem;
+    width: 100%;
     height: 3.125rem;
-    @media (min-width: 560px) and (max-width: 760px) {
-      width: 27.5rem;
-    }
-    @media (max-width: 560px) {
-      width: calc(100vw - 5rem);
-    }
   `,
 };
 

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -43,15 +43,15 @@ export const MESSAGE = Object.freeze({
   TEAM_EDIT: '팀 수정이 완료되었습니다.',
 
   FEEDBACK_CREATE: '피드백 작성이 완료되었습니다.',
-  FEEDBACK_EDIT_CONFIRM: '피드백 수정이 완료되었습니다.',
-  FEEDBACK_SAVE_CONFIRM: '피드백 저장이 완료되었습니다.',
+  FEEDBACK_EDIT: '피드백 수정이 완료되었습니다.',
+  FEEDBACK_SAVE: '피드백 저장이 완료되었습니다.',
 
-  LEVELLOG_ADD_CONFIRM: '레벨로그 작성이 완료되었습니다.',
-  LEVELLOG_EDIT_CONFIRM: '레벨로그 수정이 완료되었습니다.',
+  LEVELLOG_ADD: '레벨로그 작성이 완료되었습니다.',
+  LEVELLOG_EDIT: '레벨로그 수정이 완료되었습니다.',
 
-  PREQUESTION_ADD_CONFIRM: '사전질문 등록이 완료되었습니다.',
-  PREQUESTION_DELETE_CONFIRM: '사전질문 삭제가 완료되었습니다.',
-  PREQUESTION_EDIT_CONFIRM: '사전질문 수정이 완료되었습니다.',
+  PREQUESTION_ADD: '사전질문 등록이 완료되었습니다.',
+  PREQUESTION_DELETE: '사전질문 삭제가 완료되었습니다.',
+  PREQUESTION_EDIT: '사전질문 수정이 완료되었습니다.',
 
   INTERVIEW_CLOSE_CONFIRM: '정말로 인터뷰를 종료하시겠습니까?',
   INTERVIEW_STATUS_NOT_READY: '인터뷰가 시작 전이 아닙니다!',

--- a/frontend/src/hooks/useFeedback.ts
+++ b/frontend/src/hooks/useFeedback.ts
@@ -23,7 +23,6 @@ const useFeedback = () => {
   const [feedbacks, setFeedbacks] = useState<FeedbackType[]>([]);
   const feedbackRef = useRef<Editor[]>([]);
   const navigate = useNavigate();
-
   const accessToken = localStorage.getItem('accessToken');
 
   const postFeedback = async ({
@@ -32,7 +31,8 @@ const useFeedback = () => {
   }: Pick<FeedbackCustomHookType, 'levellogId' | 'feedbackResult'>) => {
     try {
       await requestPostFeedback({ accessToken, levellogId, feedbackResult });
-      showSnackbar({ message: MESSAGE.FEEDBACK_CREATE });
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -90,6 +90,8 @@ const useFeedback = () => {
   }: Pick<FeedbackCustomHookType, 'levellogId' | 'feedbackId' | 'feedbackResult'>) => {
     try {
       await requestEditFeedback({ accessToken, levellogId, feedbackId, feedbackResult });
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -115,8 +117,10 @@ const useFeedback = () => {
       },
     };
 
-    await postFeedback({ levellogId, feedbackResult });
-    navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
+    if (await postFeedback({ levellogId, feedbackResult })) {
+      showSnackbar({ message: MESSAGE.FEEDBACK_CREATE });
+      navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
+    }
   };
 
   const onClickFeedbackEditButton = async ({
@@ -133,9 +137,10 @@ const useFeedback = () => {
       },
     };
 
-    await editFeedback({ levellogId, feedbackId, feedbackResult });
-    showSnackbar({ message: MESSAGE.FEEDBACK_EDIT_CONFIRM });
-    navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
+    if (await editFeedback({ levellogId, feedbackId, feedbackResult })) {
+      showSnackbar({ message: MESSAGE.FEEDBACK_EDIT });
+      navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
+    }
   };
 
   const getFeedbackOnRef = async ({

--- a/frontend/src/hooks/useFeedbackAddPage.ts
+++ b/frontend/src/hooks/useFeedbackAddPage.ts
@@ -48,7 +48,6 @@ const useFeedbackAddPage = () => {
 
       return;
     }
-
     showSnackbar({ message: MESSAGE.WRONG_ACCESS });
     navigate(ROUTES_PATH.ERROR);
   };

--- a/frontend/src/hooks/useLevellog.ts
+++ b/frontend/src/hooks/useLevellog.ts
@@ -20,7 +20,6 @@ const useLevellog = () => {
   const [levellogInfo, setLevellogInfo] = useState<LevellogInfoType>(
     {} as unknown as LevellogInfoType,
   );
-
   const accessToken = localStorage.getItem('accessToken');
 
   const postLevellog = async ({
@@ -33,7 +32,8 @@ const useLevellog = () => {
         teamId,
         levellogContent: { content: inputValue },
       });
-      navigate(teamGetUriBuilder({ teamId }));
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -77,8 +77,8 @@ const useLevellog = () => {
         levellogId,
         levellogContent: { content: inputValue },
       });
-      showSnackbar({ message: MESSAGE.LEVELLOG_EDIT_CONFIRM });
-      navigate(teamGetUriBuilder({ teamId }));
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -101,26 +101,35 @@ const useLevellog = () => {
     }
   };
 
-  const onClickLevellogAddButton = ({ teamId }: Pick<LevellogCustomHookType, 'teamId'>) => {
-    if (levellogRef.current) {
-      postLevellog({
+  const onClickLevellogAddButton = async ({ teamId }: Pick<LevellogCustomHookType, 'teamId'>) => {
+    if (!levellogRef.current) return;
+
+    if (
+      await postLevellog({
         teamId,
         inputValue: levellogRef.current.getInstance().getEditorElements().mdEditor.innerText,
-      });
-      showSnackbar({ message: MESSAGE.LEVELLOG_ADD_CONFIRM });
+      })
+    ) {
+      showSnackbar({ message: MESSAGE.LEVELLOG_ADD });
+      navigate(teamGetUriBuilder({ teamId }));
     }
   };
 
-  const onClickLevellogEditButton = ({
+  const onClickLevellogEditButton = async ({
     teamId,
     levellogId,
   }: Omit<LevellogCustomHookType, 'inputValue'>) => {
-    if (levellogRef.current) {
-      editLevellog({
+    if (!levellogRef.current) return;
+
+    if (
+      await editLevellog({
         teamId,
         levellogId,
         inputValue: levellogRef.current.getInstance().getEditorElements().mdEditor.innerText,
-      });
+      })
+    ) {
+      showSnackbar({ message: MESSAGE.LEVELLOG_EDIT });
+      navigate(teamGetUriBuilder({ teamId }));
     }
   };
 

--- a/frontend/src/hooks/usePreQuestion.ts
+++ b/frontend/src/hooks/usePreQuestion.ts
@@ -57,7 +57,8 @@ const usePreQuestion = () => {
         levellogId,
         preQuestionResult: { content: preQuestionContent },
       });
-      navigate(teamGetUriBuilder({ teamId }));
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -76,6 +77,8 @@ const usePreQuestion = () => {
   }: Pick<PreQuestionCustomHookType, 'levellogId' | 'preQuestionId'>) => {
     try {
       await requestDeletePreQuestion({ accessToken, levellogId, preQuestionId });
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -89,7 +92,6 @@ const usePreQuestion = () => {
   };
 
   const editPreQuestion = async ({
-    teamId,
     levellogId,
     preQuestionId,
     preQuestionContent,
@@ -101,7 +103,8 @@ const usePreQuestion = () => {
         preQuestionId,
         preQuestionResult: { content: preQuestionContent },
       });
-      navigate(teamGetUriBuilder({ teamId }));
+
+      return true;
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -133,14 +136,18 @@ const usePreQuestion = () => {
     teamId,
     levellogId,
   }: Pick<PreQuestionCustomHookType, 'teamId' | 'levellogId'>) => {
-    if (preQuestionRef.current) {
+    if (!preQuestionRef.current) return;
+
+    if (
       await postPreQuestion({
         teamId,
         levellogId,
         preQuestionContent: preQuestionRef.current.getInstance().getEditorElements().mdEditor
           .innerText,
-      });
-      showSnackbar({ message: MESSAGE.PREQUESTION_ADD_CONFIRM });
+      })
+    ) {
+      showSnackbar({ message: MESSAGE.PREQUESTION_ADD });
+      navigate(teamGetUriBuilder({ teamId }));
     }
   };
 
@@ -149,17 +156,20 @@ const usePreQuestion = () => {
     levellogId,
     preQuestionId,
   }: Pick<PreQuestionCustomHookType, 'teamId' | 'levellogId' | 'preQuestionId'>) => {
-    if (preQuestionRef.current) {
+    if (!preQuestionRef.current) return;
+
+    if (
       await editPreQuestion({
         teamId,
         levellogId,
         preQuestionId,
         preQuestionContent: preQuestionRef.current.getInstance().getEditorElements().mdEditor
           .innerText,
-      });
-      showSnackbar({ message: MESSAGE.PREQUESTION_EDIT_CONFIRM });
+      })
+    ) {
+      showSnackbar({ message: MESSAGE.PREQUESTION_EDIT });
+      navigate(teamGetUriBuilder({ teamId }));
     }
-    navigate(teamGetUriBuilder({ teamId }));
   };
 
   return {

--- a/frontend/src/hooks/usePreQuestionModal.ts
+++ b/frontend/src/hooks/usePreQuestionModal.ts
@@ -30,7 +30,7 @@ const usePreQuestionModal = () => {
       preQuestionId,
     });
     onClickCloseModal();
-    showSnackbar({ message: MESSAGE.PREQUESTION_DELETE_CONFIRM });
+    showSnackbar({ message: MESSAGE.PREQUESTION_DELETE });
   };
 
   return {

--- a/frontend/src/hooks/useTeam.ts
+++ b/frontend/src/hooks/useTeam.ts
@@ -116,7 +116,6 @@ const useTeam = () => {
     try {
       await requestDeleteTeam({ teamId, accessToken });
       showSnackbar({ message: MESSAGE.TEAM_DELETE });
-      navigate(ROUTES_PATH.HOME);
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err instanceof Error) {
         const responseBody: AxiosResponse = err.response!;
@@ -133,7 +132,6 @@ const useTeam = () => {
     try {
       await requestCloseTeamInterview({ teamId, accessToken });
       showSnackbar({ message: MESSAGE.INTERVIEW_CLOSE });
-      navigate(ROUTES_PATH.HOME);
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
         const responseBody: AxiosResponse = err.response!;
@@ -145,18 +143,18 @@ const useTeam = () => {
     }
   };
 
-  const handleClickDeleteTeamButton = () => {
+  const handleClickDeleteTeamButton = async () => {
     if (confirm(MESSAGE.TEAM_DELETE_CONFIRM) && typeof teamId === 'string') {
-      deleteTeam({ teamId });
+      await deleteTeam({ teamId });
       navigate(ROUTES_PATH.HOME);
 
       return;
     }
   };
 
-  const handleClickCloseTeamInterviewButton = () => {
+  const handleClickCloseTeamInterviewButton = async () => {
     if (confirm(MESSAGE.INTERVIEW_CLOSE_CONFIRM) && typeof teamId === 'string') {
-      closeTeamInterview({ teamId });
+      await closeTeamInterview({ teamId });
       navigate(ROUTES_PATH.HOME);
 
       return;

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import profileDefaultImage from 'assets/images/defaultProfile.png';
 import { GITHUB_LOGIN_URL, ROUTES_PATH } from 'constants/constants';
 
+import useTeams from './useTeams';
 import { UserContext, UserDispatchContext } from 'contexts/userContext';
 
 const useUser = () => {
@@ -11,6 +12,7 @@ const useUser = () => {
   const { id, nickname, profileUrl } = useContext(UserContext);
   const userInfoDispatch = useContext(UserDispatchContext);
   const navigate = useNavigate();
+  const { getTeams } = useTeams();
 
   const handleClickProfile = () => {
     if (id) {
@@ -26,11 +28,13 @@ const useUser = () => {
     target.src = `${profileDefaultImage}`;
   };
 
-  const handleClickLogoutButton = () => {
+  const handleClickLogoutButton = async () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('userId');
+
     userInfoDispatch({ id: '', nickname: '', profileUrl: '' });
     setIsShowProfileDropdown(false);
+    if (location.pathname === ROUTES_PATH.HOME) await getTeams();
     navigate(ROUTES_PATH.HOME);
   };
 


### PR DESCRIPTION
## 구현 기능
 - 에러가 발생했음에도 정상동작과 같이 navigate시키는 코드 수정
 - 팀 전체 조회 페이지에서 로그아웃 시, 전체 팀 조회를 하도록 수정
 - 인터뷰 종료, 팀 삭제 시, 팀 정보 다시 불러오기

## 공유하고 싶은 내용
- 시간 상의 문제로 조악한 코드가 많지만 PR을 보냅니다. 
- 이어서 관련 리팩터링 이슈를 발생해서 우선순위를 고려해처리하는 것으로 해결해야할 것 같습니다.

Close #395 
