### PR TITLE
fix: 인터뷰 질문 검색 쿼리를 기존 LIKE 문법으로 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -103,7 +103,7 @@ jacocoTestReport {
 					fileTree(dir: it,
 							excludes: ['**/support/**', '**/dto/**', '**/*Application*', '**/*BaseEntity*',
 									   '**/*Github*', '**/aspect/**', '**/*Config*', '**/AdminAuthInterceptor*', '**/AdminController*',
-										'**/InterviewQuestionQueryRepository*', '**/InterviewQuestionSearchController*', '**/InterviewQuestionSort*'])
+									   '**/InterviewQuestionQueryRepository*', '**/InterviewQuestionSearchController*', '**/InterviewQuestionSort*'])
 				})
 		)
 	}
@@ -148,7 +148,7 @@ sonarqube {
 		property "sonar.test.inclusions", "**/*Test.java"
 		property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
 		property 'sonar.exclusions',
-				 '**/support/**, **/dto/**, **/*Application*, **/*BaseEntity*, **/*Github*, **/aspect/**, **/*Config*, **/*AdminAuthInterceptor*, **/*AdminController*, **/*InterviewQuestionQueryRepository*, **/*InterviewQuestionSearchController*, **/*InterviewQuestionSort*'
+				'**/support/**, **/dto/**, **/*Application*, **/*BaseEntity*, **/*Github*, **/aspect/**, **/*Config*, **/*AdminAuthInterceptor*, **/*AdminController*, **/*InterviewQuestionQueryRepository*, **/*InterviewQuestionSearchController*, **/*InterviewQuestionSort*'
 
 		property 'sonar.issue.ignore.multicriteria', 'e1, e2'
 		property 'sonar.issue.ignore.multicriteria.e1.ruleKey', 'java:S6212'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -102,8 +102,7 @@ jacocoTestReport {
 				files(classDirectories.files.collect {
 					fileTree(dir: it,
 							excludes: ['**/support/**', '**/dto/**', '**/*Application*', '**/*BaseEntity*',
-									   '**/*Github*', '**/aspect/**', '**/*Config*', '**/AdminAuthInterceptor*', '**/AdminController*',
-									   '**/InterviewQuestionQueryRepository*', '**/InterviewQuestionSearchController*', '**/InterviewQuestionSort*'])
+									   '**/*Github*', '**/aspect/**', '**/*Config*', '**/AdminAuthInterceptor*', '**/AdminController*'])
 				})
 		)
 	}
@@ -127,8 +126,7 @@ jacocoTestCoverageVerification {
 				minimum = 0.80
 			}
 
-			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*', '*aspect*', '*Config*', '*AdminAuthInterceptor*', '*AdminController*',
-						'*InterviewQuestionQueryRepository*', '*InterviewQuestionSearchController*', '*InterviewQuestionSort*']
+			excludes = ['*support*', '*dto*', '*Application*', '*BaseEntity*', '*Github*', '*aspect*', '*Config*', '*AdminAuthInterceptor*', '*AdminController*']
 		}
 	}
 }
