### PR TITLE
refactor: AllParticipantDto 리팩터링

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/team/application/TeamQueryService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/application/TeamQueryService.java
@@ -5,13 +5,13 @@ import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.domain.MemberRepository;
 import com.woowacourse.levellog.team.domain.SimpleParticipant;
 import com.woowacourse.levellog.team.domain.SimpleParticipants;
-import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamFilterCondition;
 import com.woowacourse.levellog.team.domain.TeamQueryRepository;
 import com.woowacourse.levellog.team.domain.TeamStatus;
 import com.woowacourse.levellog.team.dto.AllParticipantDto;
 import com.woowacourse.levellog.team.dto.AllSimpleParticipantDto;
 import com.woowacourse.levellog.team.dto.ParticipantDto;
+import com.woowacourse.levellog.team.dto.TeamDetailResponse;
 import com.woowacourse.levellog.team.dto.TeamDto;
 import com.woowacourse.levellog.team.dto.TeamListDto;
 import com.woowacourse.levellog.team.dto.TeamSimpleDto;
@@ -61,7 +61,7 @@ public class TeamQueryService {
         return new TeamListDto(teamSimpleDtos);
     }
 
-    public TeamDto findByTeamIdAndMemberId(final Long teamId, final Long memberId) {
+    public TeamDetailResponse findByTeamIdAndMemberId(final Long teamId, final Long memberId) {
         final List<AllParticipantDto> allParticipants = teamQueryRepository.findAllByTeamId(teamId, memberId);
         if (allParticipants.isEmpty()) {
             throw new TeamNotFoundException(DebugMessage.init()
@@ -69,17 +69,22 @@ public class TeamQueryService {
                     .append("membmerId", memberId));
         }
 
-        final Team team = allParticipants.get(0).getTeam();
+        final AllParticipantDto allParticipantDto = allParticipants.get(0);
+        final TeamDto teamDto = allParticipantDto.getTeamDto();
 
         final SimpleParticipants participants = toSimpleParticipants(allParticipants);
 
-        final TeamStatus status = team.status(timeStandard.now());
+        final TeamStatus status = toTeamStatus(allParticipantDto);
         final boolean isParticipant = participants.isContains(memberId);
-        final List<Long> interviewers = participants.toInterviewerIds(memberId, team.getInterviewerNumber());
-        final List<Long> interviewees = participants.toIntervieweeIds(memberId, team.getInterviewerNumber());
+        final List<Long> interviewers = participants.toInterviewerIds(memberId, teamDto.getInterviewerNumber());
+        final List<Long> interviewees = participants.toIntervieweeIds(memberId, teamDto.getInterviewerNumber());
 
-        return TeamDto.from(team, participants.toHostId(), status, isParticipant, interviewers, interviewees,
-                toParticipantDto(allParticipants), toWatcherDtos(allParticipants));
+        return TeamDetailResponse.from(teamDto, participants.toHostId(), status, isParticipant, interviewers,
+                interviewees, toParticipantDto(allParticipants), toWatcherDtos(allParticipants));
+    }
+
+    private TeamStatus toTeamStatus(final AllParticipantDto dto) {
+        return TeamStatus.of(dto.isClosed(), dto.getStartAt(), timeStandard.now());
     }
 
     private TeamStatus toTeamStatus(final AllSimpleParticipantDto dto) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/Team.java
@@ -58,7 +58,6 @@ public class Team extends BaseEntity {
         this.interviewerNumber = interviewerNumber;
         this.isClosed = false;
         this.deleted = false;
-
     }
 
     private void validate(final String title, final String place, final LocalDateTime startAt, final String profileUrl,

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
@@ -30,13 +30,10 @@ public class TeamQueryRepository {
             resultSet.getString("teamProfileUrl"),
             resultSet.getInt("interviewer_number"),
             resultSet.getBoolean("is_closed"),
-            resultSet.getTimestamp("created_at").toLocalDateTime(),
-            resultSet.getTimestamp("updated_at").toLocalDateTime(),
             resultSet.getObject("memberId", Long.class),
             resultSet.getObject("levellogId", Long.class),
             resultSet.getObject("preQuestionId", Long.class),
             resultSet.getString("nickname"),
-            resultSet.getString("profile_url"),
             resultSet.getBoolean("is_host"),
             resultSet.getBoolean("is_watcher")
     );
@@ -64,8 +61,8 @@ public class TeamQueryRepository {
 
     public List<AllParticipantDto> findAllByTeamId(final Long teamId, final Long memberId) {
         final String sql = "SELECT "
-                + "t.id teamId, t.title, t.place, t.start_at, t.profile_url teamProfileUrl, t.interviewer_number, t.is_closed, t.created_at, t.updated_at, "
-                + "m.id memberId, l.id levellogId, pq.id preQuestionId, m.nickname, m.profile_url, p.is_host, p.is_watcher "
+                + "t.id teamId, t.title, t.place, t.start_at, t.profile_url teamProfileUrl, t.interviewer_number, t.is_closed, "
+                + "m.id memberId, l.id levellogId, pq.id preQuestionId, m.nickname, p.is_host, p.is_watcher "
                 + "FROM participant p "
                     + "INNER JOIN member m ON p.member_id = m.id "
                     + "INNER JOIN team t ON p.team_id = t.id "

--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamStatus.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamStatus.java
@@ -26,8 +26,4 @@ public enum TeamStatus {
         }
         return TeamStatus.IN_PROGRESS;
     }
-
-    public boolean isSame(final String status) {
-        return this.status.equals(status);
-    }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/AllParticipantDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/AllParticipantDto.java
@@ -1,58 +1,50 @@
 package com.woowacourse.levellog.team.dto;
 
 import com.woowacourse.levellog.team.domain.SimpleParticipant;
-import com.woowacourse.levellog.team.domain.Team;
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.Map.Entry;
 import lombok.Getter;
-import org.springframework.util.ReflectionUtils;
 
 @Getter
 public class AllParticipantDto {
 
-    private final Team team;
+    private final Long teamId;
+    private final String title;
+    private final String place;
+    private final LocalDateTime startAt;
+    private final String profileUrl;
+    private final int interviewerNumber;
+    private final boolean isClosed;
     private final Long memberId;
     private final Long levellogId;
     private final Long preQuestionId;
     private final String nickname;
-    private final String profileUrl;
     private final boolean isHost;
     private final boolean isWatcher;
 
     public AllParticipantDto(final Long id, final String title, final String place, final LocalDateTime startAt,
-                             final String teamProfileUrl, final int interviewerNumber, final boolean isClosed,
-                             final LocalDateTime createdAt, final LocalDateTime updatedAt,
+                             final String profileUrl, final int interviewerNumber, final boolean isClosed,
                              final Long memberId, final Long levellogId, final Long preQuestionId,
-                             final String nickname, final String profileUrl, final boolean isHost,
-                             final boolean isWatcher) {
-        this.team = new Team(title, place, LocalDateTime.now().plusDays(3), teamProfileUrl, interviewerNumber);
-
-        injectTeamFields(id, startAt, isClosed, createdAt, updatedAt);
-
+                             final String nickname, final boolean isHost, final boolean isWatcher) {
+        this.teamId = id;
+        this.title = title;
+        this.place = place;
+        this.startAt = startAt;
+        this.profileUrl = profileUrl;
+        this.interviewerNumber = interviewerNumber;
+        this.isClosed = isClosed;
         this.memberId = memberId;
         this.levellogId = levellogId;
         this.preQuestionId = preQuestionId;
         this.nickname = nickname;
-        this.profileUrl = profileUrl;
         this.isHost = isHost;
         this.isWatcher = isWatcher;
     }
 
-    private void injectTeamFields(final Long id, final LocalDateTime startAt, final boolean isClosed,
-                           final LocalDateTime createdAt, final LocalDateTime updatedAt) {
-        final Map<String, Object> map = Map.of("id", id, "startAt", startAt, "isClosed", isClosed,
-                "createdAt", createdAt, "updatedAt", updatedAt);
-
-        for (final Entry<String, Object> entry : map.entrySet()) {
-            final Field field = ReflectionUtils.findField(Team.class, entry.getKey());
-            field.setAccessible(true);
-            ReflectionUtils.setField(field, team, entry.getValue());
-        }
+    public TeamDto getTeamDto() {
+        return TeamDto.from(teamId, title, place, startAt, profileUrl, interviewerNumber, isClosed);
     }
 
     public SimpleParticipant toSimpleParticipant() {
-        return new SimpleParticipant(team.getId(), memberId, isHost, isWatcher);
+        return new SimpleParticipant(teamId, memberId, isHost, isWatcher);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDetailResponse.java
@@ -1,0 +1,51 @@
+package com.woowacourse.levellog.team.dto;
+
+import com.woowacourse.levellog.team.domain.TeamStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamDetailResponse {
+
+    private Long id;
+    private String title;
+    private String place;
+    private LocalDateTime startAt;
+    private String teamImage;
+    private Long hostId;
+    private TeamStatus status;
+    private Boolean isParticipant;
+    private List<Long> interviewers;
+    private List<Long> interviewees;
+    private List<ParticipantDto> participants;
+    private List<WatcherDto> watchers;
+
+    public static TeamDetailResponse from(final TeamDto teamDto, final Long hostId, final TeamStatus status,
+                                          final Boolean isParticipant, final List<Long> interviewers,
+                                          final List<Long> interviewees,
+                                          final List<ParticipantDto> participantResponses,
+                                          final List<WatcherDto> watcherResponses) {
+        return new TeamDetailResponse(
+                teamDto.getId(),
+                teamDto.getTitle(),
+                teamDto.getPlace(),
+                teamDto.getStartAt(),
+                teamDto.getProfileUrl(),
+                hostId,
+                status,
+                isParticipant,
+                interviewers,
+                interviewees,
+                participantResponses,
+                watcherResponses
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/TeamDto.java
@@ -1,9 +1,6 @@
 package com.woowacourse.levellog.team.dto;
 
-import com.woowacourse.levellog.team.domain.Team;
-import com.woowacourse.levellog.team.domain.TeamStatus;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -20,33 +17,12 @@ public class TeamDto {
     private String title;
     private String place;
     private LocalDateTime startAt;
-    private String teamImage;
-    private Long hostId;
-    private TeamStatus status;
-    private Boolean isParticipant;
-    private List<Long> interviewers;
-    private List<Long> interviewees;
-    private List<ParticipantDto> participants;
-    private List<WatcherDto> watchers;
+    private String profileUrl;
+    private int interviewerNumber;
+    private boolean isClosed;
 
-    public static TeamDto from(final Team team, final Long hostId, final TeamStatus status,
-                               final Boolean isParticipant, final List<Long> interviewers,
-                               final List<Long> interviewees,
-                               final List<ParticipantDto> participantResponses,
-                               final List<WatcherDto> watcherResponses) {
-        return new TeamDto(
-                team.getId(),
-                team.getTitle(),
-                team.getPlace(),
-                team.getStartAt(),
-                team.getProfileUrl(),
-                hostId,
-                status,
-                isParticipant,
-                interviewers,
-                interviewees,
-                participantResponses,
-                watcherResponses
-        );
+    public static TeamDto from(final Long id, final String title, final String place, final LocalDateTime startAt,
+                               final String profileUrl, final int interviewerNumber, final boolean isClosed) {
+        return new TeamDto(id, title, place, startAt, profileUrl, interviewerNumber, isClosed);
     }
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/presentation/TeamController.java
@@ -6,7 +6,7 @@ import com.woowacourse.levellog.team.application.TeamQueryService;
 import com.woowacourse.levellog.team.application.TeamService;
 import com.woowacourse.levellog.team.domain.TeamFilterCondition;
 import com.woowacourse.levellog.team.dto.InterviewRoleDto;
-import com.woowacourse.levellog.team.dto.TeamDto;
+import com.woowacourse.levellog.team.dto.TeamDetailResponse;
 import com.woowacourse.levellog.team.dto.TeamListDto;
 import com.woowacourse.levellog.team.dto.TeamStatusDto;
 import com.woowacourse.levellog.team.dto.TeamWriteDto;
@@ -51,9 +51,9 @@ public class TeamController {
 
     @GetMapping("/{teamId}")
     @PublicAPI
-    public ResponseEntity<TeamDto> findById(@PathVariable final Long teamId,
-                                            @Authentic final Long memberId) {
-        final TeamDto response = teamQueryService.findByTeamIdAndMemberId(teamId, memberId);
+    public ResponseEntity<TeamDetailResponse> findById(@PathVariable final Long teamId,
+                                                       @Authentic final Long memberId) {
+        final TeamDetailResponse response = teamQueryService.findByTeamIdAndMemberId(teamId, memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/TeamQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/TeamQueryServiceTest.java
@@ -13,7 +13,7 @@ import com.woowacourse.levellog.member.domain.Member;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import com.woowacourse.levellog.team.domain.Team;
 import com.woowacourse.levellog.team.domain.TeamFilterCondition;
-import com.woowacourse.levellog.team.dto.TeamDto;
+import com.woowacourse.levellog.team.dto.TeamDetailResponse;
 import com.woowacourse.levellog.team.dto.TeamListDto;
 import com.woowacourse.levellog.team.dto.TeamSimpleDto;
 import com.woowacourse.levellog.team.exception.TeamNotFoundException;
@@ -122,7 +122,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             final Team team = saveTeam(rick, pepper);
 
             //when
-            final TeamDto response = teamQueryService.findByTeamIdAndMemberId(team.getId(), rick.getId());
+            final TeamDetailResponse response = teamQueryService.findByTeamIdAndMemberId(team.getId(), rick.getId());
 
             //then
             assertAll(
@@ -159,9 +159,9 @@ public class TeamQueryServiceTest extends ServiceTest {
                 final Team team = saveTeam(2, rick, pepper, roma, alien, eve);
 
                 //when
-                final TeamDto responseOfPepper = teamQueryService.findByTeamIdAndMemberId(team.getId(),
+                final TeamDetailResponse responseOfPepper = teamQueryService.findByTeamIdAndMemberId(team.getId(),
                         pepper.getId());
-                final TeamDto responseOfEve = teamQueryService.findByTeamIdAndMemberId(team.getId(),
+                final TeamDetailResponse responseOfEve = teamQueryService.findByTeamIdAndMemberId(team.getId(),
                         eve.getId());
 
                 //then
@@ -193,7 +193,8 @@ public class TeamQueryServiceTest extends ServiceTest {
                 final Team team = saveTeam(2, rick, pepper, roma);
 
                 //when
-                final TeamDto response = teamQueryService.findByTeamIdAndMemberId(team.getId(), pepper.getId());
+                final TeamDetailResponse response = teamQueryService.findByTeamIdAndMemberId(team.getId(),
+                        pepper.getId());
 
                 //then
                 assertAll(
@@ -223,7 +224,8 @@ public class TeamQueryServiceTest extends ServiceTest {
                 final Team team = saveTeam(1, rick, List.of(pobi), pepper);
 
                 //when
-                final TeamDto response = teamQueryService.findByTeamIdAndMemberId(team.getId(), pobi.getId());
+                final TeamDetailResponse response = teamQueryService.findByTeamIdAndMemberId(team.getId(),
+                        pobi.getId());
 
                 //then
                 assertAll(
@@ -254,7 +256,8 @@ public class TeamQueryServiceTest extends ServiceTest {
                 final Team team = saveTeam(rick, pepper, roma);
 
                 //when
-                final TeamDto response = teamQueryService.findByTeamIdAndMemberId(team.getId(), alien.getId());
+                final TeamDetailResponse response = teamQueryService.findByTeamIdAndMemberId(team.getId(),
+                        alien.getId());
 
                 //then
                 assertAll(


### PR DESCRIPTION
## 구현 기능
- AllParticipantDto에서 불필요하다고 생각하는 값, 로직 수정
- TeamDto -> TeamDetailResponse
- TeamDto = Team엔티티의 값만 가지고 있도록 수정
- 리플렉션 제거

## 논의하고 싶은 내용
- TeamDto는 사실상 팀 상세 조회에서만 사용되고있었고 Team 엔티티 정보 외 다른 값을 많이 가지고 있어 네이밍이 적절하지 않다고 판단했다.
- 그래서 수정했습니다.
  - TeamDto -> TeamDetailResponse
  - TeamDto = Team엔티티의 값만 가지고 있도록 수정
