### PR TITLE
fix: 비관적 락을 제거하고 유니크 제약조건을 추가한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_authorId_teamId",
+                name = "uk_feedback_author_id_team_id",
                 columnNames = {"fromId", "levellog_id"}
         )})
 public class Feedback extends BaseEntity {

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/domain/Feedback.java
@@ -11,6 +11,8 @@ import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +20,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_authorId_teamId",
+                columnNames = {"fromId", "levellog_id"}
+        )})
 public class Feedback extends BaseEntity {
 
     private static final String CONTENT_TYPE_SPEAK = "Speak";

--- a/backend/src/main/java/com/woowacourse/levellog/feedback/domain/FeedbackRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/domain/FeedbackRepository.java
@@ -3,15 +3,12 @@ package com.woowacourse.levellog.feedback.domain;
 import com.woowacourse.levellog.common.support.DebugMessage;
 import com.woowacourse.levellog.feedback.exception.FeedbackNotFoundException;
 import com.woowacourse.levellog.levellog.domain.Levellog;
-import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     boolean existsByLevellogAndFromId(Levellog levellog, Long fromId);
 
     default Feedback getFeedback(final Long feedbackId) {

--- a/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionLikes.java
+++ b/backend/src/main/java/com/woowacourse/levellog/interviewquestion/domain/InterviewQuestionLikes.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_interview_question_id_liker_id",
+                name = "uk_interview_question_likes_interview_question_id_liker_id",
                 columnNames = {"interviewQuestionId", "likerId"}
         )})
 public class InterviewQuestionLikes extends BaseEntity {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_authorId_teamId",
+                name = "uk_levellog_author_id_team_id",
                 columnNames = {"authorId", "team_id"}
         )})
 public class Levellog extends BaseEntity {

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/Levellog.java
@@ -15,6 +15,8 @@ import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_authorId_teamId",
+                columnNames = {"authorId", "team_id"}
+        )})
 public class Levellog extends BaseEntity {
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/woowacourse/levellog/levellog/domain/LevellogRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/levellog/domain/LevellogRepository.java
@@ -5,9 +5,7 @@ import com.woowacourse.levellog.levellog.exception.LevellogNotFoundException;
 import com.woowacourse.levellog.team.domain.Team;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface LevellogRepository extends JpaRepository<Levellog, Long> {
@@ -20,7 +18,6 @@ public interface LevellogRepository extends JpaRepository<Levellog, Long> {
 
     Optional<Levellog> findByAuthorIdAndTeamId(Long authorId, Long teamId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     boolean existsByAuthorIdAndTeam(Long authorId, Team team);
 
     @Query("SELECT l FROM Levellog l INNER JOIN FETCH l.team WHERE l.authorId = :authorId")

--- a/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
@@ -14,7 +14,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(uniqueConstraints = {@UniqueConstraint(name = "uk_member_github_id", columnNames = {"githubId"})})
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_member_github_id", columnNames = {"githubId"}
+        )})
 public class Member extends BaseEntity {
 
     private static final int NICKNAME_MAX_LENGTH = 50;

--- a/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/domain/Member.java
@@ -16,7 +16,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_member_github_id", columnNames = {"githubId"}
+                name = "uk_member_github_id",
+                columnNames = {"githubId"}
         )})
 public class Member extends BaseEntity {
 

--- a/backend/src/main/java/com/woowacourse/levellog/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/member/domain/MemberRepository.java
@@ -4,9 +4,7 @@ import com.woowacourse.levellog.common.support.DebugMessage;
 import com.woowacourse.levellog.member.exception.MemberNotFoundException;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -14,7 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByNicknameContains(String nickname);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     boolean existsByGithubId(int githubId);
 
     default Member getMember(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestion.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestion.java
@@ -13,6 +13,8 @@ import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +22,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_levellogId_authorId",
+                columnNames = {"levellog_id", "authorId"}
+        )})
 public class PreQuestion extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestion.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestion.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_levellogId_authorId",
+                name = "uk_pre_question_levellog_id_author_id",
                 columnNames = {"levellog_id", "authorId"}
         )})
 public class PreQuestion extends BaseEntity {

--- a/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/prequestion/domain/PreQuestionRepository.java
@@ -3,13 +3,10 @@ package com.woowacourse.levellog.prequestion.domain;
 import com.woowacourse.levellog.common.support.DebugMessage;
 import com.woowacourse.levellog.levellog.domain.Levellog;
 import com.woowacourse.levellog.prequestion.exception.PreQuestionNotFoundException;
-import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 public interface PreQuestionRepository extends JpaRepository<PreQuestion, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     boolean existsByLevellogAndAuthorId(Levellog levellog, Long authorId);
 
     default PreQuestion getPreQuestion(final Long preQuestionId) {

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -41,10 +41,7 @@ class FeedbackServiceTest extends ServiceTest {
 
         saveFeedback(alien, levellog);
         saveFeedback(eve, levellog);
-
         saveFeedback(roma, levellog);
-        saveFeedback(alien, levellog);
-        saveFeedback(eve, levellog);
 
         // when
         final List<String> fromNicknames = feedbackService.findAllByTo(getLoginStatus(eve))


### PR DESCRIPTION
## 구현 기능
- 비관적 락을 제거하고 유니크 제약조건을 추가했습니다.
- 기존 비관적 락은 걸리지 않음을 확인, 데드락을 오히려 유발할 수 있음을 인지하였기 때문에 이와 같은 구현을 합니다.

## 논의하고 싶은 내용
- 동시성 문제를 해결하기 위해서 유니크 제약조건을 걸었습니다.
- 유니크 제약조건의 문제점은 인지하고 있어야합니다.
  - MariaDB에서는 유니크 제약조건 = 유니크 인덱스이다.
  - `인덱스 쓰기 작업에서 중복값이 있는지 없는지 체크하는 과정이 추가로 들어간다` 는 점이 유니크 인덱스의 문제를 야기하는 원인입니다.
    - 이는 유니크 인덱스의 중복 값을 체크할 때 읽기 잠금을 걸게되고 이후 쓰기작업을 할 때 쓰기잠금을 가져가게 된다. 이 과정에서 데드락의 원인이 될 수 있다.
    -  유니크 인덱스는 반드시 중복을 체크해야하기 때문에  인덱스 키의 버퍼링을 위해 사용되는 체인지 버퍼가 사용되지 못하게 되므로 인덱스 쓰기 작업이 느리게 작동한다.

- 위 내용들 때문에 유니크 제약조건도 완벽한 해답은 아닌듯 싶습니다. 하지만 임시방편으로 이렇게 해두고 나중에 Named Lock 혹은 Redis와 같은 환경을 구축하여 해결하는 방법도 고려해봅시다~!
- https://techblog.woowahan.com/2631/ 
## 공유하고 싶은 내용
- 유니크 제약조건을 걸 때 ColumnName을 설정하는 부분에서 트러블을 만나 해결했습니다.
  - https://kbsat.notion.site/JPA-ColumnName-158dcc1f279342a6a322b22b6a5deebe

Close #593