@@ -148,7 +146,7 @@ sonarqube {
 		property "sonar.test.inclusions", "**/*Test.java"
 		property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
 		property 'sonar.exclusions',
-				'**/support/**, **/dto/**, **/*Application*, **/*BaseEntity*, **/*Github*, **/aspect/**, **/*Config*, **/*AdminAuthInterceptor*, **/*AdminController*, **/*InterviewQuestionQueryRepository*, **/*InterviewQuestionSearchController*, **/*InterviewQuestionSort*'
+				'**/support/**, **/dto/**, **/*Application*, **/*BaseEntity*, **/*Github*, **/aspect/**, **/*Config*, **/*AdminAuthInterceptor*, **/*AdminController*'
 
 		property 'sonar.issue.ignore.multicriteria', 'e1, e2'
 		property 'sonar.issue.ignore.multicriteria.e1.ruleKey', 'java:S6212'

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.levellog.interviewquestion.domain;
 
+import com.woowacourse.levellog.common.support.StringConverter;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultDto;
 import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -30,10 +31,10 @@ public class InterviewQuestionQueryRepository {
                 + "THEN true ELSE false END ) AS press, "
                 + "like_count AS likeCount "
                 + "FROM interview_question "
-                + "WHERE MATCH(content) AGAINST(?) "
+                + "WHERE content LIKE '%" + StringConverter.toSafeString(keyword) + "%' "
                 + String.format("ORDER BY %s %s ", sort.getField(), sort.getOrder())
                 + "LIMIT ? OFFSET ?";
 
-        return jdbcTemplate.query(sql, searchRowMapper, memberId, keyword, size, page * size);
+        return jdbcTemplate.query(sql, searchRowMapper, memberId, size, page * size);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionQueryRepository.java
@@ -1,6 +1,5 @@
 package com.woowacourse.levellog.interviewquestion.domain;
 
-import com.woowacourse.levellog.common.support.StringConverter;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultDto;
 import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -31,7 +30,7 @@ public class InterviewQuestionQueryRepository {
                 + "THEN true ELSE false END ) AS press, "
                 + "like_count AS likeCount "
                 + "FROM interview_question "
-                + "WHERE content LIKE '%" + StringConverter.toSafeString(keyword) + "%' "
+                + "WHERE content LIKE '%" + keyword + "%' "
                 + String.format("ORDER BY %s %s ", sort.getField(), sort.getOrder())
                 + "LIMIT ? OFFSET ?";
 

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/presentation/InterviewQuestionSearchController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/presentation/InterviewQuestionSearchController.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.interviewquestion.presentation;
 
 import com.woowacourse.levellog.authentication.support.Authentic;
 import com.woowacourse.levellog.authentication.support.PublicAPI;
+import com.woowacourse.levellog.common.support.StringConverter;
 import com.woowacourse.levellog.interviewquestion.application.InterviewQuestionService;
 import com.woowacourse.levellog.interviewquestion.dto.InterviewQuestionSearchResultsDto;
 import java.util.ArrayList;
@@ -30,11 +31,12 @@ public class InterviewQuestionSearchController {
             @RequestParam(defaultValue = "0") final Long page,
             @RequestParam(defaultValue = "likes") final String sort,
             @Authentic final Long memberId) {
-        if (keyword.isBlank()) {
+        final String input = StringConverter.toSafeString(keyword);
+        if (input.isBlank()) {
             return ResponseEntity.ok(InterviewQuestionSearchResultsDto.of(new ArrayList<>(), 0L));
         }
         final InterviewQuestionSearchResultsDto response = interviewQuestionService
-                .searchByKeyword(keyword, memberId, size, page, sort);
+                .searchByKeyword(input, memberId, size, page, sort);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/InterviewQuestionSearchAcceptanceTest.java
@@ -12,7 +12,6 @@ import com.woowacourse.levellog.fixture.MemberFixture;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,7 +23,6 @@ import org.springframework.http.MediaType;
 @DisplayName("인터뷰 검색 관련 기능")
 class InterviewQuestionSearchAcceptanceTest extends AcceptanceTest {
 
-    @Disabled
     @Nested
     @DisplayName("인터뷰 검색")
     class SearchBy {

--- a/backend/src/test/java/com/woowacourse/levellog/application/InterviewQuestionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/InterviewQuestionServiceTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -330,7 +329,6 @@ class InterviewQuestionServiceTest extends ServiceTest {
         }
     }
 
-    @Disabled
     @Nested
     @DisplayName("searchByKeyword 메서드는")
     class SearchByKeyword {

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
@@ -11,7 +11,6 @@ import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.team.domain.Team;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,6 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
         assertThat(actual).isPresent();
     }
 
-    @Disabled
     @Nested
     @DisplayName("searchByKeyword 메서드는")
     class SearchByKeyword {

--- a/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/InterviewQuestionLikesRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.levellog.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.levellog.common.support.StringConverter;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestion;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionLikes;
 import com.woowacourse.levellog.interviewquestion.domain.InterviewQuestionSort;
@@ -112,8 +113,9 @@ class InterviewQuestionLikesRepositoryTest extends RepositoryTest {
 
             // when
             final String sqlInjectionKeyword = "왜%' or 1=1;--";
+            final String safeKeyword = StringConverter.toSafeString(sqlInjectionKeyword);
             final List<InterviewQuestionSearchResultDto> actual = interviewQuestionQueryRepository.searchByKeyword(
-                    sqlInjectionKeyword, eve.getId(), 10L, 0L, InterviewQuestionSort.LATEST
+                    safeKeyword, eve.getId(), 10L, 0L, InterviewQuestionSort.LATEST
             );
 
             // then


### PR DESCRIPTION
## 구현 기능
- 인터뷰 질문 검색 쿼리를 기존 LIKE 문법으로 변경
- SQL Injection 위험 키워드를 Safe-Keyword로 변경하는 로직 수행 위치 변경
- 소나큐브가 인터뷰 질문 관련 코드의 테스트 커버리지를 측정하도록 변경
