### PR TITLE
fix: 의도한 바와 달리 팀 상태를 보여주는 버그 수정

### DIFF
--- a/frontend/src/components/teams/InterviewTeam.tsx
+++ b/frontend/src/components/teams/InterviewTeam.tsx
@@ -43,11 +43,12 @@ const InterviewTeam = ({ team }: InterviewTeamsProp) => {
           </S.Info>
           <S.Info>
             <S.Notice aria-label={`인터뷰 날짜와 시간 ${DateAndTime}`}>
-              {status === 'CLOSED' ? (
+              {status === 'CLOSED' && (
                 <S.ImageBox>
                   <Image src={cancelIcon} alt={'종료된 인터뷰 아이콘'} sizes={'TINY'} />
                 </S.ImageBox>
-              ) : (
+              )}
+              {status !== 'CLOSED' && (
                 <S.ImageBox>
                   <Image src={checkIcon} alt={'진행 중인 인터뷰 아이콘'} sizes={'TINY'} />
                 </S.ImageBox>

--- a/frontend/src/components/teams/InterviewTeam.tsx
+++ b/frontend/src/components/teams/InterviewTeam.tsx
@@ -16,8 +16,6 @@ import { convertDateAndTime } from 'utils/util';
 const InterviewTeam = ({ team }: InterviewTeamsProp) => {
   const { id, teamImage, title, status, place, startAt, participants } = team;
   const DateAndTime = convertDateAndTime(startAt);
-  const teamStartDate = new Date(startAt);
-  const currentDate = new Date();
 
   return (
     <Link to={teamGetUriBuilder({ teamId: id })}>
@@ -45,13 +43,13 @@ const InterviewTeam = ({ team }: InterviewTeamsProp) => {
           </S.Info>
           <S.Info>
             <S.Notice aria-label={`인터뷰 날짜와 시간 ${DateAndTime}`}>
-              {teamStartDate > currentDate ? (
+              {status === 'CLOSED' ? (
                 <S.ImageBox>
-                  <Image src={checkIcon} alt={'시작 전 인터뷰 아이콘'} sizes={'TINY'} />
+                  <Image src={cancelIcon} alt={'종료된 인터뷰 아이콘'} sizes={'TINY'} />
                 </S.ImageBox>
               ) : (
                 <S.ImageBox>
-                  <Image src={cancelIcon} alt={'시작된 인터뷰 아이콘'} sizes={'TINY'} />
+                  <Image src={checkIcon} alt={'진행 중인 인터뷰 아이콘'} sizes={'TINY'} />
                 </S.ImageBox>
               )}
               {DateAndTime}


### PR DESCRIPTION
## 구현 기능
- [x] 팀 상태가 `인터뷰 종료` 일 때만 `X` 아이콘으로 보여주도록 수정

## 기타
단순한 버그라 빠르게 이슈 파고 처리했습니다.

### 기존

![스크린샷 2022-11-02 오후 4 19 08](https://user-images.githubusercontent.com/75592315/199424771-763895f5-213f-4f83-858d-c9f083372442.png)

### 수정후
![스크린샷 2022-11-02 오후 4 20 36](https://user-images.githubusercontent.com/75592315/199424976-2e28f0f2-3e0f-4a30-b67c-fd63697dc949.png)
![스크린샷 2022-11-02 오후 4 20 31](https://user-images.githubusercontent.com/75592315/199424992-bbbf6306-4885-4fcc-87f5-f04b2ba66aa2.png)

Close #573
