### PR TITLE
fix: 팀 목록 조회 버그 수정

### DIFF
--- a/backend/src/docs/asciidoc/team.adoc
+++ b/backend/src/docs/asciidoc/team.adoc
@@ -138,9 +138,13 @@ include::{snippets}/team/create/exception/host-existence/http-response.adoc[]
 |===
 
 [[find-all-success]]
-=== 팀 목록 조회 성공
+=== 팀 목록 조회 성공 ( condition = open )
 
 operation::team/find-all[]
+
+=== 팀 목록 조회 성공 ( condition = close )
+
+operation::team/find-all/close[]
 
 [[find-all-exception]]
 === 팀 목록 조회 예외

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
@@ -53,10 +53,10 @@ public class TeamQueryRepository {
                     + "(SELECT * "
                     + "FROM team "
                     + "WHERE deleted = FALSE AND is_closed = ? "
+                    + "ORDER BY is_closed ASC, created_at DESC "
                     + "LIMIT ? OFFSET ?) AS t "
-                    + "INNER JOIN participant p ON p.team_id = t.id AND p.is_watcher = FALSE "
-                    + "INNER JOIN member m ON m.id = p.member_id "
-                + "ORDER BY t.is_closed ASC, t.created_at DESC";
+                + "INNER JOIN participant p ON p.team_id = t.id AND p.is_watcher = FALSE "
+                + "INNER JOIN member m ON m.id = p.member_id";
 
         return jdbcTemplate.query(sql, simpleRowMapper, isClosed, limit, offset);
     }

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -42,11 +42,10 @@ public class TeamController {
     @GetMapping
     @PublicAPI
     public ResponseEntity<TeamListDto> findAll(@RequestParam(defaultValue = "open") final String condition,
-                                               @RequestParam(defaultValue = "0") final String page,
-                                               @RequestParam(defaultValue = "20") final String size) {
+                                               @RequestParam(defaultValue = "0") final int page,
+                                               @RequestParam(defaultValue = "20") final int size) {
         final TeamFilterCondition filterCondition = TeamFilterCondition.from(condition);
-        final TeamListDto response = teamQueryService.findAll(filterCondition, Integer.parseInt(page),
-                Integer.parseInt(size));
+        final TeamListDto response = teamQueryService.findAll(filterCondition, page, size);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -65,7 +65,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
     /*
      * Scenario: 레벨 인터뷰 진행중인 팀 목록 조회하기
      *   given: 팀이 등록되어 있다.
-     *   when: 팀을 진행중인 인터뷰 목록 조회를 요청한다.
+     *   when: 팀을 진행중인 인터뷰 목록 조회를 요청한다. 첫 번째 페이지에서 2개만 보여지도록 요청한다.
      *   then: 200 Ok 상태 코드와 진행 혹은 준비 상태의 팀 목록을 최근 생성일 순으로 정렬한 응답을 받는다.
      */
     @Test
@@ -90,17 +90,16 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("team/find-all"))
                 .when()
-                .get("/api/teams?condition=open")
+                .get("/api/teams?condition=open&size=2&page=0")
                 .then().log().all();
 
         // then
         response.statusCode(HttpStatus.OK.value())
-                .body("teams.title", contains("잠실 포비조", "잠실 브리조", "잠실 제이슨조"),
-                        "teams.status", contains("READY", "IN_PROGRESS", "IN_PROGRESS"),
+                .body("teams.title", contains("잠실 포비조", "잠실 브리조"),
+                        "teams.status", contains("READY", "IN_PROGRESS"),
                         "teams.participants.memberId", contains(
                                 List.of(RICK.getId().intValue()),
-                                List.of(EVE.getId().intValue(), RICK.getId().intValue()),
-                                List.of(PEPPER.getId().intValue(), EVE.getId().intValue())
+                                List.of(EVE.getId().intValue(), RICK.getId().intValue())
                         )
                 );
     }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/TeamAcceptanceTest.java
@@ -66,7 +66,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
      * Scenario: 레벨 인터뷰 진행중인 팀 목록 조회하기
      *   given: 팀이 등록되어 있다.
      *   when: 팀을 진행중인 인터뷰 목록 조회를 요청한다.
-     *   then: 200 Ok 상태 코드와 진행 혹은 준비 상태의 팀 목록을 최근 생성일 순으로 정렬한 응답받는다.
+     *   then: 200 Ok 상태 코드와 진행 혹은 준비 상태의 팀 목록을 최근 생성일 순으로 정렬한 응답을 받는다.
      */
     @Test
     @DisplayName("레벨 인터뷰 진행중인 팀 목록 조회하기")
@@ -90,7 +90,7 @@ class TeamAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .filter(document("team/find-all"))
                 .when()
-                .get("/api/teams?status=open")
+                .get("/api/teams?condition=open")
                 .then().log().all();
 
         // then


### PR DESCRIPTION
## 구현 기능
- 팀 목록 조회 버그를 수정함
  - Order by가 전체 쿼리에 걸려있어 최신순으로 가져오지 않고 잘못 가져오고 있었음 팀 조회 서브쿼리에서 order by를 설정하는 것으로 변경
  - 팀 목록 조회 컨트롤러의 파라미터 타입을 변경했다.
  - 팀 목록 조회 문서화에 페이징 조건을 추가했다.

## 논의하고 싶은 내용
- fix이므로 급합니다. 얼른 머지해주세요.

Close #없슈
