### PR TITLE
chore: 무조건 성공하는 jobs 추가 및 FE 테스트 분리

### DIFF
--- a/.github/workflows/front-dev.yml
+++ b/.github/workflows/front-dev.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies # 의존 파일 설치
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ./frontend
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Dev Build # React Dev Build
         working-directory: ./frontend

--- a/.github/workflows/front-prod.yml
+++ b/.github/workflows/front-prod.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies # 의존 파일 설치
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ./frontend
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Prod Build # React Prod Build
         working-directory: ./frontend

--- a/.github/workflows/front-unit-test.yml
+++ b/.github/workflows/front-unit-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies # 의존 파일 설치
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ./frontend
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Util Test
         working-directory: ./frontend

--- a/.github/workflows/front-unit-test.yml
+++ b/.github/workflows/front-unit-test.yml
@@ -17,7 +17,7 @@ on:
 # push가 일어난 브랜치에 PR이 존재하면, push에 대한 이벤트와 PR에 대한 이벤트 모두 발생합니다.
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-22.04 # 실행 환경 지정
 
     steps:
@@ -41,11 +41,6 @@ jobs:
         working-directory: ./frontend
         run: yarn install
 
-      - name: Dev Build # React Dev Build
+      - name: Util Test
         working-directory: ./frontend
-        run: yarn build-dev
-
-  sonarqube-build:
-    runs-on: ubuntu-22.04
-    steps:
-      - run: 'echo "No build required"'
+        run: yarn test-util

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,11 @@ on:
 # push가 일어난 브랜치에 PR이 존재하면, push에 대한 이벤트와 PR에 대한 이벤트 모두 발생합니다.
 
 jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'
+
   sonarqube-build:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## 구현 기능
- 백엔드, 프론트엔드 CI를 분리하면서 생긴 문제점을 살펴봤습니다.

## 공유하고 싶은 내용
기존에는 `Require status checks to pass before merging` 에서 `build`, `test` 라는 이름의 jobs가 완료되어야했습니다.
백엔드 workflow의 jobs는 `sonarqube-build` 라는 이름의 job만 존재해서 `build` 라는 job을 CI 에서 계속 기다리게 됩니다.

추가적으로 `sonarqube-build` 라는 job이 `Require status checks to pass before merging` 에 포함되어 있지 않아서 소나큐브 빌드가 실패해도 merge가 막히지 않는 문제가 있었습니다.


![스크린샷 2022-10-28 오후 4 04 50](https://user-images.githubusercontent.com/75592315/198525016-b449160e-a261-4fc1-abf0-36fe49b583a9.png)

이를 해결하고자, `sonarqube-build` 라는 job을 추가했습니다.
그리고 각각의 workflow의 없는 job들을 무조건 성공하는 빈 job으로 추가해서 CI 에서 없는 job을 기다리지 않도록 했습니다

