### PR TITLE
fix: 스낵바가 제대로 동작하지 않는 버그 수정

### DIFF
--- a/frontend/src/hooks/feedback/useFeedbackAdd.ts
+++ b/frontend/src/hooks/feedback/useFeedbackAdd.ts
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { Editor } from '@toast-ui/react-editor';
 
+import errorHandler from 'hooks/utils/errorHandler';
 import useSnackbar from 'hooks/utils/useSnackbar';
 
 import { MESSAGE } from 'constants/constants';
@@ -28,6 +29,9 @@ const useFeedbackAdd = () => {
       onSuccess: () => {
         showSnackbar({ message: MESSAGE.FEEDBACK_CREATE });
         navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
+      },
+      onError: (err: unknown) => {
+        errorHandler({ err, showSnackbar });
       },
     },
   );

--- a/frontend/src/hooks/feedback/useFeedbackEdit.ts
+++ b/frontend/src/hooks/feedback/useFeedbackEdit.ts
@@ -4,9 +4,10 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { Editor } from '@toast-ui/react-editor';
 
+import errorHandler from 'hooks/utils/errorHandler';
 import useSnackbar from 'hooks/utils/useSnackbar';
 
-import { MESSAGE, ROUTES_PATH } from 'constants/constants';
+import { MESSAGE } from 'constants/constants';
 
 import { requestEditFeedback, requestGetFeedback } from 'apis/feedback';
 import { FeedbackCustomHookType, FeedbackFormatType } from 'types/feedback';
@@ -38,9 +39,7 @@ const useFeedbackEdit = () => {
         feedbackRef.current[2].getInstance().setMarkdown(data.feedback.etc);
       },
       onError: (err: unknown) => {
-        showSnackbar({ message: 'getFeedback.error.message' });
-        navigate(ROUTES_PATH.ERROR);
-        return;
+        errorHandler({ err, showSnackbar });
       },
     },
   );
@@ -59,9 +58,7 @@ const useFeedbackEdit = () => {
         navigate(feedbacksGetUriBuilder({ teamId, levellogId }));
       },
       onError: (err: unknown) => {
-        showSnackbar({ message: 'editFeedback.error.message' });
-        navigate(ROUTES_PATH.ERROR);
-        return;
+        errorHandler({ err, showSnackbar });
       },
     },
   );

--- a/frontend/src/hooks/preQuestion/usePreQuestionQuery.ts
+++ b/frontend/src/hooks/preQuestion/usePreQuestionQuery.ts
@@ -2,9 +2,6 @@ import { useParams } from 'react-router-dom';
 
 import { useQuery } from '@tanstack/react-query';
 
-import errorHandler from 'hooks/utils/errorHandler';
-import useSnackbar from 'hooks/utils/useSnackbar';
-
 import { requestGetPreQuestion } from 'apis/preQuestion';
 
 const QUERY_KEY = {


### PR DESCRIPTION
## 구현 기능
- 피드백 작성, 수정페이지에서 요청에러 에러가 발생해도 스낵바를 띄워주지 않는 버그 수정
- 그 외 스낵바가 제대로 동작하지 않는 이유도 `react-query` 도입 시기쯤 아래 함수로 바뀌지 않은 요청 로직인 듯함  
```tsx
 errorHandler({ err, showSnackbar });
```

나머지까지 지금 바꾸면 다른 PR들 merge에 더 걸림돌이 될 것 같아서 건들지 않음.

Close #536