### PR TITLE
feat: 깃허브 로그인 시 닉네임을 추가로 보내도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/application/OAuthService.java
@@ -29,7 +29,7 @@ public class OAuthService {
 
         final String token = jwtTokenProvider.createToken(memberId.toString());
 
-        return new LoginDto(memberId, token, githubProfile.getProfileUrl());
+        return new LoginDto(memberId, token, githubProfile.getNickname(), githubProfile.getProfileUrl());
     }
 
     private Long getMemberIdByGithubProfile(final GithubProfileDto githubProfile) {

--- a/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
+++ b/backend/src/main/java/com/woowacourse/levellog/authentication/dto/LoginDto.java
@@ -14,5 +14,6 @@ public class LoginDto {
 
     private Long id;
     private String accessToken;
+    private String nickname;
     private String profileUrl;
 }

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/OAuthAcceptanceTest.java
@@ -26,7 +26,10 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("깃허브 로그인")
     void login() throws Exception {
         // given
-        final String code = objectMapper.writeValueAsString(new GithubProfileDto("11111", "test", "profile_url"));
+        final String githubId = "11111";
+        final String nickname = "alien";
+        final String profileUrl = "alien.img";
+        final String code = objectMapper.writeValueAsString(new GithubProfileDto(githubId, nickname, profileUrl));
         final GithubCodeDto request = new GithubCodeDto(code);
 
         // when
@@ -41,7 +44,8 @@ class OAuthAcceptanceTest extends AcceptanceTest {
         // then
         response.statusCode(HttpStatus.OK.value())
                 .body("accessToken", notNullValue())
-                .body("profileUrl", is("profile_url"))
+                .body("profileUrl", is(profileUrl))
+                .body("nickname", is(nickname))
                 .body("id", notNullValue());
     }
 }

--- a/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/OAuthServiceTest.java
@@ -35,6 +35,7 @@ class OAuthServiceTest extends ServiceTest {
             assertAll(
                     () -> assertThat(Long.parseLong(payload)).isEqualTo(savedMemberId),
                     () -> assertThat(tokenResponse.getProfileUrl()).isEqualTo("rick.org"),
+                    () -> assertThat(tokenResponse.getNickname()).isEqualTo("릭"),
                     () -> assertThat(tokenResponse.getId()).isNotNull()
             );
         }


### PR DESCRIPTION
## 구현 기능
- 깃허브 로그인 시 닉네임을 추가로 보내도록 수정
- API 한 번 덜 갈 수 있다. ( 재검증 요청 )
- 원래는 로그인 이후 받는 API 에서 닉네임이 없어서 유저를 재검증해서 닉네임을 가져온다.

---
### 기존
```json
{
  "id" : 1,
  "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjY0OTY3MjkzLCJleHAiOjE2NjUwMDMyOTN9.CWV_Dqxjph01Z6uU1OacGalN1L7dNNyHkK0B8gHk0tM",
  "profileUrl" : "alien.img"
}
```
---
### 수전 후
```json
{
  "id" : 1,
  "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjY0OTY3MjkzLCJleHAiOjE2NjUwMDMyOTN9.CWV_Dqxjph01Z6uU1OacGalN1L7dNNyHkK0B8gHk0tM",
  "nickname" : "alien", // 추가됨
  "profileUrl" : "alien.img"
}
```

Close #426 
