### PR TITLE
refactor: 레벨로그 상세조회 1 + 1 쿼리 개선

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/application/LevellogService.java
@@ -71,7 +71,7 @@ public class LevellogService {
     }
 
     private Levellog getById(final Long levellogId) {
-        return levellogRepository.findById(levellogId)
+        return levellogRepository.findLevellogAndMemberByLevelogId(levellogId)
                 .orElseThrow(() -> new LevellogNotFoundException(DebugMessage.init()
                         .append("levellogId", levellogId)));
     }

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/LevellogRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/LevellogRepository.java
@@ -15,4 +15,7 @@ public interface LevellogRepository extends JpaRepository<Levellog, Long> {
 
     @Query("SELECT l FROM Levellog l INNER JOIN FETCH l.team WHERE l.author = :author")
     List<Levellog> findAllByAuthor(@Param("author") Member author);
+
+    @Query("SELECT l FROM Levellog l INNER JOIN FETCH l.author WHERE l.id = :id")
+    Optional<Levellog> findLevellogAndMemberByLevelogId(@Param("id") Long id);
 }


### PR DESCRIPTION
## 구현 기능
- 레벨로그 상세조회 API에서 발생하는 1 + 1 쿼리 개선

**BEFORE**
```sql
SELECT l.*
FROM levellog l
WHERE lid=? 

SELECT m.*
FROM member m 
WHERE m.id=? 
```

**AFTER**
```sql
SELECT l.*, m.*
FROM levellog l
  INNER JOIN member m ON l.author_id=m.id
WHERE l.id=?
```
