### PR TITLE
chore: 톰캣 설정값 변경

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,3 +28,10 @@ security:
 
   admin:
     hash: ${ADMIN_HASH}
+
+server:
+  tomcat:
+    accept-count: 60
+    max-connections: 120
+    threads:
+      max: 8


### PR DESCRIPTION
## 구현 기능
- 톰캣의 maxThreads, maxConnections, acceptCount 값을 레벨로그 트래픽을 고려하여 default 값에서 적절한 값으로 변경

## 공유하고 싶은 내용

## 테스트 도구 - nGrinder, Jmeter
1. nGrinder
 - 오픈 소스
 - 한글 지원
 - EC2 인스턴스에 설치 -> 어느 환경에서든 웹 콘솔을 통해 테스트 진행 가능
2. Jmeter
  - 간단한 사용법
    - 시나리오 스크립트 작성 필요 X
- 플러그인 설치를 통해 원하는 분석 결과를 선택적으로 확인 가능

## vUser(동시 요청을 보낼 가상 유저 수) - 120
- 레벨로그는 서비스 특성 상 우테코 크루들이 각 레벨마다 정해진 인터뷰 날짜와 시간에 동시에 서비스를 이용한다.
- 4기 크루 전체 인원 수인 120을 현재 레벨로그 트래픽을 고려하여 우리가 목표로 하는 동시 접속 유저 수로 설정한다.

## 테스트 대상 API
- 성능이 제일 낮으면서 가장 많이 호출되는 요청 - /api/teams
- 성능이 빠른(DB 접속 시간이 가장 짧은) 요청 - /api/teams/1/levellogs/1

## 데이터베이스 더미 데이터 세팅
- 멤버 6000
- 팀 1000
    - 참가자 팀별로 6명 = 6000
    - 레벨로그 참가자별로 1개 = 6000

## 테스트 전략
- 현재 우리가 목표로 하는 동시 접속 유저 수는 서버에 많은 영향을 미칠 정도로 큰 값이 아니므로, Thread 관련 문제보다는 다른 구간에서 발생하는 병목으로 인해 maxThreads, maxConnections 값을 조정해도 성능이 더이상 개선되지 않는 구간이 나타날 것이다.
- 발생 확률이 거의 없는 비현실적인 상황을 대비해 설정값을 무작정 늘리면 불필요한 메모리가 낭비될 수 있으며, 만약 예상치 못한 큰 규모의 동시 요청이 실제로 온다고 해도 서버가 많은 양의 동시 요청을 감당하지 못해 터지거나 타임아웃이 발생할 수 있다.

→ maxThreads, maxConnections 값을 높여도 TPS와 CPU 사용률에 더이상 변화가 없는 구간을 찾는다. 해당 구간에서의 maxThreads, maxConnections 값을 현재 레벨로그 서비스에 적절한 설정값이라고 가정할 수 있다. 
- 다른 구간에서 발생하는 병목  예시 : 데이터베이스 커넥션, EC2 인스턴스 성능 등

## 테스트 진행 & 결과
테스트 결과는 [스프레드 시트](https://docs.google.com/spreadsheets/d/1m61K8UOmfvmGZxBlbLqOdpvMPKEHC9ufzOAtN2CUj8s/edit?usp=sharing)에 기록해뒀습니다.
- EC2 서버와 로컬 테스트 환경의 성능을 고려하여 120개의 vUser가 10초간 요청을 연달아 보내는 방식으로 테스트를 진행한다.

### 1. maxThreads 값 찾기
- vUser - 120, acceptCount - 100(default), maxConnections - 8192(default)
- maxThreads를 극단적으로 낮은 값(1)부터 시작하여 점차 증가시켜가며 maxThreads 값에 따른 결과(TPS, CPU, ErrorRate)를 기록한다.
- maxThreads 값을 높여도 더이상 성능 개선이 발상하지 않는 지점을 찾으면, 해당 지점에서의 maxThreads 값을 적절한 maxThreads 값으로 가정한다.

테스트 결과 : maxThreads가 8일 때까지 성능이 점차 올라가다가 8 이상부터는 유의미한 성능 변화가 나타나지 않았다. 오히려 10 후반 대부터는TPS가 줄어들었는데 이 이유는 모르겠음.

### 2. maxConnections 값 찾기
- vUser - 120, acceptCount - 100(default), maxThreads - 8
- 1번에서 찾은 maxThreads값에 가장 적절한 maxConnections 값을 찾는다.
  - 적절한 값의 기준 : 성능 저하가 발생하지 않으며 120개의 동시 요청을 감당할 수 있을 만큼 안전하다.

테스트 결과 : maxConnections가 120일 때까지 성능이 점차 올라가다가 120 이상부터는 유의미한 성능 변화가 나타나지 않았다. vUser 수만큼 생성되는 각각의 테스트 Thread들은 요청을 보내면 해당 요청에 대한 응답을 받은 후에 다음 요청을 보내므로, 120개의 vUser가 동시에 요청을 연달아 보낸다고 해도 커넥션이 120 이상 연결되지는 않기 때문에 이런 결과가 나왔을 것이라고 추측했다. 즉 테스트 환경에 적절한 maxConnections 값은 vUser 수의 영향을 받는다.

### 3. acceptCount 값 설정
- maxConnections 값을 우리가 가정한 vUser 수(120)에 너무 타이트하게 맞추면, 예상치 못한 120 이상의 동시 요청이 발생했을 때의 안정성을 보장하기 힘들다. 120의 절반인 60을 acceptCount 값으로 설정함으로써 이러한 상황을 어느정도 방지한다.
- acceptCount 값을 60으로 설정 후 위에서 진행한 테스트를 다시 진행했을 때, 기존에 acceptCount 값을 100으로 설정하고 진행했을 때와 크게 다르지 않은 성능 결과를 보였다.

### 결론
- maxThreads : 8
- maxConnections : 120
- acceptCount : 60

Close #467
