### PR TITLE
fix: 인터뷰 질문 검색 시 정렬 인자 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionSort.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionSort.java
@@ -2,8 +2,8 @@ package com.woowacourse.levellog.interviewquestion.domain;
 
 public enum InterviewQuestionSort {
 
-    LATEST("updated_at", "DESC"),
-    OLDEST("updated_at", "ASC"),
+    LATEST("created_at", "DESC"),
+    OLDEST("created_at", "ASC"),
     LIKES("like_count", "DESC");
 
     private final String field;


### PR DESCRIPTION
## 구현 기능
- 인터뷰 질문 검색 시 최신순, 오래된 순 정렬 인자를 `updated_at` -> `created_at` 으로 변경
- 해당 관련 서비스 테스트 추가

## 논의하고 싶은 내용
- 추가할 테스트 내용이 있으면 알려주세요

## 공유하고 싶은 내용
- 좋아요순 조회 시 현재는 좋아요가 동률인 경우 id 순으로 조회됩니다. 후에 논의해보면 좋을 것 같습니다.


Close #454
