### PR TITLE
feat: 팀 목록 조회 결과에 nickname 필드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/domain/TeamQueryRepository.java
@@ -24,6 +24,7 @@ public class TeamQueryRepository {
             resultSet.getString("teamProfileUrl"),
             resultSet.getBoolean("is_closed"),
             resultSet.getLong("memberId"),
+            resultSet.getString("nickname"),
             resultSet.getString("profile_url")
     );
     private final RowMapper<TeamDetailQueryResult> detailRowMapper = (resultSet, rowNumber) -> new TeamDetailQueryResult(
@@ -50,7 +51,7 @@ public class TeamQueryRepository {
     public List<TeamListQueryResult> findAllList(final boolean isClosed, final int limit, final int offset) {
         final String sql = "SELECT /*! STRAIGHT_JOIN */ "
                 + "t.id teamId, t.title, t.place, t.start_at, t.profile_url teamProfileUrl, t.is_closed, "
-                + "m.id memberId, m.profile_url "
+                + "m.id memberId, m.nickname, m.profile_url "
                 + "FROM "
                 + "(SELECT * "
                 + "FROM team "
@@ -108,7 +109,7 @@ public class TeamQueryRepository {
     public List<TeamListQueryResult> findMyList(final Long memberId) {
         final String sql = "SELECT "
                 + "t.id teamId, t.title, t.place, t.start_at, t.profile_url teamProfileUrl, t.is_closed, t.created_at, "
-                + "m.id memberId, m.profile_url "
+                + "m.id memberId, m.nickname, m.profile_url "
                 + "FROM participant p "
                 + "INNER JOIN member m ON p.member_id = m.id "
                 + "INNER JOIN team t ON p.team_id = t.id "

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/query/TeamListQueryResult.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/query/TeamListQueryResult.java
@@ -16,6 +16,7 @@ public class TeamListQueryResult {
     private String teamImage;
     private boolean isClosed;
     private Long memberId;
+    private String nickname;
     private String memberImage;
 
     public TeamStatus getTeamStatus(final LocalDateTime time) {

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/response/ParticipantInTeamListResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/response/ParticipantInTeamListResponse.java
@@ -13,5 +13,6 @@ import lombok.NoArgsConstructor;
 public class ParticipantInTeamListResponse {
 
     private Long memberId;
+    private String nickname;
     private String profileUrl;
 }

--- a/backend/src/main/java/com/woowacourse/levellog/team/dto/response/TeamListResponse.java
+++ b/backend/src/main/java/com/woowacourse/levellog/team/dto/response/TeamListResponse.java
@@ -36,7 +36,8 @@ public class TeamListResponse {
                 result.getTeamImage(),
                 status,
                 simpleParticipants.stream()
-                        .map(it -> new ParticipantInTeamListResponse(it.getMemberId(), it.getMemberImage()))
+                        .map(it -> new ParticipantInTeamListResponse(it.getMemberId(), it.getNickname(),
+                                it.getMemberImage()))
                         .collect(Collectors.toList())
         );
     }

--- a/backend/src/test/java/com/woowacourse/levellog/domain/TeamQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/TeamQueryRepositoryTest.java
@@ -126,13 +126,13 @@ class TeamQueryRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(actual).hasSize(4)
-                .extracting("id", "memberId")
+                .extracting("id", "memberId", "nickname")
                 .containsExactly(
-                        tuple(team3.getId(), harry.getId()),
-                        tuple(team3.getId(), kyoul.getId()),
+                        tuple(team3.getId(), harry.getId(), harry.getNickname()),
+                        tuple(team3.getId(), kyoul.getId(), kyoul.getNickname()),
 
-                        tuple(team2.getId(), eve.getId()),
-                        tuple(team2.getId(), alien.getId())
+                        tuple(team2.getId(), eve.getId(), eve.getNickname()),
+                        tuple(team2.getId(), alien.getId(), alien.getNickname())
                 );
     }
 


### PR DESCRIPTION
## 구현 기능
- 팀 목록 조회 결과에 nickname 필드 추가
![스크린샷 2022-10-14 오후 7 40 21](https://user-images.githubusercontent.com/68512686/195827937-4ae1d298-e0d6-4409-b350-b07893b37c31.png)

## 공유하고 싶은 내용
- 웹 접근성 향상을 위해 팀 목록에 참가자 이미지에 nickname이 필요함
- 쿼리 성능에 영향이 없어서 따로 논의 없이 구현했습니다.

Close #501 
