### PR TITLE
fix: LIKE 키워드 사용 시 SQL Injection 방지 버그 수정

### DIFF
--- a/backend/src/docs/asciidoc/interviewquestionsearch.adoc
+++ b/backend/src/docs/asciidoc/interviewquestionsearch.adoc
@@ -42,6 +42,13 @@ operation::interview-question-search/search-sort-updated-at-asc[]
 
 operation::interview-question-search/search-sort-likes-desc[]
 
+[[search-exception]]
+=== 검색 관련 실패
+
+==== % 문자를 입력 한 경우
+
+include::{snippets}/interview-question-search/likes/exception/input-percent/http-response.adoc[]
+
 [[like]]
 == 좋아요 관련
 

--- a/backend/src/main/java/com/woowacourse/levellog/common/support/StringConverter.java
+++ b/backend/src/main/java/com/woowacourse/levellog/common/support/StringConverter.java
@@ -1,0 +1,13 @@
+package com.woowacourse.levellog.common.support;
+
+import java.util.regex.Pattern;
+
+public class StringConverter {
+
+    final static Pattern INJECTION_PATTERN_CHARACTERS = Pattern.compile("['\"\\-#()@;=*/+]");
+
+    public static String toSafeString(final String input) {
+        return INJECTION_PATTERN_CHARACTERS.matcher(input)
+                .replaceAll("");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.interviewquestion.domain;
 
+import com.woowacourse.levellog.common.support.StringConverter;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultDto;
 import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -25,16 +26,15 @@ public class InterviewQuestionQueryRepository {
     public List<InterviewQuestionSearchResultDto> searchByKeyword(final String keyword, final Long memberId,
                                                                   final Long size, final Long page,
                                                                   final InterviewQuestionSort sort) {
-        final String wrappedKeyword = "'%" + keyword + "%'";
         final String sql = "SELECT id, content, "
                 + "(select CASE WHEN (id IN (select interview_question_id from interview_question_likes where liker_id = ?)) "
                 + "THEN true ELSE false END ) AS press, "
                 + "like_count AS likeCount "
                 + "FROM interview_question "
-                + "WHERE content LIKE ? "
+                + "WHERE content LIKE '%" + StringConverter.toSafeString(keyword) + "%' "
                 + String.format("ORDER BY %s %s ", sort.getField(), sort.getOrder())
                 + "LIMIT ? OFFSET ?";
 
-        return jdbcTemplate.query(sql, searchRowMapper, memberId, wrappedKeyword, size, page * size);
+        return jdbcTemplate.query(sql, searchRowMapper, memberId, size, page * size);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
@@ -35,6 +35,6 @@ public class InterviewQuestionQueryRepository {
                 + String.format("ORDER BY %s %s ", sort.getField(), sort.getOrder())
                 + "LIMIT ? OFFSET ?";
 
-        return jdbcTemplate.query(sql, searchRowMapper, wrappedKeyword, memberId, size, page * size);
+        return jdbcTemplate.query(sql, searchRowMapper, memberId, wrappedKeyword, size, page * size);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
@@ -25,16 +25,16 @@ public class InterviewQuestionQueryRepository {
     public List<InterviewQuestionSearchResultDto> searchByKeyword(final String keyword, final Long memberId,
                                                                   final Long size, final Long page,
                                                                   final InterviewQuestionSort sort) {
-        final String wrappedKeyword = "%" + keyword + "%";
+        final String wrappedKeyword = "'%" + keyword + "%'";
         final String sql = "SELECT id, content, "
                 + "(select CASE WHEN (id IN (select interview_question_id from interview_question_likes where liker_id = ?)) "
                 + "THEN true ELSE false END ) AS press, "
                 + "like_count AS likeCount "
                 + "FROM interview_question "
-                + "WHERE content LIKE ?"
+                + "WHERE content LIKE ? "
                 + String.format("ORDER BY %s %s ", sort.getField(), sort.getOrder())
                 + "LIMIT ? OFFSET ?";
 
-        return jdbcTemplate.query(sql, searchRowMapper, memberId, wrappedKeyword, size, page * size);
+        return jdbcTemplate.query(sql, searchRowMapper, wrappedKeyword, memberId, size, page * size);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/presentation/InterviewQuestionSearchController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/presentation/InterviewQuestionSearchController.java
@@ -4,6 +4,7 @@ import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.PublicAPI;
 import com.woowacourse.levellog.interviewquestion.application.InterviewQuestionService;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultsDto;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,6 +30,9 @@ public class InterviewQuestionSearchController {
             @RequestParam(defaultValue = "0") final Long page,
             @RequestParam(defaultValue = "likes") final String sort,
             @Authentic final Long memberId) {
+        if (keyword.isBlank()) {
+            return ResponseEntity.ok(InterviewQuestionSearchResultsDto.of(new ArrayList<>(), 0L));
+        }
         final InterviewQuestionSearchResultsDto response = interviewQuestionService
                 .searchByKeyword(keyword, memberId, size, page, sort);
         return ResponseEntity.ok(response);

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,8 +35,10 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
          *   then: 200 OK 상태 코드와 결과를 응답받는다.
          */
         @Test
+        @ParameterizedTest
+        @ValueSource(strings = {"Spring", "왜%or1==1;--"})
         @DisplayName("로그인하지 않고 조회")
-        void searchBy_nonLogin() {
+        void searchBy_nonLogin(final String keyword) {
             // given
             PEPPER.save();
             ROMA.save();
@@ -53,7 +57,7 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .filter(document("interview-question-search/search-non-login"))
                     .when()
-                    .get("/api/interview-questions?keyword=Spring")
+                    .get("/api/interview-questions?keyword=" + keyword)
                     .then().log().all();
 
             // then

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
@@ -204,6 +204,39 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
                     .body("results.id", Matchers.contains(1, 2))
                     .body("results.likeCount", contains(1, 0));
         }
+
+        /*
+         * Scenario: keyword 파라미터가 없이 조회
+         *   when: keyword 파라미터가 없이 인터뷰 검색을 한다.
+         *   then: 200 OK 상태 코드와 빈 결과를 응답받는다.
+         */
+        @Test
+        @DisplayName("keyword 파라미터가 없이 조회")
+        void searchBy_inputPercent() {
+            // given
+            PEPPER.save();
+            ROMA.save();
+
+            final String teamId = saveTeam("잠실 제이슨조", PEPPER, 1, PEPPER, ROMA).getTeamId();
+            final String levellogId = saveLevellog("페퍼의 레벨로그", teamId, PEPPER).getLevellogId();
+
+            timeStandard.setInProgress();
+
+            saveInterviewQuestion("Spring을 사용한 이유", levellogId, ROMA);
+            saveInterviewQuestion("Spring이 무엇인가요?", levellogId, ROMA);
+            saveInterviewQuestion("Java가 무엇인가요?", levellogId, ROMA);
+
+            // when
+            final ValidatableResponse response = RestAssured.given(specification).log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/api/interview-questions")
+                    .then().log().all();
+
+            // then
+            response.statusCode(HttpStatus.OK.value())
+                    .body("results", hasSize(0));
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
@@ -15,8 +15,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -35,8 +33,6 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
          *   then: 200 OK 상태 코드와 결과를 응답받는다.
          */
         @Test
-        @ParameterizedTest
-        @ValueSource(strings = {"Spring", "왜%or1==1;--"})
         @DisplayName("로그인하지 않고 조회")
         void searchBy_nonLogin(final String keyword) {
             // given

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
@@ -34,7 +34,7 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
          */
         @Test
         @DisplayName("로그인하지 않고 조회")
-        void searchBy_nonLogin(final String keyword) {
+        void searchBy_nonLogin() {
             // given
             PEPPER.save();
             ROMA.save();
@@ -53,7 +53,7 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .filter(document("interview-question-search/search-non-login"))
                     .when()
-                    .get("/api/interview-questions?keyword=" + keyword)
+                    .get("/api/interview-questions?keyword=Spring")
                     .then().log().all();
 
             // then
@@ -94,41 +94,6 @@ class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
             // then
             response.statusCode(HttpStatus.OK.value())
                     .body("results", hasSize(2));
-        }
-
-        /*
-         * Scenario: 인터뷰 질문 전체 조회
-         *   when: 토큰을 전송하여 인터뷰 검색을 한다.
-         *   then: 200 OK 상태 코드와 전체 인터뷰 질문을 응답받는다.
-         */
-        @Test
-        @DisplayName("인터뷰 질문 전체 조회")
-        void findAll() {
-            // given
-            PEPPER.save();
-            ROMA.save();
-
-            final String teamId = saveTeam("잠실 제이슨조", PEPPER, 1, PEPPER, ROMA).getTeamId();
-            final String levellogId = saveLevellog("페퍼의 레벨로그", teamId, PEPPER).getLevellogId();
-
-            timeStandard.setInProgress();
-
-            saveInterviewQuestion("Spring을 사용한 이유", levellogId, ROMA);
-            saveInterviewQuestion("Spring이 무엇인가요?", levellogId, ROMA);
-            saveInterviewQuestion("Java가 무엇인가요?", levellogId, ROMA);
-
-            // when
-            final ValidatableResponse response = RestAssured.given(specification).log().all()
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + ROMA.getToken())
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .filter(document("interview-question-search/findAll"))
-                    .when()
-                    .get("/api/interview-questions")
-                    .then().log().all();
-
-            // then
-            response.statusCode(HttpStatus.OK.value())
-                    .body("results", hasSize(3));
         }
 
         /*

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
@@ -111,7 +111,7 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
             saveInterviewQuestion("트랜잭션을 왜 사용하였나요?", levellog, eve);
 
             // when
-            final String sqlInjectionKeyword = "왜%' or 1==1;--";
+            final String sqlInjectionKeyword = "왜%' or 1=1;--";
             final List<InterviewQuestionSearchResultDto> actual = interviewQuestionQueryRepository.searchByKeyword(
                     sqlInjectionKeyword, eve.getId(), 10L, 0L, InterviewQuestionSort.LATEST
             );
@@ -119,6 +119,5 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
             // then
             assertThat(actual).isEmpty();
         }
-
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
@@ -111,7 +111,7 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
             saveInterviewQuestion("트랜잭션을 왜 사용하였나요?", levellog, eve);
 
             // when
-            final String sqlInjectionKeyword = "왜%' or 1=1;--";
+            final String sqlInjectionKeyword = "왜%' or 1==1;--";
             final List<InterviewQuestionSearchResultDto> actual = interviewQuestionQueryRepository.searchByKeyword(
                     sqlInjectionKeyword, eve.getId(), 10L, 0L, InterviewQuestionSort.LATEST
             );

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
@@ -111,7 +111,7 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
             saveInterviewQuestion("트랜잭션을 왜 사용하였나요?", levellog, eve);
 
             // when
-            final String sqlInjectionKeyword = "왜%' or 1==1;--";
+            final String sqlInjectionKeyword = "왜%' or 1=1;--";
             final List<InterviewQuestionSearchResultDto> actual = interviewQuestionQueryRepository.searchByKeyword(
                     sqlInjectionKeyword, eve.getId(), 10L, 0L, InterviewQuestionSort.LATEST
             );

--- a/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionSearchControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/presentation/InterviewQuestionSearchControllerTest.java
@@ -1,13 +1,16 @@
 package com.woowacourse.levellog.presentation;
 
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.levellog.common.support.DebugMessage;
+import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultsDto;
 import com.woowacourse.levellog.interviewquestion.exception.InterviewQuestionLikeNotFoundException;
 import com.woowacourse.levellog.interviewquestion.exception.InterviewQuestionLikesAlreadyExistException;
+import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
@@ -16,6 +19,26 @@ import org.springframework.test.web.servlet.ResultActions;
 class InterviewQuestionSearchControllerTest extends ControllerTest {
 
     private static final String BASE_SNIPPET_PATH = "interview-question-search/likes/exception/";
+
+    @Test
+    @DisplayName("%를 입력 한 경우 빈 값을 응답한다.")
+    void searchBy_wrongInput_exception() throws Exception {
+        willReturn(InterviewQuestionSearchResultsDto.of(new ArrayList<>(), 0L))
+                .given(interviewQuestionService)
+                .searchByKeyword("%", 1L, 10L, 0L, "likes");
+
+        // when
+        final ResultActions perform = requestGet("/api/interview-questions?keyword=%&size=10&page=0&sort=likes");
+
+        // then
+        perform.andExpectAll(
+                status().isOk(),
+                jsonPath("results").isEmpty()
+        );
+
+        // docs
+        perform.andDo(document(BASE_SNIPPET_PATH + "input-percent"));
+    }
 
     @Test
     @DisplayName("이미 좋아요한 인터뷰 질문을 좋아요 한 경우 예외를 던진다.")


### PR DESCRIPTION
## 구현 기능
- LIKE 키워드 사용 시 sql injection이 안되도록 수정

## 공유하고 싶은 내용
- 인젝션 방지에 대한 테스트를 지우는 것도 좋을 것 같음
  - 인젝션은 쿼리에 따라 상황에 따라 디비 버전에 따라, 서버 코드에 따라 공격 방법이 달라짐
  - sql injection, blind injection, union injection 등 공격 방법에 따라 이름도 다를 만큼 방법이 많음
  - 따라서 하나의 케이스를 테스트했다고 모든 인젠션 공격을 막을 수 있다고 느낄 수 있는 테스트를 아예 지워버리는 건 어떤가 싶음
  - 위 내용에 의해 이후 쿼리가 바뀌면 테스트도 바뀌어야하기 때문에 지금은 코드에 끼워 맞춰진 테스트임
- 이게 왜 인젝션이 되는지 간단하게 적어봄
  - 기존 코드 => `content LIKE '%?%' ~~` 와 같이 쿼리가 있고 그대로 실행이됨
  - 키워드를 `%';--`라고 입력하면 쿼리는 `content LIKE '%%`;--%' ~~`와 같이 됨
  - sql에서 --는 주석을 의미하기 때문에 뒤에 쿼리는 실행이 안되지만 쿼리는 정상 쿼리가 됨
  - 따라서 키워드를 `%';???--`에서 ??? 부분에 정상적인 쿼리 어떤것이든 넣으면 사용자가 원하는 쿼리를 입력할 수 있음
  - `%'; drop table member;--`와 같이 쿼리를 짜면 member 테이블이 드롭되는 쿼리가 날아갈 수 있음
  - 이 외에도 `%' or 1=1;--`로 입력하면 쿼리는 `content LIKE '%%' or 1=1;--%' ~~`가 되고 조건문이 무조건 참이 됨
  - 그럼 모든 데이터를 조회할 수 있고 그게 디비 데이터 유출이 될 수 있음
- 코드의 문제가 있음
  - %를 입력 시 RequestParam이 잡아내지 못함
  - 디폴트인 ""을 검색하므로 모든 데이터가 검색이 됨
  - 가장 쉬운 방법은 전체 조회 기능을 없애면 됨
  - 그게 아니라면 프론트에서 막거나 서버에서 json으로 받거나 조건을 다르게 받아야할 것 같음
  - 그래서 인젝션이 문제가 아니라 그냥 못받고있던거였음
