### PR TITLE
fix: 내가 작성한 피드백 수정을 할 수 없는 버그 수정

### DIFF
--- a/frontend/src/apis/teams.ts
+++ b/frontend/src/apis/teams.ts
@@ -1,7 +1,6 @@
 import { fetcher } from 'apis';
 import axios, { AxiosPromise } from 'axios';
 
-import { NotAccessTokenRemoveHeader } from 'apis/utils';
 import { TeamApiType, InterviewTeamType, InterviewTeamDetailType } from 'types/team';
 
 export const requestPostTeam = async ({ teamInfo, accessToken }: Omit<TeamApiType, 'teamId'>) => {

--- a/frontend/src/hooks/team/useMember.ts
+++ b/frontend/src/hooks/team/useMember.ts
@@ -8,7 +8,7 @@ import useSnackbar from 'hooks/utils/useSnackbar';
 
 import { requestGetMembers } from 'apis/member';
 import { requestGetTeam } from 'apis/teams';
-import { MemberContext, MemberDispatchContext } from 'contexts/memberContext';
+import { MemberDispatchContext } from 'contexts/memberContext';
 import { MembersCustomHookType, MemberType } from 'types/member';
 import { debounce } from 'utils/util';
 

--- a/frontend/src/hooks/team/useTeam.ts
+++ b/frontend/src/hooks/team/useTeam.ts
@@ -29,7 +29,6 @@ const useTeam = () => {
   const [participants, setParticipants] = useState<MemberType[]>([myInfo]);
   const [watchers, setWatchers] = useState<MemberType[]>([]);
   const [nicknameValue, setNicknameValue] = useState('');
-  const [members, setMembers] = useState<MemberType[]>([]);
 
   const teamInfoDispatch = useContext(TeamDispatchContext);
   const team = useContext(TeamContext);
@@ -77,13 +76,16 @@ const useTeam = () => {
     },
   );
 
+  useEffect(() => {
+    getTeam();
+  }, []);
+
   return {
     nicknameValue,
     participants,
     watchers,
     team,
     teamInfo,
-    members,
     setNicknameValue,
     setParticipants,
     setWatchers,

--- a/frontend/src/pages/feedback/Feedbacks.tsx
+++ b/frontend/src/pages/feedback/Feedbacks.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import styled from 'styled-components';
@@ -35,6 +35,10 @@ const Feedbacks = () => {
 
   if (levellogError) {
     return <Error />;
+  }
+
+  if (!team) {
+    return <Loading />;
   }
 
   if (feedbacks?.feedbacks.length === 0) {

--- a/frontend/src/pages/interviewQuestion/InterviewQuestions.tsx
+++ b/frontend/src/pages/interviewQuestion/InterviewQuestions.tsx
@@ -33,6 +33,7 @@ const InterviewQuestions = () => {
     !loginUserNickname ||
     !loginUserProfileUrl ||
     !levellogInfo ||
+    !team ||
     Object.keys(levellogInfo).length === 0
   ) {
     return <Loading />;

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -77,9 +77,9 @@ export const convertFirstWordFinalConsonant = ({ word }: CheckFirstWordFinalCons
   if (uniCode < hangeulFirstTextUnicode || uniCode > hangeulLastTextUnicode) return;
 
   if ((uniCode - hangeulFirstTextUnicode) % finalConsonantNumber !== 0) {
-    return `${word}이`;
+    return `${word}이 `;
   } else {
-    return `${word}가`;
+    return `${word}가 `;
   }
 };
 interface CheckFirstWordFinalConsonantType {


### PR DESCRIPTION
## 구현 기능
- [x] `useTeam` 을 사용하는 페이지에서 team 정보를 가져오지 않는 버그 수정
  - [x] `InterviewQuestions` 페이지에서 team 정보 가져옴
  - [x] `feedbacks` 페이지에 team 정보 가져옴 -> 피드백 수정 가능
- [x] '이', '가' 뒤에 공백이 없어 "XX이작성해준 ~"으로 되는 버그를 수정

## 참고

뒤에 거대한 PR 머지를 원할하게 하기 위해 파일 수정을 최소화했습니다.

Close #513 
