### PR TITLE
fix: 피드백 목록 조회 시 수정 시간 기준 내림차순으로 정렬

### DIFF
--- a/backend/src/main/java/com/woowacourse/levellog/feedback/domain/FeedbackQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/levellog/feedback/domain/FeedbackQueryRepository.java
@@ -48,7 +48,8 @@ public class FeedbackQueryRepository {
                 + "FROM feedback f "
                 + "INNER JOIN member fm ON f.from_id = fm.id "
                 + "INNER JOIN member tm ON f.to_id = tm.id "
-                + "WHERE f.levellog_id = :levellogId";
+                + "WHERE f.levellog_id = :levellogId "
+                + "ORDER BY updatedAt DESC";
         final SqlParameterSource param = new MapSqlParameterSource()
                 .addValue("levellogId", levellogId);
 

--- a/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/acceptance/FeedbackAcceptanceTest.java
@@ -61,6 +61,7 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
      *   given: 피드백이 등록되어있다.
      *   when: 등록된 모든 피드백을 조회한다.
      *   then: 200 OK 상태 코드와 모든 피드백을 응답 받는다.
+     *   then: 피드백은 수정 시간 기준 내림차순으로 정렬되어 있다.
      */
     @Test
     @DisplayName("피드백 전체 조회")
@@ -68,13 +69,18 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
         // given
         RICK.save();
         ROMA.save();
+        PEPPER.save();
 
-        final String teamId = saveTeam("릭 and 로마", RICK, 1, RICK, ROMA).getTeamId();
+        final String teamId = saveTeam("릭 and 로마", RICK, 1, RICK, ROMA, PEPPER).getTeamId();
         final String levellogId = saveLevellog("레벨로그", teamId, RICK).getLevellogId();
 
         timeStandard.setInProgress();
 
-        saveFeedback("test", levellogId, ROMA);
+        final String romaContent = "로마가 릭의 레벨로그에 작성한 피드백";
+        saveFeedback(romaContent, levellogId, ROMA);
+
+        final String pepperContent = "페퍼가 릭의 레벨로그에 작성한 피드백";
+        saveFeedback(pepperContent, levellogId, PEPPER);
 
         // when
         final ValidatableResponse response = RestAssured.given(specification).log().all()
@@ -86,11 +92,11 @@ class FeedbackAcceptanceTest extends AcceptanceTest {
 
         // then
         response.statusCode(HttpStatus.OK.value())
-                .body("feedbacks.from.nickname", contains("로마"),
-                        "feedbacks.to.nickname", contains("릭"),
-                        "feedbacks.feedback.study", contains("study test"),
-                        "feedbacks.feedback.speak", contains("speak test"),
-                        "feedbacks.feedback.etc", contains("etc test")
+                .body("feedbacks.from.nickname", contains(PEPPER.getNickname(), ROMA.getNickname()),
+                        "feedbacks.to.nickname", contains(RICK.getNickname(), RICK.getNickname()),
+                        "feedbacks.feedback.study", contains("study " + pepperContent, "study " + romaContent),
+                        "feedbacks.feedback.speak", contains("speak " + pepperContent, "speak " + romaContent),
+                        "feedbacks.feedback.etc", contains("etc " + pepperContent, "etc " + romaContent)
                 );
     }
 

--- a/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/application/FeedbackServiceTest.java
@@ -60,24 +60,32 @@ class FeedbackServiceTest extends ServiceTest {
     class FindAll {
 
         @Test
-        @DisplayName("모든 피드백을 조회한다.")
+        @DisplayName("피드백이 updatedAt 기준 내림차순으로 정렬된 피드백 목록을 조회한다.")
         void success() {
             // given
             final Member eve = saveMember("이브");
             final Member roma = saveMember("로마");
             final Member alien = saveMember("알린");
+            final Member pepper = saveMember("페퍼");
             final Team team = saveTeam(eve, roma, alien);
 
             final Levellog levellog = saveLevellog(eve, team);
-            saveFeedback(roma, levellog);
+            final Feedback feedbackOfRoma = saveFeedback(roma, levellog);
             saveFeedback(alien, levellog);
+            saveFeedback(pepper, levellog);
+
+            feedbackOfRoma.updateFeedback("new", "new", "new");
+            feedbackRepository.flush();
 
             // when
-            final FeedbackResponses feedbackResponses = feedbackService.findAll(levellog.getId(),
+            final FeedbackResponses actual = feedbackService.findAll(levellog.getId(),
                     getLoginStatus(eve));
 
             // then
-            assertThat(feedbackResponses.getFeedbacks()).hasSize(2);
+            assertThat(actual.getFeedbacks())
+                    .hasSize(3)
+                    .extracting(it -> it.getFrom().getNickname())
+                    .containsExactly(roma.getNickname(), pepper.getNickname(), alien.getNickname());
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackQueryRepositoryTest.java
@@ -33,7 +33,6 @@ class FeedbackQueryRepositoryTest extends RepositoryTest {
         saveFeedback(rick, levellog);
         saveFeedback(pepper, levellog);
         feedbackOfEve.updateFeedback("new", "new", "new");
-//        feedbackRepository.save(feedbackOfEve);
 
         feedbackRepository.flush();
 

--- a/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/levellog/domain/FeedbackQueryRepositoryTest.java
@@ -18,28 +18,35 @@ import org.junit.jupiter.api.Test;
 class FeedbackQueryRepositoryTest extends RepositoryTest {
 
     @Test
-    @DisplayName("findAllByLevellog 메서드는 입력된 레벨로그에 등록된 모든 피드백을 조회한다.")
+    @DisplayName("findAllByLevellog 메서드는 입력된 레벨로그에 등록된 모든 피드백을 updatedAt 기준 내림차순으로 정렬해서 조회한다.")
     void findAllByLevellog() {
         // given
         final Member eve = saveMember("eve");
         final Member rick = saveMember("rick");
+        final Member pepper = saveMember("pepper");
         final Member toMember = saveMember("toMember");
 
         final Team team = saveTeam(eve, rick, toMember);
         final Levellog levellog = saveLevellog(toMember, team);
 
-        saveFeedback(eve, levellog);
+        final Feedback feedbackOfEve = saveFeedback(eve, levellog);
         saveFeedback(rick, levellog);
+        saveFeedback(pepper, levellog);
+        feedbackOfEve.updateFeedback("new", "new", "new");
+//        feedbackRepository.save(feedbackOfEve);
+
+        feedbackRepository.flush();
 
         // when
         final List<FeedbackResponse> feedbacks = feedbackQueryRepository.findAllByLevellogId(levellog.getId())
                 .getFeedbacks();
 
         // then
-        assertThat(feedbacks).hasSize(2)
+        assertThat(feedbacks).hasSize(3)
                 .extracting(it -> it.getFrom().getId(), it -> it.getTo().getId())
                 .containsExactly(
                         tuple(eve.getId(), toMember.getId()),
+                        tuple(pepper.getId(), toMember.getId()),
                         tuple(rick.getId(), toMember.getId())
                 );
     }

--- a/backend/src/test/java/com/woowacourse/levellog/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/levellog/fixture/MemberFixture.java
@@ -68,4 +68,8 @@ public enum MemberFixture {
 
         return null;
     }
+
+    public String getNickname() {
+        return nickname;
+    }
 }


### PR DESCRIPTION
## 구현 기능
- 피드백 목록 조회 시 수정 시간 기준 내림차순으로 정렬되지 않는 버그 해결
  - `FeedbackQueryRepository`의 `findAllByLevellogId`에서 날리는 쿼리에 `ORDER BY` 절 추가
- 피드백 목록 조회 관련 테스트 코드에 검증 로직 보충
  - repository 단위 테스트, service 통합 테스트, 인수 테스트

Close #567
