### PR TITLE
fix: 팀 목록 조회 쿼리가 JOIN 후 정렬을 보장하지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamQueryService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamQueryService.java
@@ -31,8 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TeamQueryService {
 
-    private static final String ALL_STATUS = "all";
-
     private final TeamQueryRepository teamQueryRepository;
     private final MemberRepository memberRepository;
     private final TimeStandard timeStandard;

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
@@ -53,10 +53,11 @@ public class TeamQueryRepository {
                     + "(SELECT * "
                     + "FROM team "
                     + "WHERE deleted = FALSE AND is_closed = ? "
-                    + "ORDER BY is_closed ASC, created_at DESC "
+                    + "ORDER BY created_at DESC "
                     + "LIMIT ? OFFSET ?) AS t "
                 + "INNER JOIN participant p ON p.team_id = t.id AND p.is_watcher = FALSE "
-                + "INNER JOIN member m ON m.id = p.member_id";
+                + "INNER JOIN member m ON m.id = p.member_id "
+                + "ORDER BY t.created_at DESC";
 
         return jdbcTemplate.query(sql, simpleRowMapper, isClosed, limit, offset);
     }


### PR DESCRIPTION
## 구현 기능
- 팀 목록 조회 쿼리가 JOIN 후 정렬을 보장하지 않는 문제 해결

## 공유하고 싶은 내용
- 정렬이 된 테이블에 JOIN을 하면 정렬을 보장하지 않는다.
- 정렬 순서를 보장하기 위해서 쿼리를 수정했고, 성능 이슈는 딱히 없습니다.
