### PR TITLE
fix: 팀 목록이 존재하지 않을 때 이미지 정렬 수정

### DIFF
--- a/frontend/src/components/teams/Teams.tsx
+++ b/frontend/src/components/teams/Teams.tsx
@@ -28,9 +28,9 @@ const S = {
   Container: styled.div`
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 3.125rem;
     @media (max-width: 560px) {
-      justify-content: center;
       gap: 2.5rem;
     }
   `,


### PR DESCRIPTION
## 구현 기능
- 팀 목록이 존재하지 않을 때 이미지 정렬 수정

### Before
<img width="1440" alt="스크린샷 2022-11-18 오후 4 40 51" src="https://user-images.githubusercontent.com/68512686/202647895-5e154bc9-67e6-4cc4-ab9b-0ba0d031b19b.png">

### After
<img width="776" alt="스크린샷 2022-11-18 오후 4 40 20" src="https://user-images.githubusercontent.com/68512686/202647928-19600a28-932f-4b40-b244-949cd3c67730.png">


Close 없성
