### PR TITLE
chore: develop 브랜치에 PR 요청 시 prod CI를 하도록 수정

### DIFF
--- a/.github/workflows/front-prod.yml
+++ b/.github/workflows/front-prod.yml
@@ -5,6 +5,7 @@ on:
   pull_request: # main 브랜치에서 PR이 일어났을 때 github action 동작
     branches:
       - "main"
+      - "develop"
     paths-ignore:
       - "backend/**"
 


### PR DESCRIPTION
## 구현 기능
- develop 브랜치에 PR 요청 시 prod CI를 하도록 수정
- [github actions](https://github.com/woowacourse-teams/2022-levellog/actions/runs/3373606176/jobs/5598347472)와 같은 상황을 막기위한 CI룰 수정
- 개발서버 CI : yarn build-prod, yarn build-dev 둘 다 수행
- 운영서버 CI : yarn build-prod 만 수행